### PR TITLE
Support `user` parameter on `SandboxEnvironment.connection()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Support optional `user` parameter on `K8sSandboxEnvironment.connection()` (`SandboxConnection`).
 - Add `SandboxConnection` support for human agent baselining and connecting to a sandbox for debugging.
 - Add support for specifying a kubeconfig context name in K8sSandboxEnvironmentConfig.
 - Add automatic translation of Docker Compose files to Helm values files.

--- a/test/k8s_sandbox/test_sandbox.py
+++ b/test/k8s_sandbox/test_sandbox.py
@@ -742,8 +742,8 @@ async def test_can_get_sandbox_connection(sandbox: K8sSandboxEnvironment) -> Non
 
     # kubectl exec -it agent-env-dwg883nv-default-0 -n default -c default -- bash -l
     assert re.match(
-        r"^^kubectl exec -it \S+ -n \S+ -c \S+ -- bash -l$", result.command
-    ), result
+        r"^kubectl exec -it \S+ -n \S+ -c \S+ -- bash -l$", result.command
+    ), result.command
     assert result.vscode_command is not None
     assert result.vscode_command[0] == "remote-containers.attachToK8sContainer"
     assert "name" in result.vscode_command[1]
@@ -763,7 +763,23 @@ async def test_can_get_sandbox_connection_with_specified_context() -> None:
     # kubectl exec -it agent-env-dwg883nv-default-0 -n default -c default
     # --context minikube -- bash -l
     assert re.match(
-        r"^^kubectl exec -it \S+ -n \S+ -c \S+ --context \S+ -- bash -l$",
+        r"^kubectl exec -it \S+ -n \S+ -c \S+ --context \S+ -- bash -l$",
         result.command,
-    ), result
-    # The attachToK8sContainer command does not support passing in a context name.
+    ), result.command
+    # The attachToK8sContainer command does not support passing in a context name, so
+    # we don't return any VS Code command.
+    assert result.vscode_command is None
+
+
+async def test_can_get_sandbox_connection_with_specified_user(
+    sandbox: K8sSandboxEnvironment,
+) -> None:
+    result = await sandbox.connection(user="agent")
+
+    assert re.match(
+        r"^kubectl exec -it \S+ -n \S+ -c default -- su -s /bin/bash -l agent$",
+        result.command,
+    ), result.command
+    # The attachToK8sContainer command does not support passing in a user name, so
+    # we don't return any VS Code command.
+    assert result.vscode_command is None


### PR DESCRIPTION
Not to be confused with similar #94 

`SandboxEnvironment.connection()` returns commands which the user can use to connect to a sandbox. Inspect PR https://github.com/UKGovernmentBEIS/inspect_ai/pull/1658 now adds an optional user parameter to this method.