### PR TITLE
Ignore "release not found" errors during helm uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Ignore "release not found" errors when uninstalling Helm charts (expected when helm release was not successfully installed).
 - Prevent DNS exfiltration attacks by limiting which domains can be looked up (when using the built-in Helm chart).
 - If a namespace is not includes in the kubeconfig context, default to a namespace named "default".
 - Add `CLUSTER_DEFAULT` magic string for `runtimeClassName` which will remove the field from the pod spec.

--- a/docs/docs/tips/troubleshooting.md
+++ b/docs/docs/tips/troubleshooting.md
@@ -28,9 +28,11 @@ filter the Pods.
 
 ## I'm seeing "Helm uninstall failed" errors
 
-These are likely because the Helm chart was never installed. This typically happens if
-you cancel an eval, or an eval fails before a certain sample's Helm chart was installed
-(including if the chart installation failed).
+The `k8s_sandbox` package ignores "release not found" errors when uninstalling Helm
+releases because they are expected when the Helm release was not successfully installed
+(including when the user cancelled the eval).
+
+Other uninstall failures (e.g. "failed to delete release") will result in an error.
 
 Check to see if any Helm releases were left behind:
 
@@ -43,6 +45,9 @@ And if you wish to uninstall them:
 ```sh
 helm uninstall <release-name>
 ```
+
+If you wish to bulk uninstall all Inspect Helm charts, see the [cleanup
+command](cleanup.md).
 
 ## I'm seeing "Handshake status 404 Not Found" errors from Pod operations
 

--- a/src/k8s_sandbox/_helm.py
+++ b/src/k8s_sandbox/_helm.py
@@ -186,7 +186,8 @@ async def uninstall(release_name: str, namespace: str, quiet: bool) -> None:
         # err on the side of strictness.
         return (
             re.match(
-                r"^Error: uninstall: Release not loaded: [a-z-]+: release: not found$",
+                rf"^Error: uninstall: Release not loaded: {release_name}: release: not "
+                "found$",
                 stderr,
                 re.IGNORECASE,
             )

--- a/src/k8s_sandbox/_helm.py
+++ b/src/k8s_sandbox/_helm.py
@@ -183,18 +183,18 @@ async def uninstall(release_name: str, namespace: str, quiet: bool) -> None:
                 ],
                 capture_output=True,
             )
-            if not quiet:
-                sys.stdout.write(result.stdout)
-                sys.stderr.write(result.stderr)
             # A helm uninstall failure with "release not found" implies that the release
             # was never successfully installed or has already been uninstalled.
             # When a helm release fails to install (or the user cancels the eval), this
             # uninstall function will still be called, so these errors are common and
             # result in error desensitisation.
-            if (
-                not result.success
-                and "release: not found" not in result.stderr.casefold()
-            ):
+            is_release_not_found_error = (
+                "release: not found" in result.stderr.casefold()
+            )
+            if not quiet and not is_release_not_found_error:
+                sys.stdout.write(result.stdout)
+                sys.stderr.write(result.stderr)
+            if not result.success and not is_release_not_found_error:
                 _raise_runtime_error(
                     "Helm uninstall failed.",
                     release=release_name,

--- a/src/k8s_sandbox/_helm.py
+++ b/src/k8s_sandbox/_helm.py
@@ -158,6 +158,8 @@ async def uninstall(release_name: str, namespace: str, quiet: bool) -> None:
 
     The number of concurrent uninstall operations is limited by a semaphore.
 
+    "Release not found" errors are ignored.
+
     Args:
         release_name: The name of the Helm release to uninstall (e.g. abcdefgh).
         namespace: The Kubernetes namespace in which the release is installed.
@@ -184,11 +186,20 @@ async def uninstall(release_name: str, namespace: str, quiet: bool) -> None:
             if not quiet:
                 sys.stdout.write(result.stdout)
                 sys.stderr.write(result.stderr)
-            if not result.success:
+            # A helm uninstall failure with "release not found" implies that the release
+            # was never successfully installed or has already been uninstalled.
+            # When a helm release fails to install (or the user cancels the eval), this
+            # uninstall function will still be called, so these errors are common and
+            # result in error desensitisation.
+            if (
+                not result.success
+                and "release: not found" not in result.stderr.casefold()
+            ):
                 _raise_runtime_error(
                     "Helm uninstall failed.",
                     release=release_name,
                     namespace=namespace,
+                    returncode=result.returncode,
                     stdout=result.stdout,
                     stderr=result.stderr,
                 )

--- a/test/k8s_sandbox/test_helm.py
+++ b/test/k8s_sandbox/test_helm.py
@@ -1,10 +1,12 @@
+import logging
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from inspect_ai.util import ExecResult
+from pytest import LogCaptureFixture
 
-from k8s_sandbox._helm import Release, _run_subprocess
+from k8s_sandbox._helm import Release, _run_subprocess, uninstall
 
 
 @pytest.fixture
@@ -12,13 +14,44 @@ def uninstallable_release() -> Release:
     return Release(__file__, chart_path=Path("/non_existent_chart"))
 
 
-async def test_helm_install_error(uninstallable_release: Release) -> None:
+@pytest.fixture
+def log_err(caplog: LogCaptureFixture) -> LogCaptureFixture:
+    # Note: this will prevent lower level messages from being shown in pytest output.
+    caplog.set_level(logging.ERROR)
+    return caplog
+
+
+async def test_helm_install_error(
+    uninstallable_release: Release, log_err: LogCaptureFixture
+) -> None:
     with patch("k8s_sandbox._helm._run_subprocess", wraps=_run_subprocess) as spy:
         with pytest.raises(RuntimeError) as excinfo:
             await uninstallable_release.install()
 
     assert spy.call_count == 1
     assert "not found" in str(excinfo.value)
+    assert "not found" in log_err.text
+
+
+async def test_helm_uninstall_does_not_error_for_release_not_found(
+    log_err: LogCaptureFixture,
+) -> None:
+    release = Release(__file__)
+
+    # Note: we haven't called install() on release.
+    await release.uninstall(quiet=False)
+
+    assert log_err.text == ""
+
+
+async def test_helm_uninstall_errors_for_other_errors(
+    log_err: LogCaptureFixture,
+) -> None:
+    with pytest.raises(RuntimeError) as excinfo:
+        await uninstall("my invalid release name!", "fake-namespace", quiet=False)
+
+    assert "Release name is invalid" in log_err.text
+    assert "Release name is invalid" in str(excinfo.value)
 
 
 async def test_helm_resourcequota_retries(uninstallable_release: Release) -> None:


### PR DESCRIPTION
When a helm release fails to **install** (e.g. user cancelled, timeout, resource quotas etc.), we'll error the sample and Inspect will then ask us to clean up that sample, so we'll attempt to **uninstall** the Helm release. I think this is the correct behaviour - we should not assume that a `helm install` failing means that the release isn't at least "partially" installed.

However, this results in a lot of error messages which users have become desensitised to. In amongst these "helm uninstall ... release not found" errors are sometimes different messages like `Error: failed to delete release: xxx` where we legitimately failed to uninstall an existing release.