### PR TITLE
Default user

### DIFF
--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -14,7 +14,6 @@ from inspect_ai.util import (
 )
 from pydantic import BaseModel
 
-from k8s_sandbox._sandbox_environment import K8sSandboxEnvironmentConfig
 from k8s_sandbox._helm import (
     Release,
     StaticValuesSource,
@@ -35,6 +34,18 @@ from k8s_sandbox._manager import (
 from k8s_sandbox._pod import Pod
 from k8s_sandbox._prereqs import validate_prereqs
 from k8s_sandbox.compose._compose import ComposeValuesSource, is_docker_compose_file
+
+
+class K8sSandboxEnvironmentConfig(BaseModel, frozen=True):
+  """A config Pydantic model for the K8s sandbox environment."""
+
+  # In future, charts from Helm repositories may be supported, hence str over Path.
+  chart: str | None = None
+  values: Path | None = None
+  context: str | None = None
+  """The kubeconfig context name (e.g. if you have multiple clusters)."""
+  default_user: str | None = None
+  """The default user to run commands as in the container."""
 
 
 @sandboxenv(name="k8s")
@@ -269,18 +280,6 @@ class K8sSandboxEnvironment(SandboxEnvironment):
                 "namespace": self._pod.info.namespace,
             },
         ]
-
-
-class K8sSandboxEnvironmentConfig(BaseModel, frozen=True):
-    """A config Pydantic model for the K8s sandbox environment."""
-
-    # In future, charts from Helm repositories may be supported, hence str over Path.
-    chart: str | None = None
-    values: Path | None = None
-    context: str | None = None
-    """The kubeconfig context name (e.g. if you have multiple clusters)."""
-    default_user: str | None = None
-    """The default user to run commands as in the container."""
 
 
 class K8sError(Exception):

--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -37,22 +37,27 @@ from k8s_sandbox.compose._compose import ComposeValuesSource, is_docker_compose_
 
 
 class K8sSandboxEnvironmentConfig(BaseModel, frozen=True):
-  """A config Pydantic model for the K8s sandbox environment."""
+    """A config Pydantic model for the K8s sandbox environment."""
 
-  # In future, charts from Helm repositories may be supported, hence str over Path.
-  chart: str | None = None
-  values: Path | None = None
-  context: str | None = None
-  """The kubeconfig context name (e.g. if you have multiple clusters)."""
-  default_user: str | None = None
-  """The default user to run commands as in the container."""
+    # In future, charts from Helm repositories may be supported, hence str over Path.
+    chart: str | None = None
+    values: Path | None = None
+    context: str | None = None
+    """The kubeconfig context name (e.g. if you have multiple clusters)."""
+    default_user: str | None = None
+    """The default user to run commands as in the container."""
 
 
 @sandboxenv(name="k8s")
 class K8sSandboxEnvironment(SandboxEnvironment):
     """An Inspect sandbox environment for a Kubernetes (k8s) cluster."""
 
-    def __init__(self, release: Release, pod: Pod, config: K8sSandboxEnvironmentConfig | None = None):
+    def __init__(
+        self,
+        release: Release,
+        pod: Pod,
+        config: K8sSandboxEnvironmentConfig | None = None,
+    ):
         self.release = release
         self._pod = pod
         self._config = config
@@ -153,7 +158,11 @@ class K8sSandboxEnvironment(SandboxEnvironment):
             PermissionError,
             OutputLimitExceededError,
         )
-        if user is None and self._config is not None and self._config.default_user is not None:
+        if (
+            user is None
+            and self._config is not None
+            and self._config.default_user is not None
+        ):
             user = self._config.default_user
         op = "K8s execute command in Pod"
         with self._log_op(op, expected_exceptions, **log_kwargs):
@@ -201,8 +210,12 @@ class K8sSandboxEnvironment(SandboxEnvironment):
                 )
 
     async def connection(self, *, user: str | None = None) -> SandboxConnection:
-        if user is None and self._config is not None and self._config.default_user is not None:
-          user = self._config.default_user
+        if (
+            user is None
+            and self._config is not None
+            and self._config.default_user is not None
+        ):
+            user = self._config.default_user
         return SandboxConnection(
             type="k8s",
             command=self._get_kubectl_connection_command(user),

--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -49,10 +49,10 @@ class K8sSandboxEnvironmentConfig(BaseModel, frozen=True):
 
 
 class _K8sSandboxConfig(BaseModel, frozen=True):
-  chart: Path | None
-  values: Path | None
-  context: str | None
-  default_user: str | None
+    chart: Path | None
+    values: Path | None
+    context: str | None
+    default_user: str | None
 
 
 @sandboxenv(name="k8s")
@@ -107,7 +107,9 @@ class K8sSandboxEnvironment(SandboxEnvironment):
         config: SandboxEnvironmentConfigType | None,
         metadata: dict[str, str],
     ) -> dict[str, SandboxEnvironment]:
-        async def get_sandboxes(release: Release, config: _K8sSandboxConfig) -> dict[str, SandboxEnvironment]:
+        async def get_sandboxes(
+            release: Release, config: _K8sSandboxConfig
+        ) -> dict[str, SandboxEnvironment]:
             pods = await release.get_sandbox_pods()
             sandbox_envs: dict[str, SandboxEnvironment] = {}
             for key, pod in pods.items():
@@ -166,7 +168,7 @@ class K8sSandboxEnvironment(SandboxEnvironment):
             PermissionError,
             OutputLimitExceededError,
         )
-        if (user is None):
+        if user is None:
             user = self._config.default_user
         op = "K8s execute command in Pod"
         with self._log_op(op, expected_exceptions, **log_kwargs):
@@ -214,7 +216,7 @@ class K8sSandboxEnvironment(SandboxEnvironment):
                 )
 
     async def connection(self, *, user: str | None = None) -> SandboxConnection:
-        if (user is None):
+        if user is None:
             user = self._config.default_user
         return SandboxConnection(
             type="k8s",
@@ -305,13 +307,9 @@ class K8sError(Exception):
         super().__init__(format_log_message(message, **kwargs))
 
 
-def _create_release(
-    task_name: str, config: _K8sSandboxConfig
-) -> Release:
+def _create_release(task_name: str, config: _K8sSandboxConfig) -> Release:
     values_source = _create_values_source(config)
-    return Release(
-        task_name, config.chart, values_source, config.context
-    )
+    return Release(task_name, config.chart, values_source, config.context)
 
 
 def _create_values_source(config: _K8sSandboxConfig) -> ValuesSource:
@@ -349,7 +347,9 @@ def _resolve_k8s_sandbox_config(
             validate_context_name(context)
 
     if config is None:
-        return _K8sSandboxConfig(chart=None, values=None, context=None, default_user=None)
+        return _K8sSandboxConfig(
+            chart=None, values=None, context=None, default_user=None
+        )
     if isinstance(config, K8sSandboxEnvironmentConfig):
         chart = Path(config.chart).resolve() if config.chart else None
         validate_chart_dir(chart)
@@ -357,11 +357,18 @@ def _resolve_k8s_sandbox_config(
         validate_values_file(values)
         validate_context(config.context)
         default_user = config.default_user
-        return _K8sSandboxConfig(chart=chart, values=values, context=config.context, default_user=default_user)
+        return _K8sSandboxConfig(
+            chart=chart,
+            values=values,
+            context=config.context,
+            default_user=default_user,
+        )
     if isinstance(config, str):
         values = Path(config).resolve()
         validate_values_file(values)
-        return _K8sSandboxConfig(chart=None, values=values, context=None, default_user=None)
+        return _K8sSandboxConfig(
+            chart=None, values=values, context=None, default_user=None
+        )
     raise TypeError(
         f"Invalid 'SandboxEnvironmentConfigType | None' type: {type(config)}."
     )

--- a/test/k8s_sandbox/resources/values.yaml
+++ b/test/k8s_sandbox/resources/values.yaml
@@ -33,3 +33,14 @@ services:
       requests:
         memory: "128Mi"
         cpu: "100m"
+  ubuntu-with-default-user:
+    image: "ubuntu:24.04"
+    command: ["tail", "-f", "/dev/null"]
+    workingDir: "/home/ubuntu"
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "100m"
+      requests:
+        memory: "128Mi"
+        cpu: "100m"

--- a/test/k8s_sandbox/test_sandbox.py
+++ b/test/k8s_sandbox/test_sandbox.py
@@ -21,7 +21,9 @@ pytestmark = pytest.mark.req_k8s
 
 @pytest_asyncio.fixture(scope="module")
 async def sandboxes() -> AsyncGenerator[dict[str, K8sSandboxEnvironment], None]:
-    async with install_sandbox_environments(__file__, "values.yaml", default_users={"ubuntu-with-default-user": "ubuntu"}) as envs:
+    async with install_sandbox_environments(
+        __file__, "values.yaml", default_users={"ubuntu-with-default-user": "ubuntu"}
+    ) as envs:
         yield envs
 
 
@@ -52,9 +54,9 @@ async def sandbox_busybox(
 
 @pytest_asyncio.fixture(scope="module")
 async def sandbox_with_default_user(
-  sandboxes: dict[str, K8sSandboxEnvironment],
+    sandboxes: dict[str, K8sSandboxEnvironment],
 ) -> K8sSandboxEnvironment:
-  return sandboxes["ubuntu-with-default-user"]
+    return sandboxes["ubuntu-with-default-user"]
 
 
 @pytest.fixture
@@ -530,19 +532,19 @@ async def test_api_timeout_is_not_triggered_by_long_running_commands(
 
 
 async def test_exec_with_default_user(
-  sandbox_with_default_user: K8sSandboxEnvironment,
+    sandbox_with_default_user: K8sSandboxEnvironment,
 ) -> None:
-  result = await sandbox_with_default_user.exec(["whoami"])
-  assert result.success
-  assert result.stdout == "ubuntu\n"
+    result = await sandbox_with_default_user.exec(["whoami"])
+    assert result.success
+    assert result.stdout == "ubuntu\n"
 
 
 async def test_exec_with_default_user_can_use_root(
-  sandbox_with_default_user: K8sSandboxEnvironment,
+    sandbox_with_default_user: K8sSandboxEnvironment,
 ) -> None:
-  result = await sandbox_with_default_user.exec(["whoami"], user="root")
-  assert result.success
-  assert result.stdout == "root\n"
+    result = await sandbox_with_default_user.exec(["whoami"], user="root")
+    assert result.success
+    assert result.stdout == "root\n"
 
 
 ### #write_file() ###
@@ -874,14 +876,15 @@ async def test_can_get_sandbox_connection_with_specified_user(
 
 
 async def test_can_get_sandbox_connection_with_default_user(
-  sandbox_with_default_user: K8sSandboxEnvironment,
+    sandbox_with_default_user: K8sSandboxEnvironment,
 ) -> None:
-  result = await sandbox_with_default_user.connection()
+    result = await sandbox_with_default_user.connection()
 
-  assert re.match(
-    r"^kubectl exec -it \S+ -n \S+ -c ubuntu-with-default-user -- su -s /bin/bash -l ubuntu$",
-    result.command,
-  ), result.command
-  # The attachToK8sContainer command does not support passing in a user name, so
-  # we don't return any VS Code command.
-  assert result.vscode_command is None
+    assert re.match(
+        r"^kubectl exec -it \S+ -n \S+ -c ubuntu-with-default-user -- "
+        r"su -s /bin/bash -l ubuntu$",
+        result.command,
+    ), result.command
+    # The attachToK8sContainer command does not support passing in a user name, so
+    # we don't return any VS Code command.
+    assert result.vscode_command is None

--- a/test/k8s_sandbox/test_sandbox.py
+++ b/test/k8s_sandbox/test_sandbox.py
@@ -12,7 +12,11 @@ from kubernetes.stream.ws_client import ApiException, WSClient  # type: ignore
 from pytest import LogCaptureFixture
 
 from k8s_sandbox._kubernetes_api import get_current_context_name
-from k8s_sandbox._sandbox_environment import K8sError, K8sSandboxEnvironment
+from k8s_sandbox._sandbox_environment import (
+    K8sError,
+    K8sSandboxEnvironment,
+    K8sSandboxEnvironmentConfig,
+)
 from test.k8s_sandbox.utils import install_sandbox_environments
 
 # Mark all tests in this module as requiring a Kubernetes cluster.
@@ -22,7 +26,13 @@ pytestmark = pytest.mark.req_k8s
 @pytest_asyncio.fixture(scope="module")
 async def sandboxes() -> AsyncGenerator[dict[str, K8sSandboxEnvironment], None]:
     async with install_sandbox_environments(
-        __file__, "values.yaml", default_users={"ubuntu-with-default-user": "ubuntu"}
+        __file__,
+        "values.yaml",
+        configs={
+            "ubuntu-with-default-user": K8sSandboxEnvironmentConfig(
+                default_user="ubuntu"
+            )
+        },
     ) as envs:
         yield envs
 

--- a/test/k8s_sandbox/utils.py
+++ b/test/k8s_sandbox/utils.py
@@ -2,13 +2,14 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator
 
+import k8s_sandbox
 from k8s_sandbox._helm import Release, StaticValuesSource
-from k8s_sandbox._sandbox_environment import K8sSandboxEnvironment
+from k8s_sandbox._sandbox_environment import K8sSandboxEnvironment, K8sSandboxEnvironmentConfig
 
 
 @asynccontextmanager
 async def install_sandbox_environments(
-    task_name: str, values_filename: str | None, context_name: str | None = None
+    task_name: str, values_filename: str | None, context_name: str | None = None, default_users: dict[str, str] | None = None,
 ) -> AsyncGenerator[dict[str, K8sSandboxEnvironment], None]:
     values_path = (
         Path(__file__).parent / "resources" / values_filename
@@ -25,10 +26,16 @@ async def install_sandbox_environments(
     try:
         await release.install()
         pods = await release.get_sandbox_pods()
-        sandbox_envs = {
-            pod_name: K8sSandboxEnvironment(release, pod)
-            for pod_name, pod in pods.items()
-        }
+        sandbox_envs: dict[str, K8sSandboxEnvironment] = {}
+        for pod_name, pod in pods.items():
+          default_user = default_users.get(pod_name) if default_users else None
+          sandbox_envs[pod_name] = K8sSandboxEnvironment(
+            release,
+            pod,
+            config=K8sSandboxEnvironmentConfig(
+              default_user=default_user,
+            ),
+          )
         yield sandbox_envs
     finally:
         await release.uninstall(quiet=True)

--- a/test/k8s_sandbox/utils.py
+++ b/test/k8s_sandbox/utils.py
@@ -2,14 +2,19 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator
 
-import k8s_sandbox
 from k8s_sandbox._helm import Release, StaticValuesSource
-from k8s_sandbox._sandbox_environment import K8sSandboxEnvironment, K8sSandboxEnvironmentConfig
+from k8s_sandbox._sandbox_environment import (
+    K8sSandboxEnvironment,
+    K8sSandboxEnvironmentConfig,
+)
 
 
 @asynccontextmanager
 async def install_sandbox_environments(
-    task_name: str, values_filename: str | None, context_name: str | None = None, default_users: dict[str, str] | None = None,
+    task_name: str,
+    values_filename: str | None,
+    context_name: str | None = None,
+    default_users: dict[str, str] | None = None,
 ) -> AsyncGenerator[dict[str, K8sSandboxEnvironment], None]:
     values_path = (
         Path(__file__).parent / "resources" / values_filename
@@ -28,14 +33,14 @@ async def install_sandbox_environments(
         pods = await release.get_sandbox_pods()
         sandbox_envs: dict[str, K8sSandboxEnvironment] = {}
         for pod_name, pod in pods.items():
-          default_user = default_users.get(pod_name) if default_users else None
-          sandbox_envs[pod_name] = K8sSandboxEnvironment(
-            release,
-            pod,
-            config=K8sSandboxEnvironmentConfig(
-              default_user=default_user,
-            ),
-          )
+            default_user = default_users.get(pod_name) if default_users else None
+            sandbox_envs[pod_name] = K8sSandboxEnvironment(
+                release,
+                pod,
+                config=K8sSandboxEnvironmentConfig(
+                    default_user=default_user,
+                ),
+            )
         yield sandbox_envs
     finally:
         await release.uninstall(quiet=True)


### PR DESCRIPTION
### Motivation
When setting up a sandbox it can be useful to isolate certain host services from the agent—for example, a monitoring daemon or an internal API endpoint that the agent must not touch. The usual workaround is to run those services as root and launch the agent under a different user:

```python
tools = [python(user='agent'), bash(user='agent')]
```

But having every solver override the user on each tool call is cumbersome and easy to forget. In the Docker sandbox, it works to override the user (via the image or Docker config), but Kubernetes sandboxes can’t switch from a non‐root runtime user, so that option don't work here.

### Implementation
This PR introduces a default_user configuration value in the sandbox config that overrides root whenever a tool is invoked without an explicit `user=`.

All existing behavior remains unchanged: if you still specify user='root' (or any other user) on a per‐tool basis, that explicit choice takes precedence over default_user.

I had to do some refactorings around the configuration injection to get the default user into the sandbox. Please let me know if you would prefer that I do that in another way.