### PR TITLE
Handle the case where namespace isn't specified, and default to 'default'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- If a namespace is not includes in the kubeconfig context, default to a namespace named "default".
 - Add `CLUSTER_DEFAULT` magic string for `runtimeClassName` which will remove the field from the pod spec.
 - Add ignored `timeout_retry` parameter to `exec()` method.
 - Always capture the output of `helm uninstall` so that errors can contain meaningful information.

--- a/src/k8s_sandbox/_kubernetes_api.py
+++ b/src/k8s_sandbox/_kubernetes_api.py
@@ -31,7 +31,7 @@ def get_current_context_namespace() -> str:
     """Get the current context's namespace from the Kubernetes configuration."""
     _ensure_config_loaded()
     _, current_ctx = config.list_kube_config_contexts()
-    namespace = current_ctx["context"]["namespace"]
+    namespace = current_ctx["context"].get("namespace", "default")
     assert isinstance(namespace, str)
     return namespace
 


### PR DESCRIPTION
'namespace' is often not explicitly included in context entries and the convention here is to target 'default'. In order to repro this, try creating a cluster with `kind` then using it to spawn a sandbox, and you'll get an exception due to the explicit lookup of a namespace.