### PR TITLE
Add `karpenter.sh/do-not-disrupt: "true"`

### DIFF
--- a/src/k8s_sandbox/resources/helm/agent-env/Chart.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: agent-env
-version: 0.11.0
+version: 0.12.0

--- a/src/k8s_sandbox/resources/helm/agent-env/README.md
+++ b/src/k8s_sandbox/resources/helm/agent-env/README.md
@@ -1,6 +1,6 @@
 # agent-env
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square)
 
 ## Values
 

--- a/src/k8s_sandbox/resources/helm/agent-env/templates/services.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/services.yaml
@@ -26,7 +26,11 @@ spec:
         {{- end }}
         inspect/service: {{ $name }}
       annotations:
+        # Prevent Karpenter (auto-scaler) from voluntarily choosing to disrupt this Pod.
+        karpenter.sh/do-not-disrupt: "true"
+        {{- if $.Values.annotations }}
         {{- toYaml $.Values.annotations | nindent 8 }}
+        {{- end }}
     spec:
       {{- /* "CLUSTER_DEFAULT" (magic string) prevents runtimeClassName being set. */}}
       {{- if ne $service.runtimeClassName "CLUSTER_DEFAULT" }}

--- a/test/k8s_sandbox/helm_chart/test_helm_chart.py
+++ b/test/k8s_sandbox/helm_chart/test_helm_chart.py
@@ -112,6 +112,9 @@ def test_annotations(chart_dir: Path, test_resources_dir: Path) -> None:
         assert stateful_set["metadata"]["annotations"]["myValue"] == attr_value
         template = stateful_set["spec"]["template"]
         assert template["metadata"]["annotations"]["myValue"] == attr_value
+        assert (
+            template["metadata"]["annotations"]["karpenter.sh/do-not-disrupt"] == "true"
+        )
     for network_policy in _get_documents(documents, "NetworkPolicy"):
         assert network_policy["metadata"]["annotations"]["myValue"] == attr_value
     for pvc in _get_documents(documents, "PersistentVolumeClaim"):


### PR DESCRIPTION
See docs https://karpenter.sh/v0.32/concepts/disruption/#controls

Selfishly, this is UK AISI infrastructure-relevant, but it will not cause any issues for clusters which don't use Karpenter.

Read more about why we want to avoid disruptions here https://k8s-sandbox.ai-safety-institute.org.uk/design/limitations/#containers-may-restart