### PR TITLE
`SANDBOX` log level deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## Unreleased
 
+- Remove use of Inspect's deleted `SANDBOX` log level in favour of `trace_action()` and `trace_message()` functions.
 - Initial release.

--- a/docs/docs/tips/debugging-k8s-sandboxes.md
+++ b/docs/docs/tips/debugging-k8s-sandboxes.md
@@ -4,35 +4,31 @@ This section explains features of [Inspect](https://inspect.ai-safety-institute.
 and [k9s](https://k9scli.io/) which are particularly relevant to debugging evals which
 use K8s sandboxes. Please see the dedicated docs pages of each for more information.
 
-## Capture Inspect `SANDBOX`-level logs { #sandbox-log-level }
+## View Inspect's `TRACE`-level logs { #trace-log-level }
 
-Useful sandbox-related messages like Helm installs/uninstalls, pod operations (`exec()`
+Useful sandbox-related messages like Helm installs/uninstalls, Pod operations (`exec()`
 executions including the result, `read_file()`, `write_file()`) etc. are logged at the
-`SANDBOX` log level.
+`TRACE` log level. See the [Inspect tracing
+docs](https://inspect.ai-safety-institute.org.uk/tracing.html) for more information on
+where these are stored and how to read them.
 
-Set Inspect's log level to `SANDBOX` or lower via one of these methods:
-
- * passing `--log-level sandbox` on the command line
- * setting `INSPECT_LOG_LEVEL=sandbox` environment variable
- * passing the `log_level` argument to `eval()` or `eval_set()`
-
-Example:
+Example (additional fields removed for brevity):
 
 ```raw
-SANDBOX - K8S: Installing Helm chart. {
+K8s installing Helm chart: {
   "chart": "/home/ubuntu/.../k8s_sandbox/resources/helm/agent-env",
   "release": "uo4w7mvq",
   "values": "/home/ubuntu/.../helm-values.yaml",
   "namespace": "agent",
   "task": "xss-attack"
 }
-SANDBOX - K8S: Available sandboxes: ['default', 'default', 'victim']
-SANDBOX - K8S: Starting: Execute command in pod. {
+[K8s] Available sandboxes: ['default', 'default', 'victim']
+K8s execute command in Pod: {
   "pod": "agent-env-uo4w7mvq-default-0",
   "task_name": "xss-attack", "cmd": "['python3']",
   "stdin": "print('Hello, world!')", "cwd": "None", "timeout": "300"
 }
-SANDBOX - K8S: Completed: Execute command in pod. {
+[K8s] Completed: K8s execute command in Pod. {
   "result": "ExecResult(success=True, returncode=0, stdout=\"...\", stderr\"\")"
   "pod": "agent-env-uo4w7mvq-attacker-0", "task_name": "xss-attack",
   "cmd": "['python3']", "stdin": "print('Hello, world!')", "cwd": "None",
@@ -40,18 +36,11 @@ SANDBOX - K8S: Completed: Execute command in pod. {
 }
 ```
 
-Additionally, ensure the content of the `logging` module is written to a file on disk:
+All K8s-relevant entries contain "K8s" as a substring within the "action" field which
+may be useful for filtering.
 
-```sh
-mkdir -p logs
-export INSPECT_PY_LOGGER_FILE="logs/inspect_py_log.log"
-```
-
-These will include timestamps and are invaluable when piecing together an ordered
+The trace logs include timestamps and are invaluable when piecing together an ordered
 sequence of events.
-
-Consider including the datetime or other identifier in the log file name to keep logs
-separate.
 
 ## Disabling Inspect Cleanup
 

--- a/docs/docs/tips/troubleshooting.md
+++ b/docs/docs/tips/troubleshooting.md
@@ -3,11 +3,11 @@
 For general K8s and Inspect sandbox debugging, see the [Debugging K8s
 Sandboxes](debugging-k8s-sandboxes.md) guide.
 
-## Capture Inspect `SANDBOX`-level logs
+## View Inspect's `TRACE`-level logs
 
-A good starting point to most issues is to capture the output of the Python `logging`
-module at `SANDBOX` level. See the [`SANDBOX` log level
-section](debugging-k8s-sandboxes.md#sandbox-log-level).
+A good starting point to many issues is to view the `TRACE`-level logs written by
+Inspect. See the [`TRACE` log level
+section](debugging-k8s-sandboxes.md#trace-log-level).
 
 ## I'm seeing "Helm install: context deadline exceeded" errors
 
@@ -23,8 +23,8 @@ Therefore, this error can be an indication of:
 
 Try installing the chart again (this can also be [done
 manually](../helm/built-in-chart.md#manual-chart-install)) and check the Pod statuses
-and logs using a tool like K9s. Use the helm release name (will be in error message and
-`SANDBOX` -level logs) to filter the Pods.
+and logs using a tool like K9s. Use the helm release name (will be in error message) to
+filter the Pods.
 
 ## I'm seeing "Helm uninstall failed" errors
 
@@ -80,7 +80,7 @@ kubectl get events --sort-by='.metadata.creationTimestamp' \
   --field-selector involvedObject.name=agent-env-xxxxxxxx-default-0
 ```
 
-Find the Pod name (including the random 8-character identifier) in the `SANDBOX`-level
+Find the Pod name (including the random 8-character identifier) in the `TRACE`-level
 logs or the stack trace.
 
 To specify a namespace other than the default, use the `-n` flag.

--- a/poetry.lock
+++ b/poetry.lock
@@ -22,17 +22,6 @@ awscli = ["awscli (>=1.34.16,<1.35.3)"]
 boto3 = ["boto3 (>=1.35.16,<1.35.37)"]
 
 [[package]]
-name = "aiofiles"
-version = "24.1.0"
-description = "File support for asyncio."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5"},
-    {file = "aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c"},
-]
-
-[[package]]
 name = "aiohappyeyeballs"
 version = "2.4.4"
 description = "Happy Eyeballs for asyncio"
@@ -907,17 +896,16 @@ files = [
 
 [[package]]
 name = "inspect-ai"
-version = "0.3.52"
+version = "0.3.55"
 description = "Framework for large language model evaluations"
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "inspect_ai-0.3.52-py3-none-any.whl", hash = "sha256:44d8c93490ca0b111a6140283eb28545de133f3d6b6f4e39ff424c472de59378"},
-    {file = "inspect_ai-0.3.52.tar.gz", hash = "sha256:e4811da1d36f5f34dcd2159e9416052d5eb301cf02c9cc5909e2c90320d8bca1"},
+    {file = "inspect_ai-0.3.55-py3-none-any.whl", hash = "sha256:7ba965fda44fdd064d032486f9a0c2bf2f15f47b597ea9478363ce07c476edc2"},
+    {file = "inspect_ai-0.3.55.tar.gz", hash = "sha256:9efe23c392b22909d9b8c0f9a37fdd46a7895fe43731e02530434c262e79b00c"},
 ]
 
 [package.dependencies]
-aiofiles = "*"
 aiohttp = ">=3.9.0"
 anyio = ">=4.4.0"
 beautifulsoup4 = "*"
@@ -948,7 +936,7 @@ typing_extensions = ">=4.9.0"
 zipp = ">=3.19.1"
 
 [package.extras]
-dev = ["aioboto3", "anthropic", "azure-ai-inference", "google-cloud-aiplatform", "google-generativeai", "groq", "ipython", "mistralai", "moto[server]", "mypy", "nbformat", "openai", "pre-commit", "pytest", "pytest-asyncio", "pytest-cov", "pytest-dotenv", "pytest-xdist", "ruff (==0.8.3)", "textual-dev (>=0.86.2)", "types-PyYAML", "types-aioboto3", "types-aiofiles", "types-beautifulsoup4", "types-boto3", "types-botocore", "types-jsonpatch", "types-jsonschema", "types-protobuf", "types-psutil", "types-python-dateutil"]
+dev = ["aioboto3", "anthropic", "azure-ai-inference", "google-cloud-aiplatform", "google-generativeai", "groq", "ipython", "mistralai", "moto[server]", "mypy", "nbformat", "openai", "pre-commit", "pytest", "pytest-asyncio", "pytest-cov", "pytest-dotenv", "pytest-xdist", "ruff (==0.8.4)", "textual-dev (>=0.86.2)", "types-PyYAML", "types-aioboto3", "types-beautifulsoup4", "types-boto3", "types-botocore", "types-jsonpatch", "types-jsonschema", "types-protobuf", "types-psutil", "types-python-dateutil"]
 dist = ["build", "twine"]
 doc = ["jupyter", "quarto-cli"]
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2665,4 +2665,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "61c2ca857f09089fbbecbf958cc1d921532fae4d7999ac70da3a76c950263d87"
+content-hash = "08daa34659a128b65f2bbd42ab40bbcf52fb31951ca35801f6acb0043e80ffdc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-inspect-ai = ">=0.3.50"
+inspect-ai = ">=0.3.54"
 kubernetes = "^31.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/src/k8s_sandbox/_helm.py
+++ b/src/k8s_sandbox/_helm.py
@@ -51,7 +51,7 @@ class Release:
     async def install(self) -> None:
         async with _install_semaphore():
             with inspect_trace_action(
-                "Install Helm chart",
+                "K8s install Helm chart",
                 chart=self._chart_path,
                 release=self.release_name,
                 values=self._values_path,
@@ -152,7 +152,7 @@ async def uninstall(release_name: str, quiet: bool) -> None:
     namespace = get_current_context_namespace()
     async with _uninstall_semaphore():
         with inspect_trace_action(
-            "Uninstall Helm chart", release=release_name, namespace=namespace
+            "K8s uninstall Helm chart", release=release_name, namespace=namespace
         ):
             result = await _run_subprocess(
                 "helm",

--- a/src/k8s_sandbox/_helm.py
+++ b/src/k8s_sandbox/_helm.py
@@ -13,7 +13,7 @@ from k8s_sandbox._kubernetes_api import (
     get_current_context_namespace,
     k8s_client,
 )
-from k8s_sandbox._logger import format_log_message, inspect_trace_action, sandbox_log
+from k8s_sandbox._logger import format_log_message, inspect_trace_action, log_trace
 from k8s_sandbox._pod import Pod
 
 DEFAULT_CHART = Path(__file__).parent / "resources" / "helm" / "agent-env"
@@ -137,7 +137,7 @@ class Release:
             r"again",
             result.stderr,
         ):
-            sandbox_log(
+            log_trace(
                 "resourcequota modified error whilst installing helm chart.",
                 release=self.release_name,
                 error=result.stderr,

--- a/src/k8s_sandbox/_helm.py
+++ b/src/k8s_sandbox/_helm.py
@@ -13,7 +13,7 @@ from k8s_sandbox._kubernetes_api import (
     get_current_context_namespace,
     k8s_client,
 )
-from k8s_sandbox._logger import format_log_message, sandbox_log
+from k8s_sandbox._logger import format_log_message, inspect_trace_action, sandbox_log
 from k8s_sandbox._pod import Pod
 
 DEFAULT_CHART = Path(__file__).parent / "resources" / "helm" / "agent-env"
@@ -50,24 +50,24 @@ class Release:
 
     async def install(self) -> None:
         async with _install_semaphore():
-            sandbox_log(
-                "Installing helm chart.",
+            with inspect_trace_action(
+                "Install Helm chart",
                 chart=self._chart_path,
                 release=self.release_name,
                 values=self._values_path,
                 namespace=self._namespace,
                 task=self.task_name,
-            )
-            attempt = 1
-            while True:
-                try:
-                    await self._install(upgrade=attempt > 1)
-                    break
-                except _ResourceQuotaModifiedError:
-                    if attempt >= MAX_INSTALL_ATTEMPTS:
-                        raise
-                    attempt += 1
-                    await asyncio.sleep(INSTALL_RETRY_DELAY_SECONDS)
+            ):
+                attempt = 1
+                while True:
+                    try:
+                        await self._install(upgrade=attempt > 1)
+                        break
+                    except _ResourceQuotaModifiedError:
+                        if attempt >= MAX_INSTALL_ATTEMPTS:
+                            raise
+                        attempt += 1
+                        await asyncio.sleep(INSTALL_RETRY_DELAY_SECONDS)
 
     async def uninstall(self, quiet: bool) -> None:
         await uninstall(self.release_name, quiet)
@@ -151,27 +151,30 @@ class Release:
 async def uninstall(release_name: str, quiet: bool) -> None:
     namespace = get_current_context_namespace()
     async with _uninstall_semaphore():
-        sandbox_log(
-            "Uninstalling helm release.", release=release_name, namespace=namespace
-        )
-        result = await _run_subprocess(
-            "helm",
-            [
-                "uninstall",
-                release_name,
-                "--namespace",
-                namespace,
-                "--wait",
-                "--timeout",
-                f"{_get_timeout()}s",
-            ],
-            capture_output=quiet,
-        )
-    if not result.success:
-        captured_output = result.stdout if not quiet else "not captured"
-        _raise_runtime_error(
-            "Helm uninstall failed.", release=release_name, result=captured_output
-        )
+        with inspect_trace_action(
+            "Uninstall Helm chart", release=release_name, namespace=namespace
+        ):
+            result = await _run_subprocess(
+                "helm",
+                [
+                    "uninstall",
+                    release_name,
+                    "--namespace",
+                    namespace,
+                    "--wait",
+                    "--timeout",
+                    f"{_get_timeout()}s",
+                ],
+                capture_output=quiet,
+            )
+            if not result.success:
+                captured_output = result.stdout if not quiet else "not captured"
+                _raise_runtime_error(
+                    "Helm uninstall failed.",
+                    release=release_name,
+                    namespace=namespace,
+                    result=captured_output,
+                )
 
 
 def _raise_runtime_error(

--- a/src/k8s_sandbox/_logger.py
+++ b/src/k8s_sandbox/_logger.py
@@ -3,8 +3,8 @@ import logging
 import os
 from typing import Any
 
-# TODO: We're accessing an internal constant. Can this be made public by inspect?
-from inspect_ai._util.constants import SANDBOX
+# TODO: Accessing private functions. To be made public by Inspect.
+from inspect_ai._util.trace import trace_message
 
 logger = logging.getLogger(__name__)
 
@@ -14,18 +14,30 @@ TRUNCATED_SUFFIX = "...<truncated-for-logging>"
 DEFAULT_ARG_TRUNCATION_THRESHOLD = 1000
 
 
-def sandbox_log(message: str, level: int = SANDBOX, **kwargs: Any) -> None:
-    """Format and log a message with "K8S: " prefix.
+def sandbox_log(message: str, **kwargs: Any) -> None:
+    """Format and log a message at TRACE level with K8s category.
 
     Args:
         message: The log message.
-        level: The log level. Defaults to SANDBOX.
         **kwargs: Key-value pairs to include in the log message. Values are truncated if
           they exceed DEFAULT_ARG_TRUNCATION_THRESHOLD (which can be overridden with env
           var INSPECT_K8S_LOG_TRUNCATION_THRESHOLD).
     """
     formatted = format_log_message(message, **kwargs)
-    logger.log(level, f"K8S: {formatted}")
+    trace_message(logger, "K8s", formatted)
+
+
+def sandbox_log_error(message: str, **kwargs: Any) -> None:
+    """Format and log a message at ERROR level with K8s prefix.
+
+    Args:
+        message: The log message.
+        **kwargs: Key-value pairs to include in the log message. Values are truncated if
+          they exceed DEFAULT_ARG_TRUNCATION_THRESHOLD (which can be overridden with env
+          var INSPECT_K8S_LOG_TRUNCATION_THRESHOLD).
+    """
+    formatted = format_log_message(message, **kwargs)
+    logger.error(f"K8s: {formatted}")
 
 
 def format_log_message(message: str, **kwargs: Any) -> str:

--- a/src/k8s_sandbox/_logger.py
+++ b/src/k8s_sandbox/_logger.py
@@ -15,7 +15,7 @@ TRUNCATED_SUFFIX = "...<truncated-for-logging>"
 DEFAULT_ARG_TRUNCATION_THRESHOLD = 1000
 
 
-def sandbox_log(message: str, **kwargs: Any) -> None:
+def log_trace(message: str, **kwargs: Any) -> None:
     """Format and log a message at TRACE level with K8s category.
 
     Args:
@@ -25,10 +25,10 @@ def sandbox_log(message: str, **kwargs: Any) -> None:
           var INSPECT_K8S_LOG_TRUNCATION_THRESHOLD).
     """
     formatted = format_log_message(message, **kwargs)
-    trace_message(logger, "K8s", formatted)
+    trace_message(logger, category="K8s", message=formatted)
 
 
-def sandbox_log_error(message: str, **kwargs: Any) -> None:
+def log_error(message: str, **kwargs: Any) -> None:
     """Format and log a message at ERROR level with K8s prefix.
 
     Args:

--- a/src/k8s_sandbox/_pod/executor.py
+++ b/src/k8s_sandbox/_pod/executor.py
@@ -7,7 +7,7 @@ from typing import Callable, TypeVar
 
 from inspect_ai.util import concurrency
 
-from k8s_sandbox._logger import sandbox_log
+from k8s_sandbox._logger import log_trace
 
 T = TypeVar("T")
 
@@ -32,7 +32,7 @@ class PodOpExecutor:
             cpu_count = os.cpu_count() or 1
             # Pod operations are typically I/O-bound (from the client's perspective).
             self._max_workers = cpu_count * 4
-        sandbox_log("Creating PodOpExecutor.", max_workers=self._max_workers)
+        log_trace("Creating PodOpExecutor.", max_workers=self._max_workers)
         self._executor = ThreadPoolExecutor(
             max_workers=self._max_workers, thread_name_prefix="pod-op-executor"
         )

--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -1,4 +1,3 @@
-import logging
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
@@ -14,7 +13,7 @@ from inspect_ai.util import (
 from pydantic import BaseModel
 
 from k8s_sandbox._helm import Release
-from k8s_sandbox._logger import format_log_message, sandbox_log
+from k8s_sandbox._logger import format_log_message, sandbox_log, sandbox_log_error
 from k8s_sandbox._manager import (
     HelmReleaseManager,
     uninstall_unmanaged_release,
@@ -204,9 +203,7 @@ class K8sSandboxEnvironment(SandboxEnvironment):
             sandbox_log(f"Error during: {op}", cause=e, **log_kwargs)
             raise
         except Exception as e:
-            sandbox_log(
-                f"Error during: {op}", level=logging.ERROR, cause=e, **log_kwargs
-            )
+            sandbox_log_error(f"Error during: {op}", cause=e, **log_kwargs)
             # Enrich the unexpected exception with additional context.
             raise K8sError(f"Error during: {op}", **log_kwargs) from e
         sandbox_log(f"Completed: {op}", **{**result_dict, **log_kwargs})

--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -132,7 +132,7 @@ class K8sSandboxEnvironment(SandboxEnvironment):
             PermissionError,
             OutputLimitExceededError,
         )
-        op = "Execute command in pod"
+        op = "K8s execute command in Pod"
         with self._log_op(op, expected_exceptions, **log_kwargs):
             result = await self._pod.exec(cmd, input, cwd, env, timeout)
             sandbox_log(f"Completed: {op}.", **(log_kwargs | {"result": result}))
@@ -149,7 +149,7 @@ class K8sSandboxEnvironment(SandboxEnvironment):
             temp_file.seek(0)
             # Do not log these at error level or re-raise as enriched K8sError.
             expected_exceptions = (PermissionError, IsADirectoryError)
-            with self._log_op("Write file to pod", expected_exceptions, file=file):
+            with self._log_op("K8s write file to Pod", expected_exceptions, file=file):
                 await self._pod.write_file(temp_file.file, Path(file))
 
     @overload
@@ -170,7 +170,7 @@ class K8sSandboxEnvironment(SandboxEnvironment):
                 IsADirectoryError,
                 OutputLimitExceededError,
             )
-            with self._log_op("Read file from pod", expected_exceptions, file=file):
+            with self._log_op("K8s read file from Pod", expected_exceptions, file=file):
                 await self._pod.read_file(Path(file), temp_file)
                 temp_file.seek(0)
                 return (

--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -1,7 +1,7 @@
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Callable, Generator, Literal, cast, overload
+from typing import Any, Generator, Literal, cast, overload
 
 from inspect_ai.util import (
     ExecResult,
@@ -13,7 +13,12 @@ from inspect_ai.util import (
 from pydantic import BaseModel
 
 from k8s_sandbox._helm import Release
-from k8s_sandbox._logger import format_log_message, sandbox_log, sandbox_log_error
+from k8s_sandbox._logger import (
+    format_log_message,
+    inspect_trace_action,
+    sandbox_log,
+    sandbox_log_error,
+)
 from k8s_sandbox._manager import (
     HelmReleaseManager,
     uninstall_unmanaged_release,
@@ -127,11 +132,10 @@ class K8sSandboxEnvironment(SandboxEnvironment):
             PermissionError,
             OutputLimitExceededError,
         )
-        with self._log_op(
-            "Execute command in pod.", expected_exceptions, **log_kwargs
-        ) as set_result:
+        op = "Execute command in pod"
+        with self._log_op(op, expected_exceptions, **log_kwargs):
             result = await self._pod.exec(cmd, input, cwd, env, timeout)
-            set_result(result)
+            sandbox_log(f"Completed: {op}.", **(log_kwargs | {"result": result}))
             return result
 
     async def write_file(self, file: str, contents: str | bytes) -> None:
@@ -145,7 +149,7 @@ class K8sSandboxEnvironment(SandboxEnvironment):
             temp_file.seek(0)
             # Do not log these at error level or re-raise as enriched K8sError.
             expected_exceptions = (PermissionError, IsADirectoryError)
-            with self._log_op("Write file to pod.", expected_exceptions, file=file):
+            with self._log_op("Write file to pod", expected_exceptions, file=file):
                 await self._pod.write_file(temp_file.file, Path(file))
 
     @overload
@@ -166,7 +170,7 @@ class K8sSandboxEnvironment(SandboxEnvironment):
                 IsADirectoryError,
                 OutputLimitExceededError,
             )
-            with self._log_op("Read file from pod.", expected_exceptions, file=file):
+            with self._log_op("Read file from pod", expected_exceptions, file=file):
                 await self._pod.read_file(Path(file), temp_file)
                 temp_file.seek(0)
                 return (
@@ -176,37 +180,33 @@ class K8sSandboxEnvironment(SandboxEnvironment):
     @contextmanager
     def _log_op(
         self, op: str, expected_exceptions: tuple, **log_kwargs
-    ) -> Generator[Callable[[ExecResult], None], None, None]:
+    ) -> Generator[None, None, None]:
         """Logs the lifecycle of an operation and enriches unexpected exceptions.
 
         The pod name and task name are included all log messages in addition to
         log_kwargs.
 
-        For "expected" exceptions (e.g. TimeoutError), the exception is logged at
-        "SANDBOX" level and re-raised.
+        Inspect's trace_action() context manager will log any exceptions at TRACE level.
+        No additional handling of "expected" exceptions (e.g. TimeoutError) is
+        performed.
         For "unexpected" exceptions (e.g. ApiException), the exception is logged at
         "ERROR" level and re-raised as a K8sError which includes additional context for
         debugging.
-
-        Optionally, a result can be set by the caller for inclusion in the "completed"
-        log message.
         """
         log_kwargs = dict(
             pod=self._pod.info.name, task_name=self.release.task_name, **log_kwargs
         )
-        sandbox_log(f"Starting: {op}", **log_kwargs)
-        result_dict = dict()
-        try:
-            # Allow the caller to set the result of the operation for logging.
-            yield lambda x: result_dict.update({"result": x})
-        except expected_exceptions as e:
-            sandbox_log(f"Error during: {op}", cause=e, **log_kwargs)
-            raise
-        except Exception as e:
-            sandbox_log_error(f"Error during: {op}", cause=e, **log_kwargs)
-            # Enrich the unexpected exception with additional context.
-            raise K8sError(f"Error during: {op}", **log_kwargs) from e
-        sandbox_log(f"Completed: {op}", **{**result_dict, **log_kwargs})
+        with inspect_trace_action(op, **log_kwargs):
+            try:
+                yield
+            except expected_exceptions:
+                raise
+            except Exception as e:
+                # Whilst Inspect's trace_action will have logged the exception, log it
+                # at ERROR level here for user visibility.
+                sandbox_log_error(f"Error during: {op}.", cause=e, **log_kwargs)
+                # Enrich the unexpected exception with additional context.
+                raise K8sError(f"Error during: {op}.", **log_kwargs) from e
 
 
 class K8sSandboxEnvironmentConfig(BaseModel, frozen=True):

--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -16,8 +16,8 @@ from k8s_sandbox._helm import Release
 from k8s_sandbox._logger import (
     format_log_message,
     inspect_trace_action,
-    sandbox_log,
-    sandbox_log_error,
+    log_error,
+    log_trace,
 )
 from k8s_sandbox._manager import (
     HelmReleaseManager,
@@ -78,7 +78,7 @@ class K8sSandboxEnvironment(SandboxEnvironment):
             sandbox_envs: dict[str, SandboxEnvironment] = {}
             for key, pod in pods.items():
                 sandbox_envs[key] = cls(release, pod)
-            sandbox_log(f"Available sandboxes: {list(sandbox_envs.keys())}")
+            log_trace(f"Available sandboxes: {list(sandbox_envs.keys())}")
             return sandbox_envs
 
         def reorder_default_first(
@@ -135,7 +135,7 @@ class K8sSandboxEnvironment(SandboxEnvironment):
         op = "K8s execute command in Pod"
         with self._log_op(op, expected_exceptions, **log_kwargs):
             result = await self._pod.exec(cmd, input, cwd, env, timeout)
-            sandbox_log(f"Completed: {op}.", **(log_kwargs | {"result": result}))
+            log_trace(f"Completed: {op}.", **(log_kwargs | {"result": result}))
             return result
 
     async def write_file(self, file: str, contents: str | bytes) -> None:
@@ -204,7 +204,7 @@ class K8sSandboxEnvironment(SandboxEnvironment):
             except Exception as e:
                 # Whilst Inspect's trace_action will have logged the exception, log it
                 # at ERROR level here for user visibility.
-                sandbox_log_error(f"Error during: {op}.", cause=e, **log_kwargs)
+                log_error(f"Error during: {op}.", cause=e, **log_kwargs)
                 # Enrich the unexpected exception with additional context.
                 raise K8sError(f"Error during: {op}.", **log_kwargs) from e
 

--- a/test/k8s_sandbox/conftest.py
+++ b/test/k8s_sandbox/conftest.py
@@ -1,9 +1,0 @@
-import logging
-
-from inspect_ai._util.constants import SANDBOX
-
-
-def pytest_configure(config):
-    # Set the log level to SANDBOX for the tests in this directory.
-    # This lets us see log messages when used with pytest -s.
-    logging.basicConfig(level=SANDBOX)

--- a/test/k8s_sandbox/inspect_integration/testing_utils/utils.py
+++ b/test/k8s_sandbox/inspect_integration/testing_utils/utils.py
@@ -51,14 +51,7 @@ def run_and_verify_inspect_eval(
     assert task.dataset.location
     log_dir = os.path.join(os.getcwd(), "logs")
     with _ChangeDir(task.dataset.location):
-        # log_level="SANDBOX" to facilitate test debugging.
-        logs = eval(
-            task,
-            model=model,
-            log_dir=log_dir,
-            log_level="SANDBOX",
-            sandbox_cleanup=sandbox_cleanup,
-        )
+        logs = eval(task, model=model, log_dir=log_dir, sandbox_cleanup=sandbox_cleanup)
     log = logs[0]
     assert log.status == "success"
     assert log.samples


### PR DESCRIPTION
The `SANDBOX` log level was removed when the `TRACE` log level and associated functionality ([docs](https://inspect.ai-safety-institute.org.uk/tracing.html)) was added to Inspect ([PR](https://github.com/UKGovernmentBEIS/inspect_ai/pull/1038)).

JJ recommended ([Slack](https://inspectcommunity.slack.com/archives/C0801K3CEN8/p1735832232725649?thread_ts=1735262148.252489&cid=C0801K3CEN8)) using:
* `trace_action()` for any long running tasks that we'd like the lifecycle logged of (so in our case, Helm install/uninstall and Pod ops like `exec()`)
* `trace_message()` for any other informational logging which used to be at `SANDBOX` log level (like listing Pods, or logging `exec()` results)

It is great that these logs will be automatically captured. Though there will be some added friction of dumping these logs, filtering them to just K8s-relevant ones (i.e. removing model API calls), then extracting just the relevant `message` to build up an equivalent view of what the old `SANDBOX` log level provided.