### PR TITLE
Add `unset` magic string for runtimeClassName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add `unset` magic string for `runtimeClassName` which will remove the field from the pod spec.
+- Add `CLUSTER_DEFAULT` magic string for `runtimeClassName` which will remove the field from the pod spec.
 - Add ignored `timeout_retry` parameter to `exec()` method.
 - Always capture the output of `helm uninstall` so that errors can contain meaningful information.
 - Add support for `inspect sandbox cleanup k8s` command to uninstall all Inspect Helm charts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `unset` magic string for `runtimeClassName` which will remove the field from the pod spec.
 - Add ignored `timeout_retry` parameter to `exec()` method.
 - Always capture the output of `helm uninstall` so that errors can contain meaningful information.
 - Add support for `inspect sandbox cleanup k8s` command to uninstall all Inspect Helm charts.

--- a/docs/docs/helm/built-in-chart.md
+++ b/docs/docs/helm/built-in-chart.md
@@ -14,10 +14,11 @@ familiar with them.
 In addition to the info below, see `agent-env/README.md` and `agent-env/values.yaml` for
 a full list of configurable options.
 
-## Container runtime (gVisor)
+## Container runtime class (gVisor)
 
 The default container runtime class name for every service is `gvisor` which, (depending
-on your cluster) should map to the `runsc` runtime. You can override this if required.
+on your cluster) should map to the `runsc` runtime handler. You can override this if
+required.
 
 ```yaml
 services:
@@ -27,11 +28,55 @@ services:
     runtimeClassName: runc
 ```
 
-The above example assumes you have a `RuntimeClass` named `runc` in your cluster which
-maps to the `runc` runtime.
+The above example assumes you have a `RuntimeClass` named `runc` deployed to your
+cluster which maps to the `runc` runtime handler.
 
 See the [gVisor page](../security/container-runtime.md) for considerations and
-limitations.
+limitations on using gVisor versus `runc`.
+
+??? tip "Unset the runtime class entirely"
+
+    You can unset the runtime class in the Pod spec by setting it to the `unset` magic
+    string.
+
+    ```yaml
+    services:
+      default:
+        image: ubuntu:24.04
+        command: ["tail", "-f", "/dev/null"]
+        runtimeClassName: unset
+    ```
+
+    This has the effect of using your cluster's default runtime class.
+
+    This approach is **not recommended** as it makes your evals cluster-dependent and
+    therefore less portable. It is preferable to explicitly state which runtime class
+    you require if it is not gVisor. See the [remote cluster
+    setup](../getting-started/remote-cluster.md) page for more information on installing
+    runtimes and deploying `RuntimeClass` objects which map a name to a runtime handler.
+
+??? tip "View your cluster's runtime classes"
+
+    You can view the runtime classes available in your cluster by running the following
+    command:
+
+    ```sh
+    kubectl get runtimeclass
+    ```
+
+    ```
+    NAME     HANDLER   AGE
+    gvisor   runsc     42d
+    runc     runc      42d
+    ```
+
+??? question "Aren't containerd or CRI-O the container runtimes?"
+
+    There are multiple "levels" of container runtime in Kubernetes. containerd or CRI-O
+    are the "high level" CRI implementations which Kubernetes uses to manage containers.
+    The discussion in this section concerning `runtimeClassName` field on Pod spec is
+    about the "lower level" OCI runtimes (like `runc` or `runsc`) which are used to
+    actually run the container processes.
 
 ## Internet access
 

--- a/docs/docs/helm/built-in-chart.md
+++ b/docs/docs/helm/built-in-chart.md
@@ -17,8 +17,8 @@ a full list of configurable options.
 ## Container runtime class (gVisor)
 
 The default container runtime class name for every service is `gvisor` which, (depending
-on your cluster) should map to the `runsc` runtime handler. You can override this if
-required.
+on your cluster - see [remote cluster setup page](../getting-started/remote-cluster.md))
+should map to the `runsc` runtime handler. You can override this if required.
 
 ```yaml
 services:

--- a/docs/docs/helm/built-in-chart.md
+++ b/docs/docs/helm/built-in-chart.md
@@ -34,17 +34,17 @@ cluster which maps to the `runc` runtime handler.
 See the [gVisor page](../security/container-runtime.md) for considerations and
 limitations on using gVisor versus `runc`.
 
-??? tip "Unset the runtime class entirely"
+??? tip "Use the cluster's default runtime class"
 
-    You can unset the runtime class in the Pod spec by setting it to the `unset` magic
-    string.
+    You can cause the runtime class in the Pod spec to not be set at all by setting
+    `runtimeClassName` to the `CLUSTER_DEFAULT` magic string in the relevant services.
 
     ```yaml
     services:
       default:
         image: ubuntu:24.04
         command: ["tail", "-f", "/dev/null"]
-        runtimeClassName: unset
+        runtimeClassName: CLUSTER_DEFAULT
     ```
 
     This has the effect of using your cluster's default runtime class.

--- a/src/k8s_sandbox/resources/helm/agent-env/templates/services.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/services.yaml
@@ -28,7 +28,10 @@ spec:
       annotations:
         {{- toYaml $.Values.annotations | nindent 8 }}
     spec:
+      {{- /* "unset" is a magic string which prevents `runtimeClassName` being set. */}}
+      {{- if ne $service.runtimeClassName "unset" }}
       runtimeClassName: {{ $service.runtimeClassName | default "gvisor" }}
+      {{- end }}
       {{- /* Do not leak info on services via env vars */}}
       enableServiceLinks: false
       terminationGracePeriodSeconds: 0

--- a/src/k8s_sandbox/resources/helm/agent-env/templates/services.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/services.yaml
@@ -28,8 +28,8 @@ spec:
       annotations:
         {{- toYaml $.Values.annotations | nindent 8 }}
     spec:
-      {{- /* "unset" is a magic string which prevents `runtimeClassName` being set. */}}
-      {{- if ne $service.runtimeClassName "unset" }}
+      {{- /* "CLUSTER_DEFAULT" (magic string) prevents runtimeClassName being set. */}}
+      {{- if ne $service.runtimeClassName "CLUSTER_DEFAULT" }}
       runtimeClassName: {{ $service.runtimeClassName | default "gvisor" }}
       {{- end }}
       {{- /* Do not leak info on services via env vars */}}

--- a/test/k8s_sandbox/helm_chart/resources/cluster-default-runtime-values.yaml
+++ b/test/k8s_sandbox/helm_chart/resources/cluster-default-runtime-values.yaml
@@ -2,10 +2,10 @@ services:
   default:
     image: "ubuntu:24.04"
     command: ["tail", "-f", "/dev/null"]
-    runtimeClassName: unset
+    runtimeClassName: CLUSTER_DEFAULT
   service-1:
     image: "nginx"
-    runtimeClassName: unset
+    runtimeClassName: CLUSTER_DEFAULT
   service-2:
     image: "nginx"
     runtimeClassName: my-runtime-class-name

--- a/test/k8s_sandbox/helm_chart/resources/unset-runtime-class-values.yaml
+++ b/test/k8s_sandbox/helm_chart/resources/unset-runtime-class-values.yaml
@@ -1,0 +1,11 @@
+services:
+  default:
+    image: "ubuntu:24.04"
+    command: ["tail", "-f", "/dev/null"]
+    runtimeClassName: unset
+  service-1:
+    image: "nginx"
+    runtimeClassName: unset
+  service-2:
+    image: "nginx"
+    runtimeClassName: my-runtime-class-name

--- a/test/k8s_sandbox/helm_chart/test_helm_chart.py
+++ b/test/k8s_sandbox/helm_chart/test_helm_chart.py
@@ -173,9 +173,11 @@ def test_quotes_env_var_values(chart_dir: Path, test_resources_dir: Path) -> Non
     assert env[3] == {"name": "C", "value": "three"}
 
 
-def test_unset_magic_string(chart_dir: Path, test_resources_dir: Path) -> None:
+def test_cluster_default_magic_string(
+    chart_dir: Path, test_resources_dir: Path
+) -> None:
     documents = _run_helm_template(
-        chart_dir, test_resources_dir / "unset-runtime-class-values.yaml"
+        chart_dir, test_resources_dir / "cluster-default-runtime-values.yaml"
     )
 
     stateful_sets = _get_documents(documents, "StatefulSet")

--- a/test/k8s_sandbox/helm_chart/test_helm_chart.py
+++ b/test/k8s_sandbox/helm_chart/test_helm_chart.py
@@ -173,6 +173,20 @@ def test_quotes_env_var_values(chart_dir: Path, test_resources_dir: Path) -> Non
     assert env[3] == {"name": "C", "value": "three"}
 
 
+def test_unset_magic_string(chart_dir: Path, test_resources_dir: Path) -> None:
+    documents = _run_helm_template(
+        chart_dir, test_resources_dir / "unset-runtime-class-values.yaml"
+    )
+
+    stateful_sets = _get_documents(documents, "StatefulSet")
+    assert "runtimeClassName" not in stateful_sets[0]["spec"]["template"]["spec"]
+    assert "runtimeClassName" not in stateful_sets[1]["spec"]["template"]["spec"]
+    assert (
+        stateful_sets[2]["spec"]["template"]["spec"]["runtimeClassName"]
+        == "my-runtime-class-name"
+    )
+
+
 def _run_helm_template(
     chart_dir: Path, values_file: Path | None = None, set_str: str | None = None
 ) -> list[dict[str, Any]]:

--- a/test/k8s_sandbox/resources/runtime-class-values.yaml
+++ b/test/k8s_sandbox/resources/runtime-class-values.yaml
@@ -39,10 +39,10 @@ services:
       requests:
         memory: "128Mi"
         cpu: "100m"
-  unset-magic-string:
+  cluster-default-magic-string:
     image: "ubuntu:24.04"
     command: ["tail", "-f", "/dev/null"]
-    runtimeClassName: unset
+    runtimeClassName: CLUSTER_DEFAULT
     resources:
       limits:
         memory: "128Mi"

--- a/test/k8s_sandbox/resources/runtime-class-values.yaml
+++ b/test/k8s_sandbox/resources/runtime-class-values.yaml
@@ -39,3 +39,14 @@ services:
       requests:
         memory: "128Mi"
         cpu: "100m"
+  unset-magic-string:
+    image: "ubuntu:24.04"
+    command: ["tail", "-f", "/dev/null"]
+    runtimeClassName: unset
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "100m"
+      requests:
+        memory: "128Mi"
+        cpu: "100m"

--- a/test/k8s_sandbox/test_runtime_class.py
+++ b/test/k8s_sandbox/test_runtime_class.py
@@ -42,11 +42,13 @@ async def test_unspecified(sandboxes: dict[str, K8sSandboxEnvironment]) -> None:
     assert actual == "gvisor"
 
 
-async def test_unset_magic_string(sandboxes: dict[str, K8sSandboxEnvironment]) -> None:
-    actual = await _infer_runtime_class(sandboxes["unset-magic-string"])
+async def test_cluster_default_magic_string(
+    sandboxes: dict[str, K8sSandboxEnvironment],
+) -> None:
+    actual = await _infer_runtime_class(sandboxes["cluster-default-magic-string"])
 
-    # The "unset" magic string means that runtimeClassName won't be set. runc is the
-    # default runtime on the minikube test cluster.
+    # The "CLUSTER_DEFAULT" magic string means that runtimeClassName won't be set. runc
+    # is the default runtime on the minikube test cluster.
     assert actual == "runc"
 
 

--- a/test/k8s_sandbox/test_runtime_class.py
+++ b/test/k8s_sandbox/test_runtime_class.py
@@ -42,6 +42,14 @@ async def test_unspecified(sandboxes: dict[str, K8sSandboxEnvironment]) -> None:
     assert actual == "gvisor"
 
 
+async def test_unset_magic_string(sandboxes: dict[str, K8sSandboxEnvironment]) -> None:
+    actual = await _infer_runtime_class(sandboxes["unset-magic-string"])
+
+    # The "unset" magic string means that runtimeClassName won't be set. runc is the
+    # default runtime on the minikube test cluster.
+    assert actual == "runc"
+
+
 async def _infer_runtime_class(sandbox: K8sSandboxEnvironment) -> str:
     result = await sandbox.exec(
         ["sh", "-c", "dmesg | grep -i 'starting gvisor'"], timeout=5


### PR DESCRIPTION
We've been heavily opinionated that gVisor should be the container runtime of choice, but users can always override it if needed. However, you must override it to some non-null value. We'd like to add an escape hatch for users who wish to use their cluster's default runtime. We generally don't recommend taking this approach as this makes evals portable (now documented on docs site).

See Slack discussion https://inspectcommunity.slack.com/archives/C0855KJ6BMW/p1736847936476909
