### PR TITLE
Update docs URLs for k8s-sandbox.aisi.org.uk

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ adopting this plugin, come join us in the [Inspect
 Slack](https://join.slack.com/t/inspectcommunity/shared_invite/zt-2w9eaeusj-4Hu~IBHx2aORsKz~njuz4g)!
 
 You can find documentation at
-[https://k8s-sandbox.ai-safety-institute.org.uk/](https://k8s-sandbox.ai-safety-institute.org.uk/).
+[https://k8s-sandbox.aisi.org.uk/](https://k8s-sandbox.aisi.org.uk/).
 
 If you’d like to contribute to the development of the plugin, please review our
 [contributing guidelines](CONTRIBUTING.md) before raising a pull request.

--- a/src/k8s_sandbox/_helm.py
+++ b/src/k8s_sandbox/_helm.py
@@ -23,7 +23,7 @@ MAX_INSTALL_ATTEMPTS = 3
 INSTALL_RETRY_DELAY_SECONDS = 5
 INSPECT_HELM_TIMEOUT = "INSPECT_HELM_TIMEOUT"
 HELM_CONTEXT_DEADLINE_EXCEEDED_URL = (
-    "https://k8s-sandbox.ai-safety-institute.org.uk/tips/troubleshooting/"
+    "https://k8s-sandbox.aisi.org.uk/tips/troubleshooting/"
     "#helm-context-deadline-exceeded"
 )
 


### PR DESCRIPTION
The docs are now at https://k8s-sandbox.aisi.org.uk

Once the Inspect docs site is updated, we should update the links here too.