### PR TITLE
Add support for `inspect sandbox cleanup k8s`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ## Unreleased
 
-- Remove use of Inspect's deleted `SANDBOX` log level in favour of `trace_action()` and `trace_message()` functions.
 - Add support for `inspect sandbox cleanup k8s` command to uninstall all Inspect Helm charts.
+- Remove use of Inspect's deleted `SANDBOX` log level in favour of `trace_action()` and `trace_message()` functions.
 - Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## Unreleased
 
+- Add support for `inspect sandbox cleanup k8s` command to uninstall all Inspect Helm charts.
 - Initial release.

--- a/src/k8s_sandbox/_manager.py
+++ b/src/k8s_sandbox/_manager.py
@@ -80,7 +80,7 @@ class HelmReleaseManager:
 
     def _print_cleanup_instructions(self) -> None:
         table = Table(
-            title="K8s Sandbox Environments (not yet cleaned up):",
+            title="K8s Sandbox Releases (not yet cleaned up):",
             box=box.SQUARE_DOUBLE_HEAD,
             show_lines=True,
             title_style="bold",

--- a/src/k8s_sandbox/_manager.py
+++ b/src/k8s_sandbox/_manager.py
@@ -86,7 +86,7 @@ class HelmReleaseManager:
             title_style="bold",
             title_justify="left",
         )
-        table.add_column("Container(s)", no_wrap=True)
+        table.add_column("Release(s)", no_wrap=True)
         table.add_column("Cleanup")
         for release in self._installed_releases:
             table.add_row(

--- a/src/k8s_sandbox/_manager.py
+++ b/src/k8s_sandbox/_manager.py
@@ -9,6 +9,7 @@ from rich.table import Table
 
 from k8s_sandbox._helm import Release
 from k8s_sandbox._helm import uninstall as helm_uninstall
+from k8s_sandbox._kubernetes_api import get_current_context_namespace
 
 
 class HelmReleaseManager:
@@ -93,11 +94,10 @@ class HelmReleaseManager:
             )
         print("")
         print(table)
-        # TODO: Once supported, tell user how to cleanup all environments.
-        # print(
-        #     "\nCleanup all environments with: "
-        #     "[blue]inspect sandbox cleanup k8s[/blue]\n"
-        # )
+        print(
+            "\nCleanup all sandbox releases with: "
+            "[blue]inspect sandbox cleanup k8s[/blue]\n"
+        )
 
 
 async def uninstall_unmanaged_release(release_name: str) -> None:
@@ -108,7 +108,8 @@ async def uninstall_unmanaged_release(release_name: str) -> None:
       release_name (str): The name of the release to uninstall (e.g. "lsphdyup").
     """
     _print_do_not_interrupt()
-    await helm_uninstall(release_name, quiet=False)
+    namespace = get_current_context_namespace()
+    await helm_uninstall(release_name, namespace, quiet=False)
 
 
 def _print_do_not_interrupt() -> None:

--- a/src/k8s_sandbox/_manager.py
+++ b/src/k8s_sandbox/_manager.py
@@ -114,11 +114,25 @@ async def uninstall_unmanaged_release(release_name: str) -> None:
 
 
 async def uninstall_all_unmanaged_releases():
+    def _print_table(releases: list[str]) -> None:
+        print("Releases to be uninstalled:")
+        table = Table(
+            box=box.SQUARE,
+            show_lines=False,
+            title_style="bold",
+            title_justify="left",
+        )
+        table.add_column("Release")
+        for release in releases:
+            table.add_row(f"[red]{release}[/red]")
+        print(table)
+
     namespace = get_current_context_namespace()
     releases = await get_all_release_names(namespace)
     if len(releases) == 0:
         print(f"No Inspect sandbox releases found in '{namespace}' namespace.")
         return
+    _print_table(releases)
     if not Confirm.ask(
         f"Are you sure you want to uninstall ALL {len(releases)} Inspect sandbox "
         f"release(s) in '{namespace}' namespace? If this is a shared namespace, "

--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import tempfile
 from contextlib import contextmanager
@@ -12,8 +13,10 @@ from inspect_ai.util import (
     sandboxenv,
 )
 from pydantic import BaseModel
+from rich.prompt import Confirm
 
-from k8s_sandbox._helm import Release
+from k8s_sandbox._helm import Release, get_all_release_names, uninstall
+from k8s_sandbox._kubernetes_api import get_current_context_namespace
 from k8s_sandbox._logger import format_log_message, sandbox_log
 from k8s_sandbox._manager import (
     HelmReleaseManager,
@@ -54,13 +57,10 @@ class K8sSandboxEnvironment(SandboxEnvironment):
 
     @classmethod
     async def cli_cleanup(cls, id: str | None) -> None:
-        if id is None:
-            # TODO: How can we avoid uninstalling others' releases? Uninstall all
-            # releases in namespace regardless?
-            raise NotImplementedError(
-                "Cleanup all for k8s is not supported. Please specify a release name."
-            )
-        await uninstall_unmanaged_release(id)
+        if id is not None:
+            await uninstall_unmanaged_release(id)
+        else:
+            await _uninstall_all_unmanaged_releases()
 
     @classmethod
     async def sample_init(
@@ -257,3 +257,21 @@ def _create_release(
         validate_values_file(values)
         return Release(task_name, values_path=values)
     raise TypeError(f"Invalid config type: {type(config)}.")
+
+
+async def _uninstall_all_unmanaged_releases():
+    namespace = get_current_context_namespace()
+    releases = await get_all_release_names(namespace)
+    if len(releases) == 0:
+        print(f"No Inspect sandbox releases found in '{namespace}' namespace.")
+        return
+    if not Confirm.ask(
+        f"Are you sure you want to uninstall ALL {len(releases)} Inspect sandbox "
+        f"release(s) in '{namespace}' namespace? If this is a shared namespace, "
+        "this may affect other users.",
+    ):
+        print("Cancelled.")
+        return
+    tasks = [uninstall(release, namespace, quiet=False) for release in releases]
+    await asyncio.gather(*tasks, return_exceptions=True)
+    print("Complete.")

--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -98,8 +98,8 @@ class K8sSandboxEnvironment(SandboxEnvironment):
         environments: dict[str, SandboxEnvironment],
         interrupted: bool,
     ) -> None:
-        # If we were interrupted, wait unil the end of the task to cleanup (this enables
-        # us to show output for the cleanup operation).
+        # If we were interrupted, wait until the end of the task to cleanup (this
+        # enables us to show output for the cleanup operation).
         if interrupted:
             return
         sandbox: K8sSandboxEnvironment = cast(

--- a/test/k8s_sandbox/inspect_integration/test_cleanup.py
+++ b/test/k8s_sandbox/inspect_integration/test_cleanup.py
@@ -2,8 +2,12 @@ import asyncio
 from unittest.mock import patch
 
 import pytest
+from inspect_ai import Task
+from inspect_ai.model import Model
 
 from k8s_sandbox._helm import uninstall
+from k8s_sandbox._kubernetes_api import get_current_context_namespace
+from k8s_sandbox._sandbox_environment import K8sSandboxEnvironment
 from test.k8s_sandbox.inspect_integration.testing_utils.mock_model import (
     MockToolCallModel,
 )
@@ -17,19 +21,26 @@ from test.k8s_sandbox.inspect_integration.testing_utils.utils import (
 pytestmark = pytest.mark.req_k8s
 
 
-def test_with_cleanup() -> None:
-    model = MockToolCallModel([tool_call("bash", {"cmd": "echo 'success'"})])
-    task = create_task(__file__, target="success")
+@pytest.fixture
+def model() -> Model:
+    return MockToolCallModel.from_tool_call(
+        tool_call("bash", {"cmd": "echo 'success'"})
+    )
 
+
+@pytest.fixture
+def task() -> Task:
+    return create_task(__file__, target="success")
+
+
+def test_with_cleanup(model: Model, task: Task) -> None:
     with patch("k8s_sandbox._helm.uninstall", wraps=uninstall) as spy:
         run_and_verify_inspect_eval(task=task, model=model)
 
     assert spy.call_count == 1
 
 
-def test_without_cleanup() -> None:
-    model = MockToolCallModel([tool_call("bash", {"cmd": "echo 'success'"})])
-    task = create_task(__file__, target="success")
+def test_without_cleanup(model: Model, task: Task) -> None:
     release = "no-clean"
 
     with patch(
@@ -40,4 +51,23 @@ def test_without_cleanup() -> None:
             run_and_verify_inspect_eval(task=task, model=model, sandbox_cleanup=False)
 
     assert spy.call_count == 0
-    asyncio.run(uninstall(release, quiet=False))
+    asyncio.run(uninstall(release, get_current_context_namespace(), quiet=False))
+
+
+def test_cli_cleanup_all_gets_user_confirmation(model: Model, task: Task) -> None:
+    release = "no-clean"
+    with patch(
+        "k8s_sandbox._helm.Release._generate_release_name",
+        return_value=release,
+    ):
+        run_and_verify_inspect_eval(task=task, model=model, sandbox_cleanup=False)
+
+    with patch("k8s_sandbox._helm.uninstall", wraps=uninstall) as spy:
+        # We don't want to actually uninstall all releases in this test (the test could
+        # be run on a production cluster).
+        with patch("rich.prompt.Confirm.ask", return_value=False) as confirm:
+            asyncio.run(K8sSandboxEnvironment.cli_cleanup(id=None))
+
+    assert "Are you sure you want to uninstall ALL" in confirm.call_args.args[0]
+    assert spy.call_count == 0
+    asyncio.run(uninstall(release, get_current_context_namespace(), quiet=False))


### PR DESCRIPTION
Users often ask how to do this, and we normally have to share a command like `helm list -q | xargs -P 10 helm uninstall`.

Note that the [docs recommend](https://k8s-sandbox.ai-safety-institute.org.uk/getting-started/remote-cluster/#recommendations) setting up your cluster such that each user has their own namespace to reduce the risk of a careless user uninstalling someone else's Helm charts.


https://github.com/user-attachments/assets/03a02564-f4a2-40ff-a823-a01f97abdc5d


See issue #7.
See [Inspect's docs](https://inspect.ai-safety-institute.org.uk/sandboxing.html#environment-cleanup) on this command.