### PR TITLE
Support fractional byte values

### DIFF
--- a/src/k8s_sandbox/compose/_converter.py
+++ b/src/k8s_sandbox/compose/_converter.py
@@ -331,7 +331,7 @@ class _ServiceConverter:
 
         # Despite not being documented, Docker Compose allows uppercase units.
         match = re.match(
-            r"^(?P<value>\d+)(?P<unit>gb?|mb?|kb?|b)$", value, re.IGNORECASE
+            r"^(?P<value>\d+(?:\.\d+)?)(?P<unit>gb?|mb?|kb?|b)$", value, re.IGNORECASE
         )
         if not match:
             raise ComposeConverterError(

--- a/test/k8s_sandbox/compose/test_converter.py
+++ b/test/k8s_sandbox/compose/test_converter.py
@@ -421,6 +421,18 @@ services:
     assert result["services"]["my-service"]["resources"]["limits"]["memory"] == "1Gi"
 
 
+def test_converts_fractional_mem_limit(tmp_compose: TmpComposeFixture) -> None:
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    mem_limit: 0.5G
+""")
+
+    result = convert_compose_to_helm_values(compose_path)
+
+    assert result["services"]["my-service"]["resources"]["limits"]["memory"] == "0.5Gi"
+
+
 def test_converts_mem_limit_and_applies_to_requests(
     tmp_compose: TmpComposeFixture,
 ) -> None:


### PR DESCRIPTION
Docker compose byte values (i.e. memory) are allowed to be a fractional value. Fortunately, so are Kubernetes `resource.Quantity`s.

This PR just adds this to the regexp in `_converter.convert_unit()` and adds a single test.