### PR TITLE
Add test verifying that line endings are maintained for `read_file()`

### DIFF
--- a/test/k8s_sandbox/test_sandbox.py
+++ b/test/k8s_sandbox/test_sandbox.py
@@ -602,6 +602,17 @@ async def test_read_file_from_relative_path(sandbox: K8sSandboxEnvironment) -> N
     assert result == "Hello, World!"
 
 
+async def test_read_file_maintains_line_endings(sandbox: K8sSandboxEnvironment) -> None:
+    # The SandboxEnvironment interface documents that read_file() should maintain line
+    # endings.
+    expected = "Hello,\r\nWorld!\n"
+    await sandbox.write_file("/line-endings.txt", expected)
+
+    result = await sandbox.read_file("/line-endings.txt")
+
+    assert result == expected
+
+
 async def test_read_file_not_found(
     sandbox: K8sSandboxEnvironment, log_err: LogCaptureFixture
 ) -> None:


### PR DESCRIPTION
There is a new requirement in Inspect's `SandboxEnvironment.read_file()`

>When reading text files, implementations should preserve newline constructs (e.g. crlf should be preserved not converted to lf).

https://github.com/UKGovernmentBEIS/inspect_ai/blob/bcf7bd58d083073e79a078172887e08341211426/src/inspect_ai/util/_sandbox/environment.py#L205C1-L208C1

This was already the case for the K8s sandbox provider. I've just added a test to prevent any regressions now that this is documented.

> The `read_file()` function should should preserve newline constructs (e.g. crlf should be preserved not converted to lf). This is equivalent to specifying `newline=""` in a call to the Python `open()` function.
