### PR TITLE
Add test ensuring config can be serialised and deserialized

### DIFF
--- a/test/k8s_sandbox/test_config_validation.py
+++ b/test/k8s_sandbox/test_config_validation.py
@@ -33,3 +33,14 @@ async def test_invalid_config_type() -> None:
 
     with pytest.raises(TypeError):
         await K8sSandboxEnvironment.sample_init(__file__, MyModel(), {})
+
+
+def test_can_serialize_and_deserialize_config() -> None:
+    original = K8sSandboxEnvironmentConfig(
+        chart="my-chart", values=Path("my-values.yaml")
+    )
+
+    as_json = original.model_dump()
+    recreated = K8sSandboxEnvironmentConfig.model_validate(as_json)
+
+    assert recreated == original


### PR DESCRIPTION
Prompted by this discussion https://inspectcommunity.slack.com/archives/C0805HJTK8U/p1741026691168939

This can already be serialised and deserialised, but there wasn't a test proving it (or preventing regressions).