### PR TITLE
Always capture `helm uninstall` output so that errors contain meaningful info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Always capture the output of `helm uninstall` so that errors can contain meaningful information.
 - Add support for `inspect sandbox cleanup k8s` command to uninstall all Inspect Helm charts.
 - Remove use of Inspect's deleted `SANDBOX` log level in favour of `trace_action()` and `trace_message()` functions.
 - Initial release.

--- a/src/k8s_sandbox/_helm.py
+++ b/src/k8s_sandbox/_helm.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import os
 import re
+import sys
 from pathlib import Path
 from typing import Any, NoReturn
 
@@ -178,17 +179,17 @@ async def uninstall(release_name: str, namespace: str, quiet: bool) -> None:
                     "--timeout",
                     f"{_get_timeout()}s",
                 ],
-                capture_output=quiet,
+                capture_output=True,
             )
+            if not quiet:
+                sys.stdout.write(result.stdout)
+                sys.stderr.write(result.stderr)
             if not result.success:
-                captured_output = result.stdout
-                if not quiet:
-                    captured_output = "not captured; output written to stdout/stderr"
                 _raise_runtime_error(
                     "Helm uninstall failed.",
                     release=release_name,
                     namespace=namespace,
-                    result=captured_output,
+                    result=result.stdout + result.stderr,
                 )
 
 

--- a/src/k8s_sandbox/_helm.py
+++ b/src/k8s_sandbox/_helm.py
@@ -189,7 +189,8 @@ async def uninstall(release_name: str, namespace: str, quiet: bool) -> None:
                     "Helm uninstall failed.",
                     release=release_name,
                     namespace=namespace,
-                    result=result.stdout + result.stderr,
+                    stdout=result.stdout,
+                    stderr=result.stderr,
                 )
 
 


### PR DESCRIPTION
The `quiet` parameter of `uninstall()` is designed to work the same was as the [Docker Compose implementation](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/util/_sandbox/docker/compose.py#L42) in Inspect - the idea being that the user shouldn't see `helm uninstall` output in most cases (except if they ran `inspect sandbox cleanup k8s` or the eval was cancelled/errored).

Users have previously shared logs or screenshots of `RuntimeError: Helm uninstall failed. {"release": "bmkvavf7", "result": "not captured"}`. Usually this is a red herring ([documented here](https://k8s-sandbox.ai-safety-institute.org.uk/tips/troubleshooting/#im-seeing-helm-uninstall-failed-errors)) but the "not captured" bit is unhelpful. The reason the `helm uninstall` output was not captured is that the `uninstall()`'s `quiet` parameter was `False` so the stdout/stderr of the command will have been written directly to the process's stdout/stderr.

This PR:
* Always captures stdout/stderr from `helm uninstall` subprocesses, and "forwards" it to stdout/stderr only if `quiet=False`
* Improves the documentation of the `uninstall` function - in particular around the behaviour of `quiet`.