### PR TITLE
Retry on resource quota errors

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -896,13 +896,13 @@ files = [
 
 [[package]]
 name = "inspect-ai"
-version = "0.3.69"
+version = "0.3.72"
 description = "Framework for large language model evaluations"
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "inspect_ai-0.3.69-py3-none-any.whl", hash = "sha256:caf2ad9d4ed054c54bccaac54c8eead698384ebd81c7fc0de24c58c41ea9ecad"},
-    {file = "inspect_ai-0.3.69.tar.gz", hash = "sha256:a1faf797a5bd86fc56332aa7c92339d36fe3967d629af98d9520afed7a39d442"},
+    {file = "inspect_ai-0.3.72-py3-none-any.whl", hash = "sha256:8151574aae304a461b40ba08e4bec777848f217802e61276a118d355cfc2062a"},
+    {file = "inspect_ai-0.3.72.tar.gz", hash = "sha256:e6187d5dda59b2b740072b3afc2aa6b29255f188663723bd2c2960e3402292d7"},
 ]
 
 [package.dependencies]
@@ -912,7 +912,7 @@ beautifulsoup4 = "*"
 click = ">=8.1.3"
 debugpy = "*"
 docstring-parser = ">=0.16"
-fsspec = ">=2021.09.0"
+fsspec = ">=2023.1.0,<=2024.12.0"
 httpx = "*"
 ijson = ">=3.2.0"
 jsonlines = ">=3.0.0"
@@ -931,7 +931,7 @@ s3fs = ">=2023"
 semver = ">=3.0.0"
 shortuuid = "*"
 tenacity = "*"
-textual = ">=0.86.2,<=1.0.0"
+textual = ">=0.86.2"
 typing_extensions = ">=4.9.0"
 zipp = ">=3.19.1"
 
@@ -2665,4 +2665,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "a8a5a8ea2adc5c3b6f8032c2a6619f743452e71553cbc9c492e5ae82f2a6d9aa"
+content-hash = "c24c3818f461fd91dffa06ee430b2d04daff9ad76e476ddb6c2c14dab8d296f3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-inspect-ai = ">=0.3.57"
+inspect-ai = ">=0.3.72"
 kubernetes = "^31.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/src/k8s_sandbox/_helm.py
+++ b/src/k8s_sandbox/_helm.py
@@ -24,7 +24,7 @@ from k8s_sandbox._pod import Pod
 
 DEFAULT_CHART = Path(__file__).parent / "resources" / "helm" / "agent-env"
 DEFAULT_TIMEOUT = 600  # 10 minutes
-MAX_INSTALL_ATTEMPTS = 3
+MAX_INSTALL_ATTEMPTS = 5
 INSTALL_RETRY_DELAY_SECONDS = 5
 INSPECT_HELM_TIMEOUT = "INSPECT_HELM_TIMEOUT"
 HELM_CONTEXT_DEADLINE_EXCEEDED_URL = (

--- a/src/k8s_sandbox/_helm.py
+++ b/src/k8s_sandbox/_helm.py
@@ -17,8 +17,8 @@ from k8s_sandbox._kubernetes_api import (
 from k8s_sandbox._logger import (
     format_log_message,
     inspect_trace_action,
+    log_message,
     log_trace,
-    log_warning,
 )
 from k8s_sandbox._pod import Pod
 
@@ -179,10 +179,11 @@ class Release:
             global resource_quota_exceeded_counter
             if resource_quota_exceeded_counter == 0:
                 # Log only once.
-                log_warning(
+                log_message(
+                    logging.WARNING,
                     "K8s resource quota exceeded. Please uninstall any unused Helm "
                     "releases or reduce the level of concurrency in your Inspect eval. "
-                    + match.group()
+                    + match.group(),
                 )
             resource_quota_exceeded_counter += 1
             display_counter(

--- a/src/k8s_sandbox/_helm.py
+++ b/src/k8s_sandbox/_helm.py
@@ -4,7 +4,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Any, NoReturn
+from typing import Any, AsyncContextManager, NoReturn
 
 from inspect_ai.util import ExecResult, concurrency, display_counter
 from kubernetes.client.rest import ApiException  # type: ignore
@@ -324,7 +324,7 @@ def _get_timeout() -> int:
     return timeout
 
 
-def _install_semaphore() -> asyncio.Semaphore:
+def _install_semaphore() -> AsyncContextManager[None]:
     # Limit concurrent subprocess calls to `helm install` and `helm uninstall`.
     # Use distinct semaphores for each operation to avoid deadlocks where all permits
     # are acquired by the "install" operations which are waiting for cluster resources
@@ -334,7 +334,7 @@ def _install_semaphore() -> asyncio.Semaphore:
     return concurrency("helm-install", _get_environ_int("INSPECT_MAX_HELM_INSTALL", 8))
 
 
-def _uninstall_semaphore() -> asyncio.Semaphore:
+def _uninstall_semaphore() -> AsyncContextManager[None]:
     return concurrency(
         "helm-uninstall", _get_environ_int("INSPECT_MAX_HELM_UNINSTALL", 8)
     )

--- a/src/k8s_sandbox/_logger.py
+++ b/src/k8s_sandbox/_logger.py
@@ -27,6 +27,19 @@ def log_trace(message: str, **kwargs: Any) -> None:
     trace_message(logger, category="K8s", message=formatted)
 
 
+def log_warning(message: str, **kwargs: Any) -> None:
+    """Format and log a message at WARNING level with K8s prefix.
+
+    Args:
+        message: The log message.
+        **kwargs: Key-value pairs to include in the log message. Values are truncated if
+          they exceed DEFAULT_ARG_TRUNCATION_THRESHOLD (which can be overridden with env
+          var INSPECT_K8S_LOG_TRUNCATION_THRESHOLD).
+    """
+    formatted = format_log_message(message, **kwargs)
+    logger.error(f"K8s: {formatted}")
+
+
 def log_error(message: str, **kwargs: Any) -> None:
     """Format and log a message at ERROR level with K8s prefix.
 

--- a/src/k8s_sandbox/_logger.py
+++ b/src/k8s_sandbox/_logger.py
@@ -27,30 +27,18 @@ def log_trace(message: str, **kwargs: Any) -> None:
     trace_message(logger, category="K8s", message=formatted)
 
 
-def log_warning(message: str, **kwargs: Any) -> None:
-    """Format and log a message at WARNING level with K8s prefix.
+def log_message(level: int, message: str, **kwargs: Any) -> None:
+    """Format and log a message at the specified level with K8s prefix.
 
     Args:
+        level: The log level to use (e.g. logging.WARNING).
         message: The log message.
         **kwargs: Key-value pairs to include in the log message. Values are truncated if
           they exceed DEFAULT_ARG_TRUNCATION_THRESHOLD (which can be overridden with env
           var INSPECT_K8S_LOG_TRUNCATION_THRESHOLD).
     """
     formatted = format_log_message(message, **kwargs)
-    logger.error(f"K8s: {formatted}")
-
-
-def log_error(message: str, **kwargs: Any) -> None:
-    """Format and log a message at ERROR level with K8s prefix.
-
-    Args:
-        message: The log message.
-        **kwargs: Key-value pairs to include in the log message. Values are truncated if
-          they exceed DEFAULT_ARG_TRUNCATION_THRESHOLD (which can be overridden with env
-          var INSPECT_K8S_LOG_TRUNCATION_THRESHOLD).
-    """
-    formatted = format_log_message(message, **kwargs)
-    logger.error(f"K8s: {formatted}")
+    logger.log(level, f"K8s: {formatted}")
 
 
 def format_log_message(message: str, **kwargs: Any) -> str:

--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -1,3 +1,4 @@
+import logging
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
@@ -16,7 +17,7 @@ from k8s_sandbox._helm import Release
 from k8s_sandbox._logger import (
     format_log_message,
     inspect_trace_action,
-    log_error,
+    log_message,
     log_trace,
 )
 from k8s_sandbox._manager import (
@@ -205,7 +206,9 @@ class K8sSandboxEnvironment(SandboxEnvironment):
             except Exception as e:
                 # Whilst Inspect's trace_action will have logged the exception, log it
                 # at ERROR level here for user visibility.
-                log_error(f"Error during: {op}.", cause=e, **log_kwargs)
+                log_message(
+                    logging.ERROR, f"Error during: {op}.", cause=e, **log_kwargs
+                )
                 # Enrich the unexpected exception with additional context.
                 raise K8sError(f"Error during: {op}.", **log_kwargs) from e
 

--- a/test/k8s_sandbox/test_helm.py
+++ b/test/k8s_sandbox/test_helm.py
@@ -78,7 +78,7 @@ async def test_helm_resourcequota_modified_retries(
             with pytest.raises(Exception) as excinfo:
                 await uninstallable_release.install()
 
-    assert mock.call_count == 3
+    assert mock.call_count == 5
     assert "resourcequotas" in str(excinfo.value)
 
 
@@ -106,7 +106,7 @@ async def test_helm_resource_quota_exceeded_retries(
             with pytest.raises(Exception) as excinfo:
                 await uninstallable_release.install()
 
-    assert mock.call_count == 3
+    assert mock.call_count == 5
     assert "exceeded quota: resource-quota" in str(excinfo.value)
 
 


### PR DESCRIPTION
**DNM** Given the below, does this PR add enough value to merit its inclusion?

This is only relevant to clusters which use resource quotas.

Note: Different resource quotas manifest exceeding them in different ways: for a `Pod` quota, the Helm release will eventually time out with no mention of quotas; for a `configmap` quota, an error matching the regex in this PR will be raised immediately.

https://github.com/user-attachments/assets/fb2de85a-70eb-4a6a-bfd5-238e57eb40b8

I've also tested this manually by lowering my namespace's `configmap` resource quota to 1 (see screen recording)
