### PR TITLE
Document DNS-based approach rationale + fix formatting

### DIFF
--- a/docs/docs/design/complexities.md
+++ b/docs/docs/design/complexities.md
@@ -33,6 +33,6 @@ See the source code for documentation on how this is achieved.
 !!! question "Why not use `tty=True` (`-t`)?"
 
     Whilst this would give us the behaviour we want around commands containing a
-    backgrounded task (`&`), it means that stderr is redirected to stdout. It also changes
-    the line endings of the output from `\n` to `\r\n`, which means that the output is not
-    consistent with output from other sandbox environments like Docker.
+    backgrounded task (`&`), it means that stderr is redirected to stdout. It also
+    changes the line endings of the output from `\n` to `\r\n`, which means that the
+    output is not consistent with output from other sandbox environments like Docker.

--- a/docs/docs/helm/built-in-chart.md
+++ b/docs/docs/helm/built-in-chart.md
@@ -117,6 +117,14 @@ Pod.
     correspond to the FQDN allowlist, CoreDNS service must be co-located on the same
     node which the container making the DNS request are on.
 
+??? question "Why not use `hostAliases` to edit `/etc/hosts`?"
+
+    Instead of using DNS, the `/etc/hosts` file could be modified using
+    [HostAliases](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods).
+    However, some tools which an agent might try to use (e.g. `nslookup`) do not respect
+    `/etc/hosts` and will use DNS instead. Therefore, we chose to use a DNS-based
+    approach.
+
 For the containers within your release to use this, rather than the default Kubernetes
 DNS service, the `/etc/resolv.conf` of your containers is modified to use `127.0.0.1` as
 the nameserver.

--- a/docs/docs/helm/built-in-chart.md
+++ b/docs/docs/helm/built-in-chart.md
@@ -93,6 +93,8 @@ These get translated to `toEntities` entries in the Cilium Network Policy:
 The built-in Helm chart is designed to allow services to communicate with each other
 using their service names e.g. `curl nginx`, much like you would in Docker Compose.
 
+To make services discoverable by their service name, set the `dnsRecord` key to `true`.
+
 Additionally, you can specify a list of domains that resolve to a given service e.g.
 `curl example.com` could resolve to your `nginx` service.
 

--- a/docs/docs/helm/built-in-chart.md
+++ b/docs/docs/helm/built-in-chart.md
@@ -64,6 +64,7 @@ from a variety of sources:
     ```
 
     !!! bug
+
         We're investigating occasional issues with the `allowDomains` feature where
         some network requests which ought to be allowed are blocked. It is yet unclear
         whether this is as a result of our service-based DNS resolution setup or whether


### PR DESCRIPTION
* Document why we chose a DNS-based approach over using `HostAliases` (which edits `/etc/hosts`). Off the back of #42 
* Explicitly state that  `dnsRecord: true` is required.
* Fix some minor formatting issues (see commit messages).