### PR TITLE
Export `is_docker_compose_file()` and `convert_compose_to_helm_values()`

### DIFF
--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -14,7 +14,6 @@ from inspect_ai.util import (
 )
 from pydantic import BaseModel
 
-from k8s_sandbox._compose.compose import ComposeValuesSource, is_docker_compose_file
 from k8s_sandbox._helm import (
     Release,
     StaticValuesSource,
@@ -34,6 +33,7 @@ from k8s_sandbox._manager import (
 )
 from k8s_sandbox._pod import Pod
 from k8s_sandbox._prereqs import validate_prereqs
+from k8s_sandbox.compose._compose import ComposeValuesSource, is_docker_compose_file
 
 
 @sandboxenv(name="k8s")

--- a/src/k8s_sandbox/compose/__init__.py
+++ b/src/k8s_sandbox/compose/__init__.py
@@ -1,0 +1,9 @@
+"""Limited Docker Compose support for the k8s_sandbox package."""
+
+from k8s_sandbox.compose._compose import is_docker_compose_file
+from k8s_sandbox.compose._converter import convert_compose_to_helm_values
+
+__all__ = [
+    "is_docker_compose_file",
+    "convert_compose_to_helm_values",
+]

--- a/src/k8s_sandbox/compose/_compose.py
+++ b/src/k8s_sandbox/compose/_compose.py
@@ -5,8 +5,8 @@ from typing import Generator
 
 import yaml
 
-from k8s_sandbox._compose.converter import convert_compose_to_helm_values
 from k8s_sandbox._helm import ValuesSource
+from k8s_sandbox.compose._converter import convert_compose_to_helm_values
 
 
 class ComposeValuesSource(ValuesSource):
@@ -25,6 +25,13 @@ class ComposeValuesSource(ValuesSource):
 
 
 def is_docker_compose_file(file: Path) -> bool:
-    """Infers whether a file is a Docker Compose file."""
-    # Also true for `docker-compose.yaml`.
+    """Infers whether a file is a Docker Compose file based on the filename.
+
+    This errs on the side of false negatives to avoid automatic conversion of files
+    which may not be Docker Compose files.
+
+    Returns:
+        True if the file name _ends_ in `compose.yaml` or `compose.yml`, False
+        otherwise.
+    """
     return file.name.endswith("compose.yaml") or file.name.endswith("compose.yml")

--- a/src/k8s_sandbox/compose/_converter.py
+++ b/src/k8s_sandbox/compose/_converter.py
@@ -37,7 +37,7 @@ def convert_compose_to_helm_values(compose_file: Path) -> dict[str, Any]:
     install.
 
     Returns:
-        A dictionary representing the Helm values.
+        A dictionary representing the generated Helm values.
     """
     compose = yaml.safe_load(compose_file.read_text())
     _validate_compose(compose, compose_file)
@@ -78,7 +78,7 @@ def _validate_compose(compose: dict[str, Any], compose_file: Path) -> None:
 def _convert_services(src: dict[str, Any], compose_file: Path) -> dict[str, Any]:
     result: dict[str, Any] = dict()
     for service_name, service_value in src.items():
-        service_converter = ServiceConverter(service_name, service_value, compose_file)
+        service_converter = _ServiceConverter(service_name, service_value, compose_file)
         result[service_name] = service_converter.convert()
     return result
 
@@ -114,7 +114,7 @@ def _convert_extensions(
     return result
 
 
-class ServiceConverter:
+class _ServiceConverter:
     """
     Converts a Docker Compose service to a service for the built-in Helm chart.
 

--- a/test/k8s_sandbox/compose/test_converter.py
+++ b/test/k8s_sandbox/compose/test_converter.py
@@ -4,7 +4,7 @@ from typing import Callable
 import pytest
 import yaml
 
-from k8s_sandbox._compose.converter import (
+from k8s_sandbox.compose._converter import (
     ComposeConverterError,
     convert_compose_to_helm_values,
 )


### PR DESCRIPTION
Sami at METR suggested we make these public as they're using them as part of their custom method of running Inspect evals. See the Slack thread for context: https://inspectcommunity.slack.com/archives/C080ET25C81/p1745475063114929?thread_ts=1744660848.641359&cid=C080ET25C81

Their rough implementation (copied from Slack) is:

```py
if k8s_sandbox._compose.compose.is_docker_compose_file(config_path):
    sandbox_config = (
        k8s_sandbox._compose.converter.convert_compose_to_helm_values(
            config_path
        )
    )
else:
    with config_path.open("r") as f:
        sandbox_config = cast(dict[str, Any], yaml.load(f))  # 

# add our custom logic to sandbox_config, write it back to a file, and update the Task to reference the new file
```

As mentioned elsewhere in the Slack discussion, we were considering adding a callback to `K8sSandboxEnvironmentConfig` to allow eval authors to transform the generated `helm-values.yaml` (e.g. for converting GPU requirements into specific node selectors). This would have involved making part of this compose interface public anyway.

Whilst my initial thought was to just require than `helm-values.yaml` files are written for non-simple evals (e.g. ones which require specifying GPUs), METR are hoping to make use of the many open-source evals which only have `compose.yaml` files, without needing to "fork" them and maintain a separate `helm-values.yaml` file which is why this functionality is particularly useful to them and is different from UK AISI's general usage pattern.

I've followed the [guidelines on package structure and visibility](https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/blob/main/CONTRIBUTING.md#package-structure-and-api-visibility):
- the `k8s.sandbox.compose` sub-package is no longer prefixed with an underscore
- the `k8s_sandbox.compose._compose` module is now prefixed with an underscore
- the members which are to be exported are exported in `__init__.py`

See [rationale](https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/blob/c2a97d02e4d079bbec26dda7a2831e0f464995e0/src/k8s_sandbox/_compose/converter.py#L33) on why `convert_compose_to_helm_values` just returns a `dict[str, Any]` rather than a Pydantic model.