### PR TITLE
Allow configuring coredns image and command

### DIFF
--- a/src/k8s_sandbox/resources/helm/agent-env/README.md
+++ b/src/k8s_sandbox/resources/helm/agent-env/README.md
@@ -11,6 +11,8 @@
 | allowDomains | list | Empty list (no internet access) | A list of fully qualified domain names that pods within the agent environment are allowed to access. |
 | allowEntities | list | Empty list (no additional entities compared to default policies) | A list of Cilium entities (e.g. "world") that pods within the agent environment are allowed to access. |
 | annotations | object | `{}` | A dict of annotations to apply to resources within the agent environment. |
+| corednsCommand | list | `["/coredns","-conf","/etc/coredns/Corefile"]` | The command to use for the coredns container. |
+| corednsImage | string | `"coredns/coredns:1.8.3"` | The image to use for the coredns container. |
 | global | object | set by inspect | The name of the agent environment, only overwrite in cases where e.g. name lengths are causing failures. |
 | imagePullSecrets | list | `[]` | References to pre-existing secrets that contain registry credentials. |
 | labels | object | `{}` | A dict of labels to apply to resources within the agent environment. |

--- a/src/k8s_sandbox/resources/helm/agent-env/templates/services.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/services.yaml
@@ -103,11 +103,9 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
       - name: coredns
-        image: coredns/coredns:1.8.3
+        image: {{ quote $.Values.corednsImage }}
         command:
-          - /coredns
-          - -conf
-          - /etc/coredns/Corefile
+          {{- toYaml $.Values.corednsCommand | nindent 10 }}
         resources:
           requests:
             memory: "64Mi"

--- a/src/k8s_sandbox/resources/helm/agent-env/values.schema.json
+++ b/src/k8s_sandbox/resources/helm/agent-env/values.schema.json
@@ -26,6 +26,15 @@
     "networks": {
       "type": "object"
     },
+    "corednsImage": {
+      "type": "string"
+    },
+    "corednsCommand": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "imagePullSecrets": {
       "type": "array",
       "items": {
@@ -163,7 +172,10 @@
     "additionalResources": {
       "type": "array",
       "items": {
-        "type": ["object", "string"]
+        "type": [
+          "object",
+          "string"
+        ]
       }
     },
     "annotations": {

--- a/src/k8s_sandbox/resources/helm/agent-env/values.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/values.yaml
@@ -24,6 +24,13 @@ imagePullSecrets: []
 # -- Defines network names that can be attached to services in order to specify subsets
 # of services that can communicate with one another.
 networks: {}
+# -- The image to use for the coredns container.
+corednsImage: "coredns/coredns:1.8.3"
+# -- The command to use for the coredns container.
+corednsCommand:
+  - /coredns
+  - -conf
+  - /etc/coredns/Corefile
 # -- A collection of services to deploy within the agent environment. A service can
 # connect to another service using DNS, e.g. `http://nginx:80`.
 # @default -- see [values.yaml](./values.yaml)
@@ -125,7 +132,8 @@ volumes: {}
 # template engine then converted to YAML.
 additionalResources: []
 # -- A dict of annotations to apply to resources within the agent environment.
-annotations: {}
+annotations:
+  {}
   # inspectTaskName: "task-name"
 # -- A dict of labels to apply to resources within the agent environment.
 labels: {}


### PR DESCRIPTION
We ran into issues with getting rate limited by docker hub when trying to pull the coredns image as our cluster scaled up real fast. One way around this is to authenticate image pulls, getting unlimited rate limit. There are Reasons why that's a bit more complicated for us than just adding an image pull secret, and IMO one should be able to configure the coredns image being used anyway (e.g. pull your own hardened image from your internal registry), so I added that functionality.