### PR TITLE
Improve Cilium Network Policy descriptions

### DIFF
--- a/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
@@ -8,7 +8,7 @@ spec:
   description: |
     Allow egress to:
     - cluster-wide DNS (kube-dns),
-    - everything in the sandbox,
+    - all Pods in the same agent sandbox,
     - any configured allowDomains, allowEntities, or allowCIDR.
   endpointSelector:
     matchLabels:
@@ -70,7 +70,8 @@ metadata:
     {{- toYaml $.Values.annotations | nindent 4 }}
 spec:
   description: |
-    Allow ingress from other pods in the "{{ $networkName }}" agent sandbox "network".
+    Allow ingress from all Pods in the same agent sandbox which are also on the
+    "{{ $networkName }}" "network".
   endpointSelector:
     matchLabels:
       io.kubernetes.pod.namespace: {{ $.Release.Namespace }}
@@ -93,7 +94,7 @@ metadata:
     {{- toYaml $.Values.annotations | nindent 4 }}
 spec:
   description: |
-    Allow ingress from other pods in the same agent sandbox.
+    Allow ingress from all Pods in the same agent sandbox.
   endpointSelector:
     matchLabels:
       io.kubernetes.pod.namespace: {{ .Release.Namespace }}

--- a/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
@@ -6,7 +6,10 @@ metadata:
     {{- toYaml $.Values.annotations | nindent 4 }}
 spec:
   description: |
-    Allow egress only to cluster-wide DNS, everything in the sandbox, and any allowDomains.
+    Allow egress to:
+    - cluster-wide DNS (kube-dns),
+    - everything in the sandbox,
+    - any configured allowDomains, allowEntities, or allowCIDR.
   endpointSelector:
     matchLabels:
       io.kubernetes.pod.namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Housekeeping: whilst considering an update to Cilium on our cluster, I realised the CNP descriptions were a bit inconsistent and out of date wrt supporting `allowCIDR` and `allowEntities`.