### PR TITLE
Document certain "known" exceptions and why we don't retry `exec()` commands

### DIFF
--- a/docs/docs/design/limitations.md
+++ b/docs/docs/design/limitations.md
@@ -111,6 +111,26 @@ chart](../helm/built-in-chart.md#dns). Or, if using a custom Helm chart, conside
 the `hostAliases` field in the Pod spec
 ([docs](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/)).
 
+## Transient network or infrastructure issues during `exec()` won't be retried
+
+The following exceptions have occasionally been observed during calls to `exec()`,
+`read_file()` or `write_file()`:
+
+* `WebSocketBadStatusException: pod does not exist` (re-raised as `ApiException`)
+* `WebSocketBadStatusException: container not found` (re-raised as `ApiException`)
+* `WebSocketBadStatusException: Handshake status 500 Internal Server Error` (re-raised
+  as `ApiException`)
+* `WebSocketConnectionClosedException: Connection to remote host was lost`
+* `SSLEOFError: EOF occurred in violation of protocol`
+
+These are likely due to transient network or infrastructure issues. For example, when a
+node becomes unhealthy and the Pod is rescheduled.
+
+The `k8s_sandbox` package will not retry the remote command execution when any of these
+(or other) exceptions are raised because it cannot assume that the command is idempotent
+and that the command did not at least start executing. This will result in that sample
+of the eval failing.
+
 ## The `user` parameter to `exec()` is not supported
 
 In Kubernetes, a container runs as a single user. If you need to run commands as


### PR DESCRIPTION
This was prompted by a discussion on an [Inspect PR](https://github.com/UKGovernmentBEIS/inspect_ai/pull/1107)

I've gathered the exceptions recorded in the issues of this repo https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/issues?q=is%3Aissue+is%3Aopen+label%3A%223rd+party+errors%22

And explained the rationale for not retrying upon seeing these exceptions.