### PR TITLE
Replace Inspect URLs from `ai-safety-institute.org.uk` to `aisi.org.uk`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,8 +96,7 @@ Consider using the recommended [Rewrap](https://stkb.github.io/Rewrap/) extensio
 ### Package Structure and API Visibility
 
 The Python packages, modules and members follow a similar API visibility naming
-convention to that used in the [inspect_ai](https://inspect.ai-safety-institute.org.uk/)
-package.
+convention to that used in the [inspect_ai](https://inspect.aisi.org.uk/) package.
 
 Public API members (e.g. classes, functions, constants) are exported in the package's
 `__init__.py` file. Members are exported rather than modules (i.e. .py files) to avoid

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-[<img width="295" src="docs/docs/assets/aisi-logo.svg"
-/>](https://aisi.gov.uk/)
+[<img width="295" src="docs/docs/assets/aisi-logo.svg" />](https://aisi.gov.uk/)
 
-Welcome to the `k8s_sandbox` plugin for
-[Inspect](https://inspect.ai-safety-institute.org.uk/). It provides a Kubernetes (K8s)
-sandbox environment in which agentic evaluations can securely be run at scale.
+Welcome to the `k8s_sandbox` plugin for [Inspect](https://inspect.aisi.org.uk/). It
+provides a Kubernetes (K8s) sandbox environment in which agentic evaluations can
+securely be run at scale.
 
 We are releasing this publicly because it is a useful example of a complex Sandbox
 Environment provider. While this work was designed within the context of UK AISI's

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -2,13 +2,13 @@
 
 ![pkg icon](assets/icon-dark.png){: style="height:80px;float:left;margin-right:20px;"}
 The `k8s_sandbox` Python package provides a Kubernetes (K8s) sandbox environment for
-[inspect_ai](https://inspect.ai-safety-institute.org.uk/).
+[inspect_ai](https://inspect.aisi.org.uk/).
 
 <br>
 Learn more about what sandbox environments are for from the [Inspect docs
-site](https://inspect.ai-safety-institute.org.uk/tools.html#sandboxing). At a high
-level, this package lets you run Docker containers which your agents interact with
-within a Kubernetes cluster instead of locally (e.g. using Docker Compose).
+site](https://inspect.aisi.org.uk/tools.html#sandboxing). At a high level, this package
+lets you run Docker containers which your agents interact with within a Kubernetes
+cluster instead of locally (e.g. using Docker Compose).
 
 The Inspect process itself still runs on your local machine.
 

--- a/docs/docs/tips/debugging-k8s-sandboxes.md
+++ b/docs/docs/tips/debugging-k8s-sandboxes.md
@@ -1,16 +1,16 @@
 # Debugging K8s Sandboxes
 
-This section explains features of [Inspect](https://inspect.ai-safety-institute.org.uk/)
-and [k9s](https://k9scli.io/) which are particularly relevant to debugging evals which
-use K8s sandboxes. Please see the dedicated docs pages of each for more information.
+This section explains features of [Inspect](https://inspect.aisi.org.uk/) and
+[k9s](https://k9scli.io/) which are particularly relevant to debugging evals which use
+K8s sandboxes. Please see the dedicated docs pages of each for more information.
 
 ## View Inspect's `TRACE`-level logs { #trace-log-level }
 
 Useful sandbox-related messages like Helm installs/uninstalls, Pod operations (`exec()`
 executions including the result, `read_file()`, `write_file()`) etc. are logged at the
 `TRACE` log level. See the [Inspect tracing
-docs](https://inspect.ai-safety-institute.org.uk/tracing.html) for more information on
-where these are stored and how to read them.
+docs](https://inspect.aisi.org.uk/tracing.html) for more information on where these are
+stored and how to read them.
 
 Example (additional fields removed for brevity):
 


### PR DESCRIPTION
Inspect's docs are now hosted at https://inspect.aisi.org.uk.

0 grep matches for "safety" in this repo now (all refer to AISI or AI Security Institute).