### PR TITLE
Ignore `x-local` key when converting from Compose to Helm values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Ignore `x-local` key in Docker Compose files (Inspect-specific extension).
 - Enhanced `additionalResources` to support full Helm templating.
 - Support `user` parameter on `K8sSandboxEnvironment.exec()` (only when container is running as root and `runuser` is installed).
 - Support `user` parameter on `K8sSandboxEnvironment.connection()` (returns `SandboxConnection`).

--- a/src/k8s_sandbox/compose/_converter.py
+++ b/src/k8s_sandbox/compose/_converter.py
@@ -174,6 +174,11 @@ class _ServiceConverter:
             # is almost always used in Compose and we don't have an alternative
             # suggestion to offer to users.
             logger.info(f"Ignoring 'init' key: not supported in K8s. {self.context}")
+        if src.pop("x-local") is not None:
+            # x-local is an Inspect-specific key to indicate that an image should not be
+            # pulled.
+            # https://inspect.aisi.org.uk/sandboxing.html#task-configuration
+            logger.info(f"Ignoring 'x-local' key: not supported in K8s. {self.context}")
         if src:
             raise ComposeConverterError(
                 f"Unsupported key(s) in 'service': {set(src)}. {self.context}"

--- a/src/k8s_sandbox/compose/_converter.py
+++ b/src/k8s_sandbox/compose/_converter.py
@@ -174,11 +174,14 @@ class _ServiceConverter:
             # is almost always used in Compose and we don't have an alternative
             # suggestion to offer to users.
             logger.info(f"Ignoring 'init' key: not supported in K8s. {self.context}")
-        if src.pop("x-local") is not None:
-            # x-local is an Inspect-specific key to indicate that an image should not be
-            # pulled.
-            # https://inspect.aisi.org.uk/sandboxing.html#task-configuration
-            logger.info(f"Ignoring 'x-local' key: not supported in K8s. {self.context}")
+        # x-local is an Inspect-specific key to indicate that an image should not be
+        # pulled. https://inspect.aisi.org.uk/sandboxing.html#task-configuration
+        # If it is set to anything but "true", silently ignore it.
+        if src.pop("x-local", None) == "true":
+            logger.warning(
+                f"Ignoring `x-local: true`: not supported in K8s. All images must be "
+                f"available for pulling from a container registry. {self.context}"
+            )
         if src:
             raise ComposeConverterError(
                 f"Unsupported key(s) in 'service': {set(src)}. {self.context}"

--- a/test/k8s_sandbox/compose/test_converter.py
+++ b/test/k8s_sandbox/compose/test_converter.py
@@ -677,7 +677,9 @@ services:
     result = convert_compose_to_helm_values(compose_path)
 
     assert "my-service" in result["services"]
+    assert "x-local" not in result["services"]["my-service"]
     assert "my-service-2" in result["services"]
+    assert "x-local" not in result["services"]["my-service-2"]
 
 
 def test_rejects_unsupported_service_key(tmp_compose: TmpComposeFixture) -> None:

--- a/test/k8s_sandbox/compose/test_converter.py
+++ b/test/k8s_sandbox/compose/test_converter.py
@@ -669,11 +669,15 @@ services:
   my-service:
     image: my-image
     x-local: true
+  my-service-2:
+    image: my-image
+    x-local: false
 """)
 
     result = convert_compose_to_helm_values(compose_path)
 
     assert "my-service" in result["services"]
+    assert "my-service-2" in result["services"]
 
 
 def test_rejects_unsupported_service_key(tmp_compose: TmpComposeFixture) -> None:

--- a/test/k8s_sandbox/compose/test_converter.py
+++ b/test/k8s_sandbox/compose/test_converter.py
@@ -663,6 +663,19 @@ services:
     assert "my-service" in result["services"]
 
 
+def test_ignores_x_local_key(tmp_compose: TmpComposeFixture) -> None:
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    image: my-image
+    x-local: true
+""")
+
+    result = convert_compose_to_helm_values(compose_path)
+
+    assert "my-service" in result["services"]
+
+
 def test_rejects_unsupported_service_key(tmp_compose: TmpComposeFixture) -> None:
     compose_path = tmp_compose("""
 services:


### PR DESCRIPTION
See discussion here re swebench https://github.com/UKGovernmentBEIS/inspect_evals/issues/212#issuecomment-2896690871

From the Inspect docs:
>The ctf-agent-environment is not an image that exists on a remote registry, so we add the x-local: true to indicate that it should not be pulled. If local images are tagged, they also will not be pulled by default (so x-local: true is not required).

For k8s, we always pull images. We'll emit a warning if `x-local: true`, and silently ignore it if it is any other value.