### PR TITLE
Update skipped Inspect `self_check` tests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -896,13 +896,13 @@ files = [
 
 [[package]]
 name = "inspect-ai"
-version = "0.3.57"
+version = "0.3.69"
 description = "Framework for large language model evaluations"
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "inspect_ai-0.3.57-py3-none-any.whl", hash = "sha256:2dd77e460ee05e2be3be10eaf9fa87c45e2b683e1daf88c5c839c8500f8a1ac1"},
-    {file = "inspect_ai-0.3.57.tar.gz", hash = "sha256:cad47d13c53a60e2f9d6b5877dac127eec069b564cb6b2a34ea16413b66ca81e"},
+    {file = "inspect_ai-0.3.69-py3-none-any.whl", hash = "sha256:caf2ad9d4ed054c54bccaac54c8eead698384ebd81c7fc0de24c58c41ea9ecad"},
+    {file = "inspect_ai-0.3.69.tar.gz", hash = "sha256:a1faf797a5bd86fc56332aa7c92339d36fe3967d629af98d9520afed7a39d442"},
 ]
 
 [package.dependencies]
@@ -931,14 +931,14 @@ s3fs = ">=2023"
 semver = ">=3.0.0"
 shortuuid = "*"
 tenacity = "*"
-textual = ">=0.86.2"
+textual = ">=0.86.2,<=1.0.0"
 typing_extensions = ">=4.9.0"
 zipp = ">=3.19.1"
 
 [package.extras]
-dev = ["aioboto3", "anthropic", "azure-ai-inference", "google-cloud-aiplatform", "google-generativeai", "groq", "ipython", "mistralai", "moto[server]", "mypy", "nbformat", "openai", "pre-commit", "pytest", "pytest-asyncio", "pytest-cov", "pytest-dotenv", "pytest-xdist", "ruff (==0.9.0)", "textual-dev (>=0.86.2)", "types-PyYAML", "types-aioboto3", "types-beautifulsoup4", "types-boto3", "types-botocore", "types-jsonpatch", "types-jsonschema", "types-protobuf", "types-psutil", "types-python-dateutil"]
+dev = ["aioboto3", "anthropic", "azure-ai-inference", "goodfire", "google-cloud-aiplatform", "google-genai", "griffe", "groq", "ipython", "mistralai", "moto[server]", "mypy", "nbformat", "openai", "pip", "pre-commit", "pylint", "pytest", "pytest-asyncio", "pytest-cov", "pytest-dotenv", "pytest-xdist", "ruff (==0.9.6)", "textual-dev (>=0.86.2)", "types-Markdown", "types-PyYAML", "types-aioboto3", "types-beautifulsoup4", "types-boto3", "types-botocore", "types-jsonpatch", "types-jsonschema", "types-protobuf", "types-psutil", "types-python-dateutil"]
 dist = ["build", "twine"]
-doc = ["jupyter", "quarto-cli"]
+doc = ["jupyter", "markdown", "panflute", "quarto-cli (==1.5.57)"]
 
 [[package]]
 name = "jmespath"

--- a/test/k8s_sandbox/test_inspect_self_check.py
+++ b/test/k8s_sandbox/test_inspect_self_check.py
@@ -34,7 +34,8 @@ async def test_self_check_k8s_default_root(root: SandboxEnvironment) -> None:
         # Root can read from files after `chmod -r`.
         "test_read_file_not_allowed",
         # Root can write to files after `chmod -w`.
-        "test_write_file_without_permissions",
+        "test_write_text_file_without_permissions",
+        "test_write_binary_file_without_permissions",
     ]
 
     return await _run_self_check(root, known_failures)


### PR DESCRIPTION
The `test_write_file_without_permissions` test has been split into 2, causing this test to fail against the latest version of Inspect.

* `test_write_text_file_without_permissions`
* `test_write_binary_file_without_permissions`