### PR TITLE
Improve helm install timeout error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- For "helm install timeout" errors, add link to docs within and include instructions on increasing timeout within the error message.
 - Prevent DNS exfiltration attacks by limiting which domains can be looked up (when using the built-in Helm chart).
 - If a namespace is not includes in the kubeconfig context, default to a namespace named "default".
 - Add `CLUSTER_DEFAULT` magic string for `runtimeClassName` which will remove the field from the pod spec.

--- a/docs/docs/tips/troubleshooting.md
+++ b/docs/docs/tips/troubleshooting.md
@@ -9,22 +9,28 @@ A good starting point to many issues is to view the `TRACE`-level logs written b
 Inspect. See the [`TRACE` log level
 section](debugging-k8s-sandboxes.md#trace-log-level).
 
-## I'm seeing "Helm install: context deadline exceeded" errors
+## I'm seeing "Helm install: context deadline exceeded" errors {#helm-context-deadline-exceeded}
 
 This means that the Helm chart installation timed out. When installing the Helm chart,
 the `k8s_sandbox` package uses the `--wait` flag to wait for all Pods to be ready.
 
 Therefore, this error can be an indication of:
 
-* Cluster capacity issues. Consider [increasing the
-  timeout](configuration.md#helm-install-timeout) or scaling up your cluster.
+* If you have an auto-scaling cluster, it may need more time to provision new nodes.
+* If you don't have an auto-scaling cluster, you may have reached capacity.
+* If you are using large images, they may take a long time to pull onto the nodes.
 * A Pod failing to enter the ready state (could be a failing readiness probe, failing to
   pull the image, crash loop backoff, etc.)
 
+Consider [increasing the timeout](configuration.md#helm-install-timeout).
+
+If your cluster does not auto-scale and it is at capacity, consider reducing parallelism
+or scaling up the relevant cluster node group.
+
 Try installing the chart again (this can also be [done
 manually](../helm/built-in-chart.md#manual-chart-install)) and check the Pod statuses
-and logs using a tool like K9s. Use the helm release name (will be in error message) to
-filter the Pods.
+and events using a tool like K9s to get a definitive answer as to the underlying
+problem. Use the Helm release name (will be in error message) to filter the Pods.
 
 ## I'm seeing "Helm uninstall failed" errors
 

--- a/docs/docs/tips/troubleshooting.md
+++ b/docs/docs/tips/troubleshooting.md
@@ -29,8 +29,9 @@ or scaling up the relevant cluster node group.
 
 Try installing the chart again (this can also be [done
 manually](../helm/built-in-chart.md#manual-chart-install)) and check the Pod statuses
-and events using a tool like K9s to get a definitive answer as to the underlying
-problem. Use the Helm release name (will be in error message) to filter the Pods.
+and events using a tool like kubectl or K9s to get a definitive answer as to the
+underlying problem. Use the Helm release name (will be in error message) to filter the
+Pods.
 
 ## I'm seeing "Helm uninstall failed" errors
 

--- a/test/k8s_sandbox/test_helm.py
+++ b/test/k8s_sandbox/test_helm.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 from inspect_ai.util import ExecResult
 
-from k8s_sandbox._helm import Release, _run_subprocess
+from k8s_sandbox._helm import INSPECT_HELM_TIMEOUT, Release, _run_subprocess
 
 
 @pytest.fixture
@@ -46,7 +46,19 @@ async def test_helm_resourcequota_retries(uninstallable_release: Release) -> Non
 async def test_invalid_helm_timeout(
     uninstallable_release: Release, value: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("INSPECT_HELM_TIMEOUT", value)
+    monkeypatch.setenv(INSPECT_HELM_TIMEOUT, value)
 
     with pytest.raises(ValueError):
         await uninstallable_release.install()
+
+
+async def test_helm_install_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(INSPECT_HELM_TIMEOUT, "1")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await Release(__file__).install()
+
+    # Verify that we detect the install timeout and add our own message.
+    assert "The configured timeout value was 1s. Please see the docs" in str(
+        excinfo.value
+    )


### PR DESCRIPTION
A get a lot of support queries about "INSTALLATION FAILED: context deadline exceeded". We have docs on this, so I'd like to make it easier to users to refer to them (and discover them).

I'm also conscious that almost all of UK AISI's k8s usage is on a cluster which auto scales node groups, so I've made the docs more general to also encompass this.