### PR TITLE
Add ignored `timeout_retry=True` parameter to `exec()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add ignored `timeout_retry` parameter to `exec()` method.
 - Always capture the output of `helm uninstall` so that errors can contain meaningful information.
 - Add support for `inspect sandbox cleanup k8s` command to uninstall all Inspect Helm charts.
 - Remove use of Inspect's deleted `SANDBOX` log level in favour of `trace_action()` and `trace_message()` functions.

--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -117,6 +117,9 @@ class K8sSandboxEnvironment(SandboxEnvironment):
         env: dict[str, str] = {},
         user: str | None = None,
         timeout: int | None = None,
+        # Ignored. Inspect docs: "For sandbox implementations this parameter is advisory
+        # (they should only use it if potential unreliablity exists in their runtime)."
+        timeout_retry: bool = True,
     ) -> ExecResult[str]:
         if user is not None:
             raise NotImplementedError(


### PR DESCRIPTION
See discussion on Inspect PR https://github.com/UKGovernmentBEIS/inspect_ai/pull/1107

Summary:
Due to unreliability in the Docker sandbox provider, it is necessary to retry `exec()` commands if they fail with a `TimeoutError`. This is configurable via the new `timeout_retry` parameter to `exec()`.

Generally, retrying unknown commands (as it, ones provided by LLMs or users) is not desirable as they may not be idempotent. So this retry policy (on timeout errors only) is only recommended if the sandbox provider suffers from an issue similar to the Docker one.

>Note that to deal with potential unreliability of container services, the `exec()` method includes a `timeout_retry` parameter that defaults to `True`. For sandbox implementations this parameter is _advisory_ (they should only use it if potential unreliablity exists in their runtime)

