### PR TITLE
Add missing `context_name` arg, prevent similar issues in future

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,10 @@ ignore = [
 convention = "google"
 
 
+[tool.mypy]
+check_untyped_defs = true
+
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 markers = [

--- a/src/k8s_sandbox/_manager.py
+++ b/src/k8s_sandbox/_manager.py
@@ -146,7 +146,10 @@ async def uninstall_all_unmanaged_releases() -> None:
     ):
         print("Cancelled.")
         return
-    tasks = [helm_uninstall(release, namespace, quiet=False) for release in releases]
+    tasks = [
+        helm_uninstall(release, namespace, context_name=None, quiet=False)
+        for release in releases
+    ]
     await asyncio.gather(*tasks, return_exceptions=True)
     print("Complete.")
 

--- a/src/k8s_sandbox/_manager.py
+++ b/src/k8s_sandbox/_manager.py
@@ -116,7 +116,7 @@ async def uninstall_unmanaged_release(release_name: str) -> None:
     await helm_uninstall(release_name, namespace, context_name=None, quiet=False)
 
 
-async def uninstall_all_unmanaged_releases():
+async def uninstall_all_unmanaged_releases() -> None:
     def _print_table(releases: list[str]) -> None:
         print("Releases to be uninstalled:")
         table = Table(


### PR DESCRIPTION
Disappointing bug which got through to production, noticed by Alex. Was a missing required `context_name=None` argument in a call to `uninstall()`.

My first reaction is "mypy should have caught this". But it wasn't because
a) the return type of the function containing the error was not defined (should have been `-> None`)
b) we don't run mypy with `--strict` or have `check_untyped_defs` set

I've resolved both in this PR.

Sadly tests do not cover this precise code path (they do cover other parts of the function though). This is because such a test would involve uninstalling all Helm releases in a namespace, and a user can run tests against the production cluster so I thought it would be unwise to actually try to perform this action just by running `pytest`. In a more mature system, I'd add dependency injection to allow us to mock a `helm uninstall`.