### PR TITLE
Validate service names and throw informative errors

### DIFF
--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -252,8 +252,6 @@ def validate_k8s_name(name: str) -> tuple[bool, str]:
     This is, as of the time of writing, located here in the Kubernetes source code:
     https://github.com/kubernetes/kubernetes/blob/68899f8e6d5861e7b6197c51b0dee9f8a486e3e0/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L179
 
-    This function identifies failures in the
-
     Args:
         name: The string to validate as a Kubernetes resource name
 

--- a/test/k8s_sandbox/test_config_validation.py
+++ b/test/k8s_sandbox/test_config_validation.py
@@ -1,9 +1,12 @@
+import tempfile
 from pathlib import Path
 
 import pytest
+import yaml
 from pydantic import BaseModel
 
 from k8s_sandbox import K8sSandboxEnvironment, K8sSandboxEnvironmentConfig
+from k8s_sandbox._sandbox_environment import validate_k8s_name, validate_service_names
 
 VALID_VALUES = str(Path(__file__).parent / "resources" / "values.yaml")
 
@@ -33,3 +36,90 @@ async def test_invalid_config_type() -> None:
 
     with pytest.raises(TypeError):
         await K8sSandboxEnvironment.sample_init(__file__, MyModel(), {})
+
+
+def test_valid_k8s_name() -> None:
+    valid_names = [
+        "myservice",
+        "my-service",
+        "my.service",
+        "myservice123",
+        "a" * 63,  # Max length
+        "a",  # Min length
+    ]
+
+    for name in valid_names:
+        is_valid, _ = validate_k8s_name(name)
+        assert is_valid, f"Expected '{name}' to be valid"
+
+
+def test_invalid_k8s_name() -> None:
+    """Test that invalid Kubernetes service names are rejected."""
+    invalid_names = [
+        "",  # Empty
+        "a" * 64,  # Too long
+        "-myservice",  # Starts with hyphen
+        "myservice-",  # Ends with hyphen
+        "my_service",  # Contains underscore
+        "MyService",  # Contains uppercase
+        "my service",  # Contains space
+    ]
+
+    for name in invalid_names:
+        is_valid, error = validate_k8s_name(name)
+        assert not is_valid, f"Expected '{name}' to be invalid"
+        assert error, "Error message should not be empty"
+
+
+async def test_invalid_service_names() -> None:
+    invalid_service_names = {
+        "Invalid_Service": "must consist only of lowercase alphanumeric characters",
+        "-invalid-start": "must start with an alphanumeric character",
+        "invalid-end-": "must end with an alphanumeric character",
+        "too-long" + "x" * 60: "is too long (max 63 characters)",
+    }
+
+    # Create a services dict for the values file
+    invalid_services_config = {
+        "services": {name: {"image": "nginx"} for name in invalid_service_names}
+    }
+
+    with pytest.raises(ValueError) as excinfo:
+        validate_service_names(invalid_services_config)
+
+    error_lines = str(excinfo.value).splitlines()
+
+    assert "Invalid Kubernetes service name(s) in values file:" in error_lines[0]
+    assert any("Service names must:" in line for line in error_lines)
+
+    for service_name, expected_error in invalid_service_names.items():
+        # Find the line containing the given service name
+        service_error_line = next(
+            (line for line in error_lines if service_name in line), None
+        )
+        assert service_error_line is not None, f"No error line found for {service_name}"
+
+        # Check that the line contains the expected error message
+        assert expected_error in service_error_line, (
+            f"Error for {service_name} doesn't contain '{expected_error}'. "
+            f"Actual: {service_error_line}"
+        )
+
+
+async def test_invalid_yaml_syntax() -> None:
+    """Test that values file with invalid YAML syntax raises a YAML error."""
+    invalid_yaml = """
+    services:
+      valid-service:
+        image: nginx
+      # Invalid YAML - missing colon
+      another-service
+        image: ubuntu
+    """
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as temp_file:
+        temp_file.write(invalid_yaml)
+        temp_file.flush()
+
+        with pytest.raises(yaml.YAMLError):
+            await K8sSandboxEnvironment.sample_init(__file__, temp_file.name, {})


### PR DESCRIPTION
Users have reported confusing errors like:
```
RuntimeError: Helm install failed. {"release": "byzslntg", "result": "ExecResult(success=False, returncode=1, stdout='', stderr='Error: INSTALLATION FAILED: 1 error occurred:\\n\\t* StatefulSet.apps \"agent-env-byzslntg-web_browser\" is invalid: metadata.name: Invalid value: 
\"agent-env-byzslntg-web_browser\": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or \\'-\\', and must start and end with an alphanumeric character (e.g. \\'my-name\\',  or \\'123-abc\\', regex used for validation is 
\\'[a-z0-9]([-a-z0-9]*[a-z0-9])?\\')\\n\\n\\n')"}
```

It's extremely easy to miss, but the `web_browser` is the user's configured "service name" (from the Helm values.yaml file), and while this is allowed in docker-compose, it's not permitted in k8s identifiers. The information on the naming rules are present in the error, but it's very easy to miss.

Instead of letting these invalid names proceed to Helm, and letting the Kubernetes API server bubble back out a validation error, we now check all service names before attempting to `helm install`, and report back failures with explanations (see the docstring of `validate_service_names()` for an example of error text).