### PR TITLE
Increase coredns resource requests to match limits to ensure Guaranteed QoS

### DIFF
--- a/src/k8s_sandbox/resources/helm/agent-env/templates/services.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/services.yaml
@@ -108,8 +108,8 @@ spec:
           {{- toYaml $.Values.corednsCommand | nindent 10 }}
         resources:
           requests:
-            memory: "64Mi"
-            cpu: "50m"
+            memory: "128Mi"
+            cpu: "100m"
           limits:
             memory: "128Mi"
             cpu: "100m"


### PR DESCRIPTION
The inspect k8s plugin documentation [currently states that](https://k8s-sandbox.aisi.org.uk/helm/built-in-chart/#resource-requests-and-limits):
> Default resource limits are assigned for each service within the Helm chart. The limits and requests are equal such that the Pods have a Guaranteed [QoS class](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/).

This is not actually true at the moment though, because the `coredns` service has a lower requests than limits: https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/blob/7ec705f967e598a96d8a9d0cd809bca5a014ceae/src/k8s_sandbox/resources/helm/agent-env/templates/services.yaml#L105-L115

Per the [k8s docs](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed), to obtain Guaranteed QoS it is required that "for every Container in the Pod, the CPU limit must equal the CPU request".

This commit remedies this issue by upping coredns's requests to match its current limits.