### PR TITLE
Fix issues with pinging containers with limited ports

### DIFF
--- a/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
@@ -107,6 +107,17 @@ spec:
         - ports:
 {{ include "agentEnv.servicePortsListFor" (dict "svc" $svc) | nindent 12 }}
       {{- end }}
+    - fromEndpoints:
+      - matchLabels:
+          io.kubernetes.pod.namespace: {{ $.Release.Namespace }}
+          {{- include "agentEnv.selectorLabels" $ | nindent 10 }}
+          aisi.gov.uk/network-{{ $net }}: "true"
+      icmps:
+        - fields:
+          - type: 8
+            family: IPv4
+          - type: 128
+            family: IPv6
       {{- end }}
     {{- else }}
     {{- /* If no network fallback to default rule (no ingress) */}}
@@ -128,6 +139,7 @@ spec:
   description: |
     Allow ingress to workload "{{ $svcName }}" from same sandbox.
     If ports are specified, only those ports are exposed; otherwise all ports are allowed.
+    Always allow ICMP echo requests (ping).
   endpointSelector:
     matchLabels:
       io.kubernetes.pod.namespace: {{ $.Release.Namespace }}
@@ -143,5 +155,15 @@ spec:
         - ports:
 {{ include "agentEnv.servicePortsListFor" (dict "svc" $svc) | nindent 12 }}
       {{- end }}
+    - fromEndpoints:
+      - matchLabels:
+          io.kubernetes.pod.namespace: {{ $.Release.Namespace }}
+          {{- include "agentEnv.selectorLabels" $ | nindent 10 }}
+      icmps:
+        - fields:
+          - type: 8
+            family: IPv4
+          - type: 128
+            family: IPv6
   {{- end }}
 {{- end }}

--- a/test/k8s_sandbox/test_network_policy_ports_network.py
+++ b/test/k8s_sandbox/test_network_policy_ports_network.py
@@ -22,7 +22,11 @@ async def sandbox_ports() -> AsyncGenerator[K8sSandboxEnvironment, None]:
 @pytest.mark.parametrize(
     "host_to_mapped_ports",
     [
-        {"host": "ports-specified", "open_ports": ["8080"], "closed_ports": ["9090"]},
+        {
+            "host": "ports-specified",
+            "open_ports": ["8080"],
+            "closed_ports": ["9090"],
+        },
         {
             "host": "ports-specified-two-networks",
             "open_ports": ["8080"],
@@ -43,4 +47,14 @@ async def sandbox_ports() -> AsyncGenerator[K8sSandboxEnvironment, None]:
 async def test_only_specified_ports_are_open(
     sandbox_ports: K8sSandboxEnvironment, host_to_mapped_ports
 ):
+    host = host_to_mapped_ports["host"]
+    reachable = len(host_to_mapped_ports["open_ports"]) > 0
+
+    result = await sandbox_ports.exec(["ping", "-c", "1", "-W", "5", host], timeout=10)
+    print(result.stdout)
+    print(result.stderr)
+    assert not reachable or result.returncode == 0, (
+        f"Host {host} should be reachable but is not: {result}"
+    )
+
     await assert_proper_ports_are_open(sandbox_ports, host_to_mapped_ports)

--- a/test/k8s_sandbox/test_network_policy_ports_no_network.py
+++ b/test/k8s_sandbox/test_network_policy_ports_no_network.py
@@ -35,4 +35,15 @@ async def sandbox_ports_no_net() -> AsyncGenerator[K8sSandboxEnvironment, None]:
 async def test_only_specified_ports_are_open_no_networks(
     sandbox_ports_no_net: K8sSandboxEnvironment, host_to_mapped_ports
 ):
+    host = host_to_mapped_ports["host"]
+    reachable = len(host_to_mapped_ports["open_ports"]) > 0
+
+    result = await sandbox_ports_no_net.exec(
+        ["ping", "-c", "1", "-W", "5", host], timeout=10
+    )
+    print(result.stdout)
+    print(result.stderr)
+    assert not reachable or result.returncode == 0, (
+        f"Host {host} should be reachable but is not: {result}"
+    )
     await assert_proper_ports_are_open(sandbox_ports_no_net, host_to_mapped_ports)


### PR DESCRIPTION
Cillium blocks all layer 4 protocols (like ICMP) if ports are specified in the policy. This blocks common cyber exploration tools like `ping` and `nmap` which is not ideal for evaluations. This commit adds testing for this and adds the proper rules in the policy for allowing ICMP pings.