### PR TITLE
Add initial changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+## 0.1.0 (19 December 2024)
+
+- Initial release.


### PR DESCRIPTION
Structure copied from inspect_ai.

To codify previous UK AISI, discussions we don't plan on publishing this package to PyPI until we've got some more mileage and consider it "stable".

I'm undecided on whether we should still be doing discrete "releases" (i.e. bumping package version, adding a tag, moving "unreleased" changelog items). Sometimes it is hard for us or users to reason about what version of the package they were using. Happy for opinions/input from others!