### PR TITLE
Add non-expiring Slack invite link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,9 @@
 
 **NOTE:** If you have any feature requests or suggestions, we'd love to hear about them
 and discuss them with you before you raise a PR. Please come discuss your ideas with us
-in our [Inspect Community](https://inspectcommunity.slack.com) Slack workspace.
+in our [Inspect
+Community](https://join.slack.com/t/inspectcommunity/shared_invite/zt-2w9eaeusj-4Hu~IBHx2aORsKz~njuz4g)
+Slack workspace.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ infrastructure, we do expect it to be useful to other organisations if they adop
 of our conventions. If you have an existing Kubernetes cluster this provider may work
 for you, or may require further tailoring and adaptation. To ask questions or discuss
 adopting this plugin, come join us in the [Inspect
-Slack](https://inspectcommunity.slack.com)!
+Slack](https://join.slack.com/t/inspectcommunity/shared_invite/zt-2w9eaeusj-4Hu~IBHx2aORsKz~njuz4g)!
 
 You can find documentation at
 [https://k8s-sandbox.ai-safety-institute.org.uk/](https://k8s-sandbox.ai-safety-institute.org.uk/).


### PR DESCRIPTION
As the workspace is currently invite-only, following the https://inspectcommunity.slack.com URL won't gain you access.
This is a never-expiring invite link. Even if you're already a member, it opens the relevant Slack workspace.