### PR TITLE
Add networking diagnostic test

### DIFF
--- a/test/diagnostics/network-issues/README.md
+++ b/test/diagnostics/network-issues/README.md
@@ -22,13 +22,14 @@ potential mitigations and solutions.
 ## Usage
 
 ```bash
-python main.py
+python run.py
 ```
 
-The scores will start to be computed after ~5 minutes (see the `asyncio.sleep`).
+The scores will start to be computed after ~5 minutes (see `post_curl_sleep`).
 
-The mean score will be reported. A score of 1.0 indicates all `curl` commands succeeded,
-indicating that both DNS and the HTTP requests were successful.
+The mean score will be reported when the eval finishes. A score of 1.0 indicates that
+all `curl` commands succeeded, implying that both DNS and the HTTP requests were
+successful.
 
 Try adjusting values such as epochs, resources in `helm-values.yaml` (to control the
 number of Pods per Node), uncommenting the readinessProbe, switching from allowDomains

--- a/test/diagnostics/network-issues/README.md
+++ b/test/diagnostics/network-issues/README.md
@@ -1,0 +1,45 @@
+# Context
+
+In December 2024, UK AISI migrated to a new K8s Cluster whilst also migrating some evals
+from Docker to K8s.
+
+The agentic evals in question required both internet access and access to services
+deployed as part of the eval, resolved via DNS (e.g. a `victim` web server). These evals
+used the built-in Helm chart which uses Cilium Network Policies (CNP). The Helm chart
+also uses a release-scoped DNS service to resolve domain names like `victim` to the
+relevant Pod deployed as part of the eval.
+
+We observed Cilium dropping packets which ought to have been allowed by the Network
+Policies. For example, queries to `wikipedia.org` would be dropped even if the
+`allowDomains` field in `helm-values.yaml` was set to `["*"]`. The behaviour observed
+was the request e.g. `curl` simply timed out. There may have also been issues accessing
+eval-specific services like a `victim` web server.
+
+This simple Inspect eval was used to measure the impact of the issue and evaluate
+potential mitigations and solutions.
+
+
+## Usage
+
+```bash
+python main.py
+```
+
+The scores will start to be computed after ~5 minutes (see the `asyncio.sleep`).
+
+The mean score will be reported. A score of 1.0 indicates all `curl` commands succeeded,
+indicating that both DNS and the HTTP requests were successful.
+
+Try adjusting values such as epochs, resources in `helm-values.yaml` (to control the
+number of Pods per Node), uncommenting the readinessProbe, switching from allowDomains
+to allowEntities.
+
+
+## Expectations
+
+Once the issue was resolved (which we suspect was due to the interaction between CNPs at
+the cluster level with the CNPs at the eval level resulting in many Cilium
+regenerations), the mean score is expected to be 1.0 without needing any changes to the
+`helm-values.yaml` file.
+
+When we were observing issues, the scores were ~0.6-0.8.

--- a/test/diagnostics/network-issues/helm-values.yaml
+++ b/test/diagnostics/network-issues/helm-values.yaml
@@ -1,0 +1,34 @@
+services:
+  default:
+    image: "python:3.12-bookworm"
+    command: ["tail", "-f", "/dev/null"]
+    runtimeClassName: gvisor
+    # Resources can be adjusted to tune the number of Pods per Node.
+    resources:
+      requests:
+        cpu: 0.1
+        memory: 0.2G
+      limits:
+        cpu: 0.1
+        memory: 0.2G
+    # One attempted fix for the issue was to add a readinessProbe which would check if
+    # the service is ready to accept traffic.
+    # Note that this readinessProbe is executed inside the container.
+    # readinessProbe:
+    #   exec:
+    #     command:
+    #       - /bin/sh
+    #       - -c
+    #       - curl -f -s httpstat.us/200
+allowDomains:
+  - "*"
+  # Also evaluated, was explicitly allowing only the required domains.
+  # - "amazon.com"
+  # - "google.com"
+  # - "yahoo.com"
+  # - "bing.com"
+  # - "wikipedia.org"
+# Also evaluated, was using Cilium entity-based policies to "all" or "world"
+# https://docs.cilium.io/en/stable/security/policy/language/#entities-based
+# allowEntities:
+#   - "all"

--- a/test/diagnostics/network-issues/main.py
+++ b/test/diagnostics/network-issues/main.py
@@ -1,0 +1,67 @@
+import asyncio
+import os
+import random
+
+from inspect_ai import Task, eval, task
+from inspect_ai.dataset import MemoryDataset, Sample
+from inspect_ai.model import (
+    ChatMessageAssistant,
+    ModelOutput,
+)
+from inspect_ai.scorer import includes
+from inspect_ai.solver import Generate, TaskState, solver
+from inspect_ai.util import sandbox
+
+# Runs a Task with many epochs (repeats) each of which simply curls a domain to quantify
+# DNS or network access issues. The scoring is 1.0 for success and 0.0 for a timeout or
+# other error.
+
+success_str = "sandbox_exec_success"
+domains = ["google.com", "yahoo.com", "bing.com", "wikipedia.org", "amazon.com"]
+
+
+@task
+def internet_access_task():
+    return Task(
+        dataset=MemoryDataset([Sample(input="Input", target=success_str)]),
+        sandbox=("k8s", "helm-values.yaml"),
+        solver=[internet_access_solver()],
+        scorer=includes(),
+    )
+
+
+@solver
+def internet_access_solver():
+    async def solve(state: TaskState, generate: Generate):
+        result = await curl_domain()
+        state.messages.append(ChatMessageAssistant(content=result, source="generate"))
+        state.output = ModelOutput.from_content(model="mock", content=result)
+        # Keep the eval going a while longer so that the Pod sticks around in case the
+        # issue is exacerbated by number of Pods or number of Cilium Network Policies.
+        await asyncio.sleep(5 * 60)
+        return state
+
+    return solve
+
+
+async def curl_domain() -> str:
+    target_domain = random.choice(domains)
+    try:
+        result = await sandbox().exec(["curl", "-I", target_domain], timeout=20)
+    except TimeoutError:
+        return f"timeout\n{target_domain}"
+    if result.returncode != 0:
+        return f"error\n{target_domain}\n{result}"
+    return f"{success_str}\n{target_domain}\n{result}"
+
+
+if __name__ == "__main__":
+    os.environ["INSPECT_MAX_HELM_INSTALL"] = "100"
+    os.environ["INSPECT_MAX_HELM_UNINSTALL"] = "100"
+    os.environ["INSPECT_MAX_POD_OPS"] = "200"
+    eval(
+        tasks=[internet_access_task()],
+        model="mockllm/model",
+        max_samples=10_000,  # Effectively unlimited: let all epochs run concurrently.
+        epochs=500,
+    )

--- a/test/diagnostics/network-issues/test_can_run_diagnostic.py
+++ b/test/diagnostics/network-issues/test_can_run_diagnostic.py
@@ -1,0 +1,9 @@
+from run import run_diagnostic_eval
+
+
+def test_can_run_diagnostic_network_issues() -> None:
+    score = run_diagnostic_eval(epochs=1, post_curl_sleep=0)
+
+    # Whilst we do verify the score, the purpose of this test is to ensure there haven't
+    # been any regressions in the ability to run the diagnostic.
+    assert score == 1.0


### PR DESCRIPTION
As suggested by Jason, let's put this script somewhere such that we can easily refer back to it and share with others. I haven't included the results as these are quite specific to our infrastructure at the time of running the tests and were not done in a particularly well controlled environment.

It will be run at a very small scale as part of CI just to prevent regressions in the script. I don't believe we'll get meaningful data from trying to run this at scale in CI:
1. We're heavily limited on how many concurrent deployments we can have on the default GitHub runner
2. There are no cluster-wide Cilium Network Policies (CNP) on our Minikube cluster (which we think were a contributor to the issues)

I've created an issue to better document our findings #29 and recommendations for CNPs.