### PR TITLE
Prevent DNS exfiltration attacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Prevent DNS exfiltration attacks by limiting which domains can be looked up (when using the built-in Helm chart).
 - If a namespace is not includes in the kubeconfig context, default to a namespace named "default".
 - Add `CLUSTER_DEFAULT` magic string for `runtimeClassName` which will remove the field from the pod spec.
 - Add ignored `timeout_retry` parameter to `exec()` method.

--- a/docs/docs/getting-started/remote-cluster.md
+++ b/docs/docs/getting-started/remote-cluster.md
@@ -4,7 +4,19 @@
 
 ### If using the built-in Helm Chart
 
+#### Cilium
+
 Your cluster will need to have [Cilium](https://cilium.io/) installed.
+
+If choosing to deploying any cluster- or namespace-wide Cilium Network Policies, please
+consider their interplay with the CNPs that this package's built-in Helm chart deploys.
+Cilium effectively combines policies by means of a logical disjunction (OR)
+([docs](https://docs.cilium.io/en/latest/security/policy/intro/#rule-basics)) so if your
+policies are too permissive, they may undermine the more restrictive policies deployed
+by the built-in Helm chart. In particular, see the [DNS exfiltration
+section](../security/network-access.md#dns-exfiltration).
+
+#### `StorageClass`
 
 To make use of the `volumes` functionality offered by the built-in Helm chart, your
 cluster must have an `nfs-csi`
@@ -12,6 +24,8 @@ cluster must have an `nfs-csi`
 supports the `ReadWriteMany` access mode on `PersistentVolumeClaim`. If this is not
 practical, you can override the `spec` field of any `volumes` in the `values.yaml` to
 your choosing.
+
+#### gVisor
 
 Unless you override the `runtimeClassName` in your `values.yaml`, you will need to have
 a `gvisor` [Runtime

--- a/docs/docs/security/network-access.md
+++ b/docs/docs/security/network-access.md
@@ -4,8 +4,8 @@ It is good security practice to prevent your containers from communicating with 
 internet by default.
 
 However, some evals may require internet access (e.g. to install packages or research
-topics). The [built-in Helm chart](../helm/built-in-chart.md) allows you to specify a list
-of domains that your containers can access.
+topics). The [built-in Helm chart](../helm/built-in-chart.md) allows you to specify a
+list of domains that your containers can access.
 
 ## Cilium
 
@@ -19,3 +19,26 @@ using the built-in Helm chart due to how DNS resolution is handled.
 
 See the [limitations](../design/limitations.md) section for how Cilium may make certain
 Cyber misuse evals harder or impossible to solve.
+
+### DNS Exfiltration
+
+The built-in Helm chart prevents DNS exfiltration attacks. This is where an attacker
+uses DNS lookups to an attacker-controlled domain or set of subdomains in order to
+exfiltrate data from a system. For example, a malicious agent could make DNS requests
+(which go via the kube-dns service if the Core DNS sidecar can't resolve them) to
+hostnames like `somedata.attacker.com` and `somedata2.attacker.com` to exfiltrate data.
+
+DNS lookups are restricted to only:
+* Services within the Kubernetes namespace
+* The domains specified in the `allowDomains` list in the `values.yaml` file.
+
+See the [limitations](../design/limitations.md) section for how this may affect your
+evals.
+
+??? danger "I don't want to restrict DNS lookups"
+
+    Please consider the security implications; DNS exfiltration will be possible **and**
+    your containers will have unrestricted internet access.
+
+    To allow **all** DNS queries and **all** internet access, set
+    `allowDomains: ["*"]` or `allowEntities: "all"` in the `values.yaml` file.

--- a/docs/docs/security/network-access.md
+++ b/docs/docs/security/network-access.md
@@ -37,8 +37,13 @@ evals.
 
 ??? danger "I don't want to restrict DNS lookups"
 
-    Please consider the security implications; DNS exfiltration will be possible **and**
-    your containers will have unrestricted internet access.
+    The list of DNS names that can be queried is controlled by the same allow-list as
+    general traffic egress to a domain. In order to allow all DNS lookups without
+    restriction (including reverse DNS), you will need to allow all traffic to the
+    internet.
+
+    Please consider the security implications: your containers will have unrestricted
+    internet access (including the ability to use DNS to exfiltrate data).
 
     To allow **all** DNS queries and **all** internet access, set
     `allowDomains: ["*"]` or `allowEntities: "all"` in the `values.yaml` file.

--- a/src/k8s_sandbox/resources/helm/agent-env/Chart.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: agent-env
-version: 0.10.0
+version: 0.11.0

--- a/src/k8s_sandbox/resources/helm/agent-env/README.md
+++ b/src/k8s_sandbox/resources/helm/agent-env/README.md
@@ -1,6 +1,6 @@
 # agent-env
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square)
 
 ## Values
 

--- a/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
@@ -7,9 +7,13 @@ metadata:
 spec:
   description: |
     Allow egress to:
-    - cluster-wide DNS (kube-dns),
+    - cluster-wide DNS (kube-dns) for certain domains,
     - all Pods in the same agent sandbox,
     - any configured allowDomains, allowEntities, or allowCIDR.
+    To prevent DNS exfiltration, only allow DNS lookups for:
+    - services in this namespace,
+    - allowDomains, or
+    - allowEntities.
   endpointSelector:
     matchLabels:
       io.kubernetes.pod.namespace: {{ .Release.Namespace }}
@@ -25,7 +29,13 @@ spec:
               protocol: ANY
           rules:
             dns:
+              - matchPattern: "*.{{ .Release.Namespace }}.svc.cluster.local"
+              {{- range .Values.allowDomains }}
+              - matchPattern: "{{ . }}"
+              {{- end }}
+              {{- if or (has "all" .Values.allowEntities) (has "world" .Values.allowEntities) }}
               - matchPattern: "*"
+              {{- end }}
     - toEndpoints:
       - matchLabels:
           io.kubernetes.pod.namespace: {{ .Release.Namespace }}

--- a/test/k8s_sandbox/test_networks.py
+++ b/test/k8s_sandbox/test_networks.py
@@ -17,7 +17,7 @@ async def sandbox() -> AsyncGenerator[K8sSandboxEnvironment, None]:
 
 
 async def can_ping_service(service: str, sandbox: K8sSandboxEnvironment) -> bool:
-    result = await sandbox.exec(["ping", "-c", "1", service], timeout=3)
+    result = await sandbox.exec(["ping", "-c", "1", "-n", service], timeout=3)
     return "1 packets transmitted, 1 received" in result.stdout
 
 


### PR DESCRIPTION
Please see the `### DNS Exfiltration` docs section added in this PR for the motivation.

I'll advertise the following changes in behaviour to users:
1. Only DNS lookups to services part of the eval and any `allowedDomains` are permitted.
2. Reverse DNS lookups (i.e. IP address to domain name) are no longer permitted.
3. Requests to domains which aren't on the allow list will now typically fail more quickly with "temporary failure in DNS resolution" or similar rather than a long timeout (this depends on the client used though).

I've done some validation against UK AISI evals (I'll discuss this internally).