### PR TITLE
Bump default Helm install (and uninstall) timeout from 5 to 10 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Increase default Helm install timeout from 5 to 10 minutes.
 - Prevent DNS exfiltration attacks by limiting which domains can be looked up (when using the built-in Helm chart).
 - If a namespace is not includes in the kubeconfig context, default to a namespace named "default".
 - Add `CLUSTER_DEFAULT` magic string for `runtimeClassName` which will remove the field from the pod spec.

--- a/src/k8s_sandbox/_helm.py
+++ b/src/k8s_sandbox/_helm.py
@@ -18,7 +18,7 @@ from k8s_sandbox._logger import format_log_message, inspect_trace_action, log_tr
 from k8s_sandbox._pod import Pod
 
 DEFAULT_CHART = Path(__file__).parent / "resources" / "helm" / "agent-env"
-DEFAULT_TIMEOUT = 300
+DEFAULT_TIMEOUT = 600  # 10 minutes
 MAX_INSTALL_ATTEMPTS = 3
 INSTALL_RETRY_DELAY_SECONDS = 5
 


### PR DESCRIPTION
5 minutes is the default for Helm which is why we adopted it.

It is a balancing act between increasing this to allow time for pulling large images and cluster autoscaling versus reducing it so that errors (e.g. incorrect image name, container keeps crashing, readiness probe will never pass) are caught without a long delay.

On balance, I think 10 minutes is more appropriate, especially for clusters which auto-scale node groups.

I welcome disagreement - but our users are generally asking for this, so as long as it is for sound, explainable reasons, we can push back.