### PR TITLE
Update uv installation instructions in doc

### DIFF
--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -19,7 +19,7 @@ Python package in your environment.
 === "uv"
 
     ```sh
-    uv pip install git+https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox.git
+    uv add git+https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox.git
     ```
 
 Then, pass `"k8s"` as the `sandbox` argument to the Inspect `Task` or `Sample`


### PR DESCRIPTION
The docs previously suggested using `uv pip install`, which will add the library to the venv, but not register the dependency in the `pyproject.toml` or to the `uv.lock` file.

`uv add` is a more comparable equivalent command to `poetry add`, which is what we suggest for installing with Poetry.