### PR TITLE
Support `user` parameter on `SandboxEnvironment.exec()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- Support `user` parameter in `exec()` method (only when container is running as root and `runuser` is installed).
-- Support optional `user` parameter on `K8sSandboxEnvironment.connection()` (`SandboxConnection`).
+- Support `user` parameter on `K8sSandboxEnvironment.exec()` (only when container is running as root and `runuser` is installed).
+- Support `user` parameter on `K8sSandboxEnvironment.connection()` (returns `SandboxConnection`).
 - Add `SandboxConnection` support for human agent baselining and connecting to a sandbox for debugging.
 - Add support for specifying a kubeconfig context name in K8sSandboxEnvironmentConfig.
 - Add automatic translation of Docker Compose files to Helm values files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Support `user` parameter in `exec()` method (only when container is running as root and `runuser` is installed).
 - Add `SandboxConnection` support for human agent baselining and connecting to a sandbox for debugging.
 - Add support for specifying a kubeconfig context name in K8sSandboxEnvironmentConfig.
 - Add automatic translation of Docker Compose files to Helm values files.

--- a/docs/docs/design/limitations.md
+++ b/docs/docs/design/limitations.md
@@ -167,11 +167,28 @@ The `k8s_sandbox` package will not retry the remote command execution when any o
 and that the command did not at least start executing. This will result in that sample
 of the eval failing.
 
-## The `user` parameter to `exec()` is not supported
+## Must run as root to use the `user` parameter in `exec()` { #exec-user }
 
-In Kubernetes, a container runs as a single user. If you need to run commands as
-different users, you may have to run the container as root and use a tool like `runuser`
-to run commands as different users.
+In Kubernetes, a container runs as a single user. The user can be specified in the
+`values.yaml` file. For example, if using the [built-in Helm
+chart](../helm//built-in-chart.md):
+
+```yaml
+services:
+  my-service:
+    image: alpine
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+```
+
+Therefore, executing commands as a different user to the one which the container was
+started with is **not recommended**. Generally, specifying users in tool definitions can
+result in undesirable coupling between your tools and sandbox.
+
+That said, if you need to run commands as different users, the `user` parameter to
+`exec()` is supported. However, you must run the container as root and ensure that
+`runuser` is installed in the container.
 
 ## Images are not automatically built, tagged or pushed
 

--- a/docs/docs/getting-started/prerequisites.md
+++ b/docs/docs/getting-started/prerequisites.md
@@ -29,6 +29,7 @@ containers which you'd like `K8sSandboxEnvironment` to directly interact with (i
 * `mkdir`
 * `timeout`
 * `base64`
+* `runuser`
 
 ## Cluster requirements
 

--- a/src/k8s_sandbox/_pod/error.py
+++ b/src/k8s_sandbox/_pod/error.py
@@ -5,7 +5,7 @@ from k8s_sandbox._logger import format_log_message
 
 class PodError(Exception):
     """
-    A generic error raised when interacting with a pod.
+    A generic error raised when interacting with a Pod.
 
     This will typically cause the eval to fail.
     """
@@ -15,6 +15,16 @@ class PodError(Exception):
 
 
 class GetReturncodeError(Exception):
-    """The return code of a pod operation could not be retrieved."""
+    """The return code of a Pod operation could not be retrieved."""
+
+    pass
+
+
+class ExecutableNotFoundError(Exception):
+    """The executable could not be found in the container.
+
+    This is **not** raised as a result of user-supplied commands not being found. It is
+    typically raised when /bin/sh or runuser cannot be found in the container.
+    """
 
     pass

--- a/src/k8s_sandbox/_pod/get_returncode.py
+++ b/src/k8s_sandbox/_pod/get_returncode.py
@@ -1,7 +1,7 @@
 import yaml
 from kubernetes.stream.ws_client import ERROR_CHANNEL, WSClient  # type: ignore
 
-from k8s_sandbox._pod.error import GetReturncodeError
+from k8s_sandbox._pod.error import ExecutableNotFoundError, GetReturncodeError
 
 
 def get_returncode(ws_client: WSClient) -> int:
@@ -29,6 +29,8 @@ def get_returncode(ws_client: WSClient) -> int:
     for cause in loaded["details"]["causes"]:
         if cause.get("reason") == "ExitCode":
             return int(cause["message"])
+    if "error finding executable" in loaded["message"]:
+        raise ExecutableNotFoundError(loaded["message"])
     raise GetReturncodeError(
         "Failed to get returncode from k8s error channel because `status`!='Success' "
         "and there was no entry in `details.causes` with `reason`=='ExitCode'. "

--- a/src/k8s_sandbox/_pod/pod.py
+++ b/src/k8s_sandbox/_pod/pod.py
@@ -30,6 +30,7 @@ class Pod:
         stdin: str | bytes | None,
         cwd: str | None,
         env: dict[str, str],
+        user: str | None,
         timeout: int | None,
     ) -> ExecResult[str]:
         """
@@ -68,6 +69,9 @@ class Pod:
             directory does not exist, an unsuccessful ExecResult will be returned and
             cmd will not be run.
           env (dict[str, str]): The environment variables to set before running cmd.
+          user (str | None): The user to run the command as. If None, the default user
+            for the pod will be used. The container must be running as root to run as a
+            different user and the runuser command must be available in the container.
           timeout (int | None): The optional timeout for cmd to complete in. Defaults to
             no timeout. If provided, SIGTERM will be sent to cmd once the timeout has
             elapsed. This is enforced by the `timeout` command on the pod. This will not
@@ -75,7 +79,7 @@ class Pod:
         """
         executor = ExecuteOperation(self.info)
         result = await self._run_async(
-            lambda: executor.exec(cmd, stdin, cwd, env, timeout)
+            lambda: executor.exec(cmd, stdin, cwd, env, user, timeout)
         )
         return result
 

--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -132,10 +132,6 @@ class K8sSandboxEnvironment(SandboxEnvironment):
         # (they should only use it if potential unreliablity exists in their runtime)."
         timeout_retry: bool = True,
     ) -> ExecResult[str]:
-        if user is not None:
-            raise NotImplementedError(
-                "The user parameter for exec() is not yet supported."
-            )
         log_kwargs = dict(cmd=cmd, stdin=input, cwd=cwd, env=env, timeout=timeout)
         # Do not log these at error level or re-raise as enriched K8sError.
         expected_exceptions = (
@@ -146,7 +142,7 @@ class K8sSandboxEnvironment(SandboxEnvironment):
         )
         op = "K8s execute command in Pod"
         with self._log_op(op, expected_exceptions, **log_kwargs):
-            result = await self._pod.exec(cmd, input, cwd, env, timeout)
+            result = await self._pod.exec(cmd, input, cwd, env, user, timeout)
             log_trace(f"Completed: {op}.", **(log_kwargs | {"result": result}))
             return result
 

--- a/test/k8s_sandbox/test_inspect_self_check.py
+++ b/test/k8s_sandbox/test_inspect_self_check.py
@@ -28,8 +28,8 @@ async def non_root(
 
 async def test_self_check_k8s_default_root(root: SandboxEnvironment) -> None:
     known_failures = [
-        # The user parameter is not supported in K8sSandboxEnvironment.
-        "test_exec_as_user",
+        # Running as a nonexistent user results in an exception being raised (by design)
+        # whereas the test expects an ExecResult to be returned without an exception.
         "test_exec_as_nonexistent_user",
         # Root can read from files after `chmod -r`.
         "test_read_file_not_allowed",
@@ -43,9 +43,11 @@ async def test_self_check_k8s_default_root(root: SandboxEnvironment) -> None:
 
 async def test_self_check_k8s_non_root(non_root: SandboxEnvironment) -> None:
     known_failures = [
-        # The user parameter is not supported in K8sSandboxEnvironment.
-        "test_exec_as_user",
+        # Running as a nonexistent user results in an exception being raised (by design)
+        # whereas the test expects an ExecResult to be returned without an exception.
         "test_exec_as_nonexistent_user",
+        # In K8s, the container must be running as root to exec as a different user.
+        "test_exec_as_user",
     ]
 
     return await _run_self_check(non_root, known_failures)

--- a/test/k8s_sandbox/test_sandbox.py
+++ b/test/k8s_sandbox/test_sandbox.py
@@ -228,6 +228,71 @@ async def test_exec_env_requiring_quotes(sandbox: K8sSandboxEnvironment) -> None
     assert result.stdout.strip() == "b'\"a r"
 
 
+@pytest.mark.parametrize(
+    "cmd",
+    [["whoami"], ["bash", "-c", "echo $USER"], ["bash", "-c", "whoami"]],
+)
+async def test_exec_user(sandbox: K8sSandboxEnvironment, cmd: list[str]) -> None:
+    # The nobody user is available in the default python:3.12-bookworm image.
+    result = await sandbox.exec(cmd, user="nobody")
+
+    assert result.success
+    assert result.stdout.strip() == "nobody"
+
+
+async def test_exec_user_when_specified_user_does_not_exist(
+    sandbox: K8sSandboxEnvironment,
+) -> None:
+    with pytest.raises(K8sError) as excinfo:
+        await sandbox.exec(["whoami"], user="foo")
+
+    error_msg = str(excinfo.value.__cause__)
+    assert (
+        "The user parameter 'foo' provided to exec() does not appear to exist in the "
+        "container" in error_msg
+    )
+    assert "https://k8s-sandbox.aisi.org.uk/design/limitations#exec-user" in error_msg
+
+
+async def test_exec_user_when_not_running_as_root(
+    sandbox_non_root: K8sSandboxEnvironment,
+) -> None:
+    with pytest.raises(K8sError) as excinfo:
+        await sandbox_non_root.exec(["whoami"], user="nobody")
+
+    error_msg = str(excinfo.value.__cause__)
+    assert (
+        "When a user parameter ('nobody') is provided to exec(), the container must be "
+        "running as root" in error_msg
+    )
+    assert "https://k8s-sandbox.aisi.org.uk/design/limitations#exec-user" in error_msg
+
+
+async def test_exec_user_when_runuser_not_installed(
+    sandbox_busybox: K8sSandboxEnvironment,
+) -> None:
+    with pytest.raises(K8sError) as excinfo:
+        await sandbox_busybox.exec(["whoami"], user="foo")
+
+    error_msg = str(excinfo.value.__cause__)
+    assert (
+        "When a user parameter ('foo') is provided to exec(), the runuser binary "
+        "must be installed in the container"
+    ) in error_msg
+    assert "https://k8s-sandbox.aisi.org.uk/design/limitations#exec-user" in error_msg
+
+
+async def test_exec_does_not_raise_error_if_command_happens_to_use_runuser(
+    sandbox: K8sSandboxEnvironment,
+) -> None:
+    # If an LLM happens to generate a command that uses `runuser`, we don't want to
+    # raise an error.
+    result = await sandbox.exec(["bash", "-c", "runuser -u foo -- whoami"])
+
+    assert not result.success
+    assert "runuser: user foo does not exist" in result.stderr
+
+
 @pytest.mark.parametrize("cmd", [["bash", "-c", "sleep 10"], ["sleep", "10"]])
 async def test_exec_timeout(
     sandbox: K8sSandboxEnvironment, cmd: list[str], log_err: LogCaptureFixture


### PR DESCRIPTION
Use `runuser` to be able to `exec` commands as different users.

If any of the following occur, an error is raised which will cause the eval to fail (not just a failed ExecResult). The error message will include a link to the relevant docs.
- container not running as root
- container doesn't have `runuser`
- specified user doesn't exist

This is intentional as it is most likely a programming error/bug, not an LLM feeding in something silly.

See comment below on Inspect/Platform Infra discussion on this.