### PR TITLE
Add support for specifying a kubeconfig context name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add support for specifying a kubeconfig context name in K8sSandboxEnvironmentConfig.
 - Add automatic translation of Docker Compose files to Helm values files.
 - Handle cancellation of evals (either manually or due to an error) such that Helm releases are uninstalled.
 - Increase default Helm install timeout from 5 to 10 minutes.

--- a/docs/docs/tips/configuration.md
+++ b/docs/docs/tips/configuration.md
@@ -10,6 +10,41 @@ expect to run into cluster capacity issues, you can increase the timeout by sett
 export INSPECT_HELM_TIMEOUT=21600   # 6 hours
 ```
 
+
+## Targeting specific or multiple kubeconfig contexts
+
+Your
+[kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
+file provides information about the Kubernetes clusters you can access.
+
+By default, your kubeconfig's _current context_ is used to install Helm charts. You can
+determine what this is by running:
+
+```bash
+kubectl config current-context
+```
+
+At an Inspect `Task` or `Sample` level, you can specify the name of the Kubernetes
+context in which the Helm chart should be installed by providing a
+`K8sSandboxEnvironmentConfig` in the `sandbox` argument. This might be useful if for
+example certain Samples require GPU nodes which are only available in a specific
+cluster.
+
+```python
+Sample(
+    sandbox=SandboxEnvironmentSpec(
+        "k8s",
+        K8sSandboxEnvironmentConfig(context="minikube"),
+    ),
+)
+```
+
+!!! note
+    If using the `inspect sandbox cleanup k8s` [command](cleanup.md), please note
+    that it only cleans up Helm releases in the current context. Use `kubectl` or `k9s`
+    to clean up Helm releases in other contexts.
+
+
 ## Structured logging truncation threshold
 
 By default, each key/value pair (e.g. an exec command's output) logged to Python's

--- a/src/k8s_sandbox/_kubernetes_api.py
+++ b/src/k8s_sandbox/_kubernetes_api.py
@@ -120,7 +120,7 @@ class _Config:
                 return context
         raise ValueError(
             f"Could not find a context named '{context_name}' in the kubeconfig file. "
-            f"Available contexts: {self.contexts}."
+            f"Available contexts: {[ctx['name'] for ctx in self.contexts]}."
         )
 
 

--- a/src/k8s_sandbox/_kubernetes_api.py
+++ b/src/k8s_sandbox/_kubernetes_api.py
@@ -2,43 +2,157 @@ from __future__ import annotations
 
 import logging
 import threading
+from typing import Any
 
 from kubernetes import client, config  # type: ignore
 
 logger = logging.getLogger(__name__)
 
 _thread_local = threading.local()
-_load_config_lock = threading.Lock()
-_config_loaded = False
 
 
-def k8s_client() -> client.CoreV1Api:
+def k8s_client(context_name: str | None) -> client.CoreV1Api:
     """
-    Gets a thread-local Kubernetes client.
+    Get a thread-local Kubernetes client for interacting with the specified context.
+
+    The context name must refer to an existing context within the kubeconfig file. If
+    context is None, the current context is used.
 
     This function is thread-safe and ensures that the Kubernetes configuration is
     loaded.
+
     A Kubernetes client cannot be used simultaneously from multiple threads (which are
     used because the kubernetes client is not async).
     """
-    _ensure_config_loaded()
-    if not hasattr(_thread_local, "client"):
-        _thread_local.client = client.CoreV1Api()
-    return _thread_local.client
+    _Config.ensure_loaded()
+    if not hasattr(_thread_local, "client_factory"):
+        _thread_local.client_factory = _ThreadLocalClientFactory()
+    return _thread_local.client_factory.get_client(context_name)
 
 
-def get_current_context_namespace() -> str:
-    """Get the current context's namespace from the Kubernetes configuration."""
-    _ensure_config_loaded()
-    _, current_ctx = config.list_kube_config_contexts()
-    namespace = current_ctx["context"].get("namespace", "default")
+def get_default_namespace(context_name: str | None) -> str:
+    """
+    Get the default namespace for the specified kubeconfig context name.
+
+    If context_name is None, the current context is used.
+
+    If the namespace is not specified in the kubeconfig file, "default" is returned.
+    """
+    context = _Config.get_instance().get_context(context_name)
+    namespace = context["context"].get("namespace", "default")
     assert isinstance(namespace, str)
     return namespace
 
 
-def _ensure_config_loaded() -> None:
-    with _load_config_lock:
-        global _config_loaded
-        if not _config_loaded:
-            config.load_kube_config()
-            _config_loaded = True
+def get_current_context_name() -> str:
+    """Get the name of the current kubeconfig context.
+
+    As defined by the kubeconfig file.
+    """
+    context = _Config.get_instance().get_context(None)
+    return context["name"]
+
+
+def validate_context_name(context_name: str) -> None:
+    """Validate that the current kubeconfig context is a valid context.
+
+    If the context is invalid, a ValueError is raised.
+    """
+    _Config.get_instance().get_context(context_name)
+
+
+class _Config:
+    """A thread-safe singleton that holds a snapshot of the kubeconfig file.
+
+    Loaded only once for performance and thread-safety.
+
+    This config can become out of date if the underlying kubeconfig file on disk is
+    modified after it is loaded.
+    """
+
+    _load_lock: threading.Lock = threading.Lock()
+    _instance: _Config | None = None
+
+    def __init__(
+        self,
+        contexts: list[dict[str, Any]] | None,
+        current_context: dict[str, Any] | None,
+    ):
+        self.contexts = contexts
+        self.current_context = current_context
+
+    @classmethod
+    def get_instance(cls) -> _Config:
+        # The kubernetes.config module is not thread-safe.
+        with cls._load_lock:
+            if cls._instance is None:
+                # Must call load_kube_config() before any clients created with the
+                # current context can be used.
+                config.load_kube_config()
+                cls._instance = _Config(*config.list_kube_config_contexts())
+        return cls._instance
+
+    @classmethod
+    def ensure_loaded(cls) -> None:
+        cls.get_instance()
+
+    def get_context(self, context_name: str | None) -> dict[str, Any]:
+        if context_name is None:
+            return self._get_current_context()
+        return self._get_named_context(context_name)
+
+    def _get_current_context(self) -> dict:
+        if self.current_context is None:
+            raise ValueError(
+                "Could not get the current context because the current context is not "
+                "set in the kubeconfig file."
+            )
+        return self.current_context
+
+    def _get_named_context(self, context_name: str) -> dict:
+        if not self.contexts:
+            raise ValueError(
+                f"Could not find a context named '{context_name}' in kubeconfig "
+                "because no contexts were present in the kubeconfig file."
+            )
+        for context in self.contexts:
+            if context["name"] == context_name:
+                return context
+        raise ValueError(
+            f"Could not find a context named '{context_name}' in the kubeconfig file. "
+            f"Available contexts: {self.contexts}."
+        )
+
+
+class _ThreadLocalClientFactory:
+    """Each instance of this class assumes that only one thread may access it."""
+
+    def __init__(self) -> None:
+        self._current_context_client: client.CoreV1Api | None = None
+        self._clients: dict[str, client.CoreV1Api] = {}
+
+    def get_client(self, context_name: str | None) -> client.CoreV1Api:
+        if context_name is None:
+            return self._get_or_create_client_for_current_context()
+        return self._get_or_create_client_for_named_context(context_name)
+
+    def _get_or_create_client_for_current_context(self) -> client.CoreV1Api:
+        if self._current_context_client is None:
+            self._current_context_client = client.CoreV1Api()
+        return self._current_context_client
+
+    def _get_or_create_client_for_named_context(
+        self, context_name: str
+    ) -> client.CoreV1Api:
+        if context_name in self._clients:
+            return self._clients[context_name]
+        api_client = self._create_client_for_named_context(context_name)
+        self._clients[context_name] = api_client
+        return api_client
+
+    def _create_client_for_named_context(self, context_name: str) -> client.CoreV1Api:
+        # Inspired from example
+        # https://github.com/kubernetes-client/python/blob/master/examples/multiple_clusters.py
+        return client.CoreV1Api(
+            api_client=config.new_client_from_config(context=context_name)
+        )

--- a/src/k8s_sandbox/_pod/op.py
+++ b/src/k8s_sandbox/_pod/op.py
@@ -27,6 +27,8 @@ class PodInfo:
 
     name: str
     namespace: str
+    context_name: str | None
+    """The name of the kubeconfig context. If None, use the current context."""
     default_container_name: str
 
 
@@ -46,7 +48,7 @@ class PodOperation(ABC):
     def create_websocket_client_for_exec(
         self, **kwargs
     ) -> Generator[WSClient, None, None]:
-        client = k8s_client()
+        client = k8s_client(self._pod.context_name)
         # Note: ApiException is intentionally not caught; it should fail the eval.
         ws_client = stream(
             client.connect_get_namespaced_pod_exec,

--- a/src/k8s_sandbox/_pod/pod.py
+++ b/src/k8s_sandbox/_pod/pod.py
@@ -15,8 +15,14 @@ T = TypeVar("T")
 
 
 class Pod:
-    def __init__(self, name: str, namespace: str, default_container_name: str) -> None:
-        self.info = PodInfo(name, namespace, default_container_name)
+    def __init__(
+        self,
+        name: str,
+        namespace: str,
+        context_name: str | None,
+        default_container_name: str,
+    ) -> None:
+        self.info = PodInfo(name, namespace, context_name, default_container_name)
 
     async def exec(
         self,

--- a/test/k8s_sandbox/inspect_integration/custom_chart/test_integration.py
+++ b/test/k8s_sandbox/inspect_integration/custom_chart/test_integration.py
@@ -1,10 +1,12 @@
 from pathlib import Path
 
 import pytest
+from inspect_ai import eval
 from inspect_ai.model import Model
 from inspect_ai.util import SandboxEnvironmentSpec
 
 from k8s_sandbox import K8sSandboxEnvironmentConfig
+from k8s_sandbox._kubernetes_api import get_current_context_name
 from test.k8s_sandbox.inspect_integration.testing_utils.mock_model import (
     MockToolCallModel,
 )
@@ -56,3 +58,47 @@ def test_custom_chart_custom_values(model: Model) -> None:
 
     assert result.scores is not None
     assert result.scores["match"].value == "C"
+
+
+def test_specified_kube_config_context() -> None:
+    # We don't have a test to verify that Helm charts can be installed into non-current
+    # contexts as we don't assume that the environment running this test has access to
+    # multiple Kubernetes clusters.
+    current_context = get_current_context_name()
+    model = MockToolCallModel(
+        [tool_call("bash", {"cmd": "cat /etc/os-release | grep VERSION_CODENAME"})],
+    )
+    task = create_task(
+        __file__,
+        target="bookworm",
+        sandbox=SandboxEnvironmentSpec(
+            "k8s",
+            K8sSandboxEnvironmentConfig(context=current_context),
+        ),
+    )
+
+    result = run_and_verify_inspect_eval(task=task, model=model)[0]
+
+    assert result.scores is not None
+    assert result.scores["match"].value == "C"
+
+
+def test_specified_kube_config_context_flows_to_error_message(model: Model) -> None:
+    # Verify that the specified context flows through to the error message.
+    task = create_task(
+        __file__,
+        target="bookworm",
+        sandbox=SandboxEnvironmentSpec(
+            "k8s",
+            K8sSandboxEnvironmentConfig(context="does-not-exist"),
+        ),
+    )
+
+    result = eval(task, model=model)[0]
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert (
+        "Could not find a context named 'does-not-exist' in the kubeconfig file."
+        in result.error.message
+    )

--- a/test/k8s_sandbox/inspect_integration/test_cleanup.py
+++ b/test/k8s_sandbox/inspect_integration/test_cleanup.py
@@ -6,7 +6,7 @@ from inspect_ai import Task
 from inspect_ai.model import Model
 
 from k8s_sandbox._helm import uninstall
-from k8s_sandbox._kubernetes_api import get_current_context_namespace
+from k8s_sandbox._kubernetes_api import get_default_namespace
 from k8s_sandbox._sandbox_environment import K8sSandboxEnvironment
 from test.k8s_sandbox.inspect_integration.testing_utils.mock_model import (
     MockToolCallModel,
@@ -51,7 +51,7 @@ def test_without_cleanup(model: Model, task: Task) -> None:
             run_and_verify_inspect_eval(task=task, model=model, sandbox_cleanup=False)
 
     assert spy.call_count == 0
-    asyncio.run(uninstall(release, get_current_context_namespace(), quiet=False))
+    asyncio.run(uninstall(release, get_default_namespace(None), None, quiet=False))
 
 
 def test_cli_cleanup_all_gets_user_confirmation(model: Model, task: Task) -> None:
@@ -70,4 +70,4 @@ def test_cli_cleanup_all_gets_user_confirmation(model: Model, task: Task) -> Non
 
     assert "Are you sure you want to uninstall ALL" in confirm.call_args.args[0]
     assert spy.call_count == 0
-    asyncio.run(uninstall(release, get_current_context_namespace(), quiet=False))
+    asyncio.run(uninstall(release, get_default_namespace(None), None, quiet=False))

--- a/test/k8s_sandbox/test_config_validation.py
+++ b/test/k8s_sandbox/test_config_validation.py
@@ -27,6 +27,13 @@ async def test_invalid_chart() -> None:
         )
 
 
+async def test_invalid_kubeconfig_context_name() -> None:
+    with pytest.raises(ValueError):
+        await K8sSandboxEnvironment.sample_init(
+            __file__, K8sSandboxEnvironmentConfig(context="invalid-context"), {}
+        )
+
+
 async def test_invalid_config_type() -> None:
     class MyModel(BaseModel, frozen=True):
         pass
@@ -37,7 +44,7 @@ async def test_invalid_config_type() -> None:
 
 def test_can_serialize_and_deserialize_config() -> None:
     original = K8sSandboxEnvironmentConfig(
-        chart="my-chart", values=Path("my-values.yaml")
+        chart="my-chart", values=Path("my-values.yaml"), context="my-context"
     )
 
     as_json = original.model_dump()

--- a/test/k8s_sandbox/test_helm.py
+++ b/test/k8s_sandbox/test_helm.py
@@ -15,7 +15,7 @@ from k8s_sandbox._helm import (
     get_all_release_names,
     uninstall,
 )
-from k8s_sandbox._kubernetes_api import get_current_context_namespace
+from k8s_sandbox._kubernetes_api import get_default_namespace
 
 
 @pytest.fixture
@@ -24,6 +24,7 @@ def uninstallable_release() -> Release:
         __file__,
         chart_path=Path("/non_existent_chart"),
         values_source=ValuesSource.none(),
+        context_name=None,
     )
 
 
@@ -47,7 +48,7 @@ async def test_helm_install_error(
 
 
 async def test_cancelling_install_uninstalls():
-    release = Release(__file__, None, ValuesSource.none())
+    release = Release(__file__, None, ValuesSource.none(), None)
     with patch("k8s_sandbox._helm.uninstall", wraps=uninstall) as spy:
         task = asyncio.create_task(release.install())
         await asyncio.sleep(0.5)
@@ -58,14 +59,14 @@ async def test_cancelling_install_uninstalls():
 
     assert spy.call_count == 1
     assert release.release_name not in await get_all_release_names(
-        get_current_context_namespace()
+        get_default_namespace(context_name=None), None
     )
 
 
 async def test_helm_uninstall_does_not_error_for_release_not_found(
     log_err: LogCaptureFixture,
 ) -> None:
-    release = Release(__file__, None, ValuesSource.none())
+    release = Release(__file__, None, ValuesSource.none(), None)
 
     # Note: we haven't called install() on release.
     await release.uninstall(quiet=False)
@@ -77,7 +78,7 @@ async def test_helm_uninstall_errors_for_other_errors(
     log_err: LogCaptureFixture,
 ) -> None:
     with pytest.raises(RuntimeError) as excinfo:
-        await uninstall("my invalid release name!", "fake-namespace", quiet=False)
+        await uninstall("my invalid release name!", "fake-namespace", None, quiet=False)
 
     assert "Release name is invalid" in log_err.text
     assert "Release name is invalid" in str(excinfo.value)
@@ -118,7 +119,7 @@ async def test_helm_install_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(INSPECT_HELM_TIMEOUT, "1")
 
     with pytest.raises(RuntimeError) as excinfo:
-        await Release(__file__, None, ValuesSource.none()).install()
+        await Release(__file__, None, ValuesSource.none(), None).install()
 
     # Verify that we detect the install timeout and add our own message.
     assert "The configured timeout value was 1s. Please see the docs" in str(

--- a/test/k8s_sandbox/utils.py
+++ b/test/k8s_sandbox/utils.py
@@ -16,7 +16,12 @@ async def install_sandbox_environments(
         else None
     )
     values_source = StaticValuesSource(values_path)
-    release = Release(task_name=task_name, chart_path=None, values_source=values_source)
+    release = Release(
+        task_name=task_name,
+        chart_path=None,
+        values_source=values_source,
+        context_name=None,
+    )
     try:
         await release.install()
         pods = await release.get_sandbox_pods()


### PR DESCRIPTION
As requested by Sami.

This allows users to have a `Sample` target a specific cluster e.g. if a `Sample` requires GPU access and your primary cluster doesn't have suitable nodes. You can therefore be interacting with multiple clusters within the scope of a single eval / inspect process.

See #88

## Concurrency
There are 2 considerations:
1. the Python `kubernetes` library is synchronous, so we use threads to parallelise usage of it
2. the kubeconfig file can change on disk between loading it and the Helm subprocess or kubernetes client using it

I've mitigated 1 by use of locks and thread locals.

For 2, as we're "telling" Helm which context _name_ to use (rather than e.g. passing it the immutable context dict itself), we'd have to take steps like creating a copy of the kubeconfig file on disk and having Helm use that. However, I'm not convinced that the added complexity is worth it - if the user is deleting contexts from their kubeconfig while an eval which references it is running, maybe it is on them?

In other systems, I'd take a more hard line approach and insist that if a race condition can be mitigated, we do so, but I'm not sure where we want to draw the line for this package. Comments/disagreements welcome!