### PR TITLE
Fix Helm template rendering with multiple labels

### DIFF
--- a/src/k8s_sandbox/resources/helm/agent-env/templates/helpers/_helpers.tpl
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/helpers/_helpers.tpl
@@ -34,7 +34,7 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "agentEnv.labels" -}}
-{{- include "agentEnv.labelsFromValues" . }}
+{{- include "agentEnv.labelsFromValues" . -}}
 helm.sh/chart: {{ include "agentEnv.chart" . }}
 {{ include "agentEnv.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
@@ -49,7 +49,7 @@ Labels from values
 {{- define "agentEnv.labelsFromValues" -}}
 {{- range $key, $value := $.Values.labels -}}
 {{ $key }}: {{ quote $value }}
-{{- end }}
+{{ end -}}
 {{- end -}}
 
 {{/*

--- a/test/k8s_sandbox/helm_chart/test_helm_chart.py
+++ b/test/k8s_sandbox/helm_chart/test_helm_chart.py
@@ -162,26 +162,33 @@ def test_annotations(chart_dir: Path, test_resources_dir: Path) -> None:
 
 
 def test_labels(chart_dir: Path, test_resources_dir: Path) -> None:
-    label_value = "test-label"
+    label_value_1 = "test-label-1"
+    label_value_2 = "test-label-2"
 
     documents = _run_helm_template(
         chart_dir,
         test_resources_dir / "volumes-values.yaml",
-        f"labels.myValue={label_value}",
+        f"labels.myValue1={label_value_1},labels.myValue2={label_value_2}",
     )
 
     for stateful_set in _get_documents(documents, "StatefulSet"):
-        assert stateful_set["metadata"]["labels"]["myValue"] == label_value
+        assert stateful_set["metadata"]["labels"]["myValue1"] == label_value_1
+        assert stateful_set["metadata"]["labels"]["myValue2"] == label_value_2
         template = stateful_set["spec"]["template"]
-        assert template["metadata"]["labels"]["myValue"] == label_value
+        assert template["metadata"]["labels"]["myValue1"] == label_value_1
+        assert template["metadata"]["labels"]["myValue2"] == label_value_2
     for network_policy in _get_documents(documents, "NetworkPolicy"):
-        assert network_policy["metadata"]["labels"]["myValue"] == label_value
+        assert network_policy["metadata"]["labels"]["myValue1"] == label_value_1
+        assert network_policy["metadata"]["labels"]["myValue2"] == label_value_2
     for pvc in _get_documents(documents, "PersistentVolumeClaim"):
-        assert pvc["metadata"]["labels"]["myValue"] == label_value
+        assert pvc["metadata"]["labels"]["myValue1"] == label_value_1
+        assert pvc["metadata"]["labels"]["myValue2"] == label_value_2
     for service in _get_documents(documents, "Service"):
-        assert service["metadata"]["labels"]["myValue"] == label_value
+        assert service["metadata"]["labels"]["myValue1"] == label_value_1
+        assert service["metadata"]["labels"]["myValue2"] == label_value_2
     for deployment in _get_documents(documents, "Deployment"):
-        assert deployment["metadata"]["labels"]["myValue"] == label_value
+        assert deployment["metadata"]["labels"]["myValue1"] == label_value_1
+        assert deployment["metadata"]["labels"]["myValue2"] == label_value_2
 
 
 def test_resource_requests_and_limits(

--- a/test/k8s_sandbox/helm_chart/test_helm_chart.py
+++ b/test/k8s_sandbox/helm_chart/test_helm_chart.py
@@ -170,6 +170,10 @@ def test_annotations(chart_dir: Path, test_resources_dir: Path) -> None:
             {"myLabel": "test-label", "myOtherLabel": "test-other-label"},
             id="two-labels",
         ),
+        pytest.param(
+            {"labelWithColon": "a: b"},
+            id="label-with-colon",
+        ),
     ],
 )
 def test_labels(

--- a/test/k8s_sandbox/helm_chart/test_helm_chart.py
+++ b/test/k8s_sandbox/helm_chart/test_helm_chart.py
@@ -182,19 +182,18 @@ def test_labels(
         set_str,
     )
 
-    for key, value in labels.items():
-        for stateful_set in _get_documents(documents, "StatefulSet"):
-            assert stateful_set["metadata"]["labels"][key] == value
-            template = stateful_set["spec"]["template"]
-            assert template["metadata"]["labels"][key] == value
-        for network_policy in _get_documents(documents, "NetworkPolicy"):
-            assert network_policy["metadata"]["labels"][key] == value
-        for pvc in _get_documents(documents, "PersistentVolumeClaim"):
-            assert pvc["metadata"]["labels"][key] == value
-        for service in _get_documents(documents, "Service"):
-            assert service["metadata"]["labels"][key] == value
-        for deployment in _get_documents(documents, "Deployment"):
-            assert deployment["metadata"]["labels"][key] == value
+    for stateful_set in _get_documents(documents, "StatefulSet"):
+        assert labels.items() <= stateful_set["metadata"]["labels"].items()
+        template = stateful_set["spec"]["template"]
+        assert labels.items() <= template["metadata"]["labels"].items()
+    for network_policy in _get_documents(documents, "NetworkPolicy"):
+        assert labels.items() <= network_policy["metadata"]["labels"].items()
+    for pvc in _get_documents(documents, "PersistentVolumeClaim"):
+        assert labels.items() <= pvc["metadata"]["labels"].items()
+    for service in _get_documents(documents, "Service"):
+        assert labels.items() <= service["metadata"]["labels"].items()
+    for deployment in _get_documents(documents, "Deployment"):
+        assert labels.items() <= deployment["metadata"]["labels"].items()
 
 
 def test_resource_requests_and_limits(


### PR DESCRIPTION
Sorry, #105 doesn't work when there's more than one label specified in `values.yaml`. This PR fixes the underlying issue. The problem was, the template removed whitespace between each label in the list of labels in `agentEnv.labelsFromValues`.

I've added tests for this case.

I've also tested this manually, with this `values.yaml`:

```yaml
additionalResources: ["apiVersion: cilium.io/v2\nkind: CiliumNetworkPolicy\nmetadata:\n\
    \  name: {{ template \"agentEnv.fullname\" $ }}-sandbox-default-external-ingress\n\
    \  annotations:\n    {{- toYaml $.Values.annotations | nindent 6 }}\nspec:\n \
    \ description: |\n    Allow external ingress from all entities to the default
    service on port 2222.\n  endpointSelector:\n    matchLabels:\n      io.kubernetes.pod.namespace:
    {{ $.Release.Namespace }}\n      {{- include \"agentEnv.selectorLabels\" $ | nindent
    6 }}\n      inspect/service: default\n  ingress:\n    - fromEntities:\n      -
    all\n      toPorts:\n      - ports:\n        - port: \"2222\"\n          protocol:
    TCP"]
annotations: {karpenter.sh/do-not-disrupt: 'true'}
labels: {inspect-ai.metr.org/created-by: me, inspect-ai.metr.org/eval-set-id: inspect-eval-set-1d88b8ee-88ef-4e95-996f-b05cd55466dd}
services:
  default: {runtimeClassName: CLUSTER_DEFAULT}
```

```shell
helm template foo ./src/k8s_sandbox/resources/helm/agent-env/ --values values.yaml
```