### PR TITLE
Implement `SandboxConnection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `SandboxConnection` support for human agent baselining and connecting to a sandbox for debugging.
 - Add support for specifying a kubeconfig context name in K8sSandboxEnvironmentConfig.
 - Add automatic translation of Docker Compose files to Helm values files.
 - Handle cancellation of evals (either manually or due to an error) such that Helm releases are uninstalled.

--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -207,8 +207,15 @@ class K8sSandboxEnvironment(SandboxEnvironment):
         return SandboxConnection(
             type="k8s",
             command=shlex.join(kubectl_cmd),
-            # TODO: Can we use `remote-containers.attachToK8sContainer`?
-            vscode_command=None,
+            # Note that there is no facility to specify the kubeconfig context or the
+            # default container name.
+            vscode_command=[
+                "remote-containers.attachToK8sContainer",
+                {
+                    "name": pod.name,
+                    "namespace": pod.namespace,
+                },
+            ],
             container=pod.default_container_name,
         )
 

--- a/test/k8s_sandbox/test_sandbox.py
+++ b/test/k8s_sandbox/test_sandbox.py
@@ -744,6 +744,10 @@ async def test_can_get_sandbox_connection(sandbox: K8sSandboxEnvironment) -> Non
     assert re.match(
         r"^^kubectl exec -it \S+ -n \S+ -c \S+ -- bash -l$", result.command
     ), result
+    assert result.vscode_command is not None
+    assert result.vscode_command[0] == "remote-containers.attachToK8sContainer"
+    assert "name" in result.vscode_command[1]
+    assert "namespace" in result.vscode_command[1]
 
 
 async def test_can_get_sandbox_connection_with_specified_context() -> None:
@@ -762,3 +766,4 @@ async def test_can_get_sandbox_connection_with_specified_context() -> None:
         r"^^kubectl exec -it \S+ -n \S+ -c \S+ --context \S+ -- bash -l$",
         result.command,
     ), result
+    # The attachToK8sContainer command does not support passing in a context name.

--- a/test/k8s_sandbox/utils.py
+++ b/test/k8s_sandbox/utils.py
@@ -8,7 +8,7 @@ from k8s_sandbox._sandbox_environment import K8sSandboxEnvironment
 
 @asynccontextmanager
 async def install_sandbox_environments(
-    task_name: str, values_filename: str | None
+    task_name: str, values_filename: str | None, context_name: str | None = None
 ) -> AsyncGenerator[dict[str, K8sSandboxEnvironment], None]:
     values_path = (
         Path(__file__).parent / "resources" / values_filename
@@ -20,7 +20,7 @@ async def install_sandbox_environments(
         task_name=task_name,
         chart_path=None,
         values_source=values_source,
-        context_name=None,
+        context_name=context_name,
     )
     try:
         await release.install()


### PR DESCRIPTION
This is useful for human agent baselining or for providing users with a command to copy/paste to get a shell into the container.

This is not aimed at preventing METR implementing a method for doing this over SSH (as their human baseliners won't have cluster credentials) - it is simply aimed at ensuring the default method of creating a `SandboxConnection` is the vanilla `kubectl` option. We can definitely add alternative methods in future!

It is a bit janky as an error pops up despite command working - this may just be related to how we're using VS Code at AISI though (via SSH to EC2 instances).

Using Terminal:

https://github.com/user-attachments/assets/e9a2ff0c-1cca-47d1-95ee-f9e209b7821b





Using Window:
Sadly there's no way to specify the container name to connect to, or the kubeconfig context when using `remote-containers.attachToK8sContainer`. No docs or easy to access source code for this easy AFAICT.


https://github.com/user-attachments/assets/67c7a650-c14c-4e71-a57f-1590f284e8af


