### PR TITLE
Check for container restarts

### DIFF
--- a/docs/docs/design/limitations.md
+++ b/docs/docs/design/limitations.md
@@ -41,6 +41,10 @@ chart](../helm//built-in-chart.md#resource-requests-and-limits).
 
 You can reduce the impact of a container restarting by using persistent volumes.
 
+The framework will issue a warning if a container restarts during an eval. If you set
+the `restarted_container_behaviour` parameter to `raise`, the eval will fail the sample 
+if it detects a container restart.
+
 ??? question "Why not use Jobs over StatefulSets?"
 
     Instead of using

--- a/src/k8s_sandbox/_pod/execute.py
+++ b/src/k8s_sandbox/_pod/execute.py
@@ -28,6 +28,7 @@ class ExecuteOperation(PodOperation):
         user: str | None,
         timeout: int | None,
     ) -> ExecResult[str]:
+        self._check_for_pod_restart()
         shell_script = self._build_shell_script(cmd, stdin, cwd, env, timeout)
         with self._interactive_shell(user) as ws_client:
             # Write the script to the shell's stdin rather than passing it as a command

--- a/src/k8s_sandbox/_pod/pod.py
+++ b/src/k8s_sandbox/_pod/pod.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import IO, Callable, TypeVar
+from typing import IO, Callable, Literal, TypeVar
 
 from inspect_ai.util import ExecResult
 
@@ -21,8 +21,19 @@ class Pod:
         namespace: str,
         context_name: str | None,
         default_container_name: str,
+        uid: str,
+        initial_restart_count: int,
+        restarted_container_behavior: Literal["warn", "raise"],
     ) -> None:
-        self.info = PodInfo(name, namespace, context_name, default_container_name)
+        self.info = PodInfo(
+            name,
+            namespace,
+            context_name,
+            default_container_name,
+            uid,
+            initial_restart_count,
+            restarted_container_behavior,
+        )
 
     async def exec(
         self,

--- a/src/k8s_sandbox/_pod/read.py
+++ b/src/k8s_sandbox/_pod/read.py
@@ -17,6 +17,7 @@ from k8s_sandbox._pod.op import (
 
 class ReadFileOperation(PodOperation):
     def read_file(self, src: Path, dst: IO[bytes]) -> None:
+        self._check_for_pod_restart()
         with self._start_read_command(src) as ws_client:
             self._handle_stream_output(ws_client, dst)
 

--- a/src/k8s_sandbox/_pod/write.py
+++ b/src/k8s_sandbox/_pod/write.py
@@ -16,6 +16,7 @@ from k8s_sandbox._pod.op import (
 
 class WriteFileOperation(PodOperation):
     def write_file(self, src: IO[bytes], dst: Path) -> None:
+        self._check_for_pod_restart()
         file_size = self._get_file_size(src)
         with self._start_write_command(dst, file_size) as ws_client:
             self._write_data_to_stdin(ws_client, src)

--- a/test/k8s_sandbox/utils.py
+++ b/test/k8s_sandbox/utils.py
@@ -1,6 +1,6 @@
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import AsyncGenerator, cast
+from typing import AsyncGenerator, Literal, cast
 
 from k8s_sandbox._sandbox_environment import (
     K8sSandboxEnvironment,
@@ -14,6 +14,7 @@ async def install_sandbox_environments(
     values_filename: str | None,
     context_name: str | None = None,
     default_user: str | None = None,
+    restarted_container_behavior: Literal["warn", "raise"] = "warn",
 ) -> AsyncGenerator[dict[str, K8sSandboxEnvironment], None]:
     values_path = (
         Path(__file__).parent / "resources" / values_filename
@@ -21,7 +22,10 @@ async def install_sandbox_environments(
         else None
     )
     config = K8sSandboxEnvironmentConfig(
-        values=values_path, context=context_name, default_user=default_user
+        values=values_path,
+        context=context_name,
+        default_user=default_user,
+        restarted_container_behavior=restarted_container_behavior,
     )
     try:
         envs = cast(


### PR DESCRIPTION
When we run samples using k8s-sandbox, the agent can exceed the memory limits and force the container to restart. There is a [section about this](https://k8s-sandbox.aisi.org.uk/design/limitations/) in the docs. The agent can't detect the restart, so it gets confused that the sandbox has been reset. ([Slack](https://inspectcommunity.slack.com/archives/C0855KJ6BMW/p1754463522997109))

This PR makes the framework track the pod UID and the number of times the default container has been restarted.

It then validates these values before performing any operations, and either warns or raises an error if it detects a change.