### PR TITLE
feat: add provider-level exec retry for transient K8s errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
   "inspect-ai>=0.3.161",
   "kubernetes>=35.0.0",
   "jsonschema>=4.23.0",
+  "tenacity>=8.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/k8s_sandbox/_pod/execute.py
+++ b/src/k8s_sandbox/_pod/execute.py
@@ -1,5 +1,4 @@
 import base64
-import logging
 import re
 import shlex
 from contextlib import contextmanager
@@ -10,11 +9,9 @@ from inspect_ai.util import SandboxEnvironmentLimits as limits
 from kubernetes.stream.ws_client import WSClient  # type: ignore[import-untyped]
 
 from k8s_sandbox._pod.buffer import LimitedBuffer
-from k8s_sandbox._pod.error import ExecutableNotFoundError
+from k8s_sandbox._pod.error import ExecutableNotFoundError, PodError
 from k8s_sandbox._pod.get_returncode import get_returncode
 from k8s_sandbox._pod.op import PodOperation
-
-logger = logging.getLogger(__name__)
 
 COMPLETED_SENTINEL = "completed-sentinel-value"
 COMPLETED_SENTINEL_PATTERN = re.compile(rf"<{COMPLETED_SENTINEL}-(\d+)>")
@@ -31,7 +28,6 @@ class ExecuteOperation(PodOperation):
         user: str | None,
         timeout: int | None,
     ) -> ExecResult[str]:
-        self._check_for_pod_restart()
         shell_script = self._build_shell_script(cmd, stdin, cwd, env, timeout)
         with self._interactive_shell(user) as ws_client:
             # Write the script to the shell's stdin rather than passing it as a command
@@ -146,9 +142,15 @@ class ExecuteOperation(PodOperation):
                             ws_client.close()
                     self._verify_output_limit(stdout, stderr)
                 except (BrokenPipeError, ConnectionResetError) as e:
-                    logger.warning(f"WebSocket connection lost during exec: {e}")
-                    ws_client.close()
-                    break
+                    if returncode is not None:
+                        # Sentinel already received — we have the result.
+                        # This commonly happens after ws_client.close() when
+                        # the next update() hits the closed socket.
+                        break
+                    raise PodError(
+                        "WebSocket connection lost during exec",
+                        pod=self._pod.name,
+                    ) from e
             # returncode won't be set if setup commands e.g. `cd` failed.
             if returncode is None:
                 returncode = get_returncode(ws_client)

--- a/src/k8s_sandbox/_pod/op.py
+++ b/src/k8s_sandbox/_pod/op.py
@@ -119,53 +119,56 @@ class PodOperation(ABC):
         ws_client._all = _IgnoredIO()
 
     def _check_for_pod_restart(self):
-        client = k8s_client(self._pod.context_name)
-        pod = client.read_namespaced_pod(
-            name=self._pod.name, namespace=self._pod.namespace
+        check_for_pod_restart(self._pod)
+
+
+def check_for_pod_restart(pod: PodInfo) -> None:
+    """Check if the pod has been replaced or its container has restarted."""
+    api = k8s_client(pod.context_name)
+    k8s_pod = api.read_namespaced_pod(name=pod.name, namespace=pod.namespace)
+    assert k8s_pod.metadata is not None
+    assert k8s_pod.status is not None
+    if k8s_pod.metadata.uid != pod.uid:
+        message = (
+            f"Pod UID mismatch: expected {pod.uid}, got {k8s_pod.metadata.uid} "
+            f"for {k8s_pod.metadata.name}"
         )
-        assert pod.metadata is not None
-        assert pod.status is not None
-        if pod.metadata.uid != self._pod.uid:
-            message = (
-                f"Pod UID mismatch: expected {self._pod.uid}, got {pod.metadata.uid} "
-                f"for {pod.metadata.name}"
-            )
-            if self._pod.restarted_container_behavior == "warn":
-                logger.warning(message)
-            else:
-                raise RuntimeError(message)
-        assert pod.status.container_statuses is not None
-        status = next(
-            (
-                container_status
-                for container_status in pod.status.container_statuses
-                if container_status.name == self._pod.default_container_name
-            ),
-            None,
+        if pod.restarted_container_behavior == "warn":
+            logger.warning(message)
+        else:
+            raise RuntimeError(message)
+    assert k8s_pod.status.container_statuses is not None
+    status = next(
+        (
+            container_status
+            for container_status in k8s_pod.status.container_statuses
+            if container_status.name == pod.default_container_name
+        ),
+        None,
+    )
+    if status is None:
+        message = (
+            f"Pod '{k8s_pod.metadata.name}' does not have a container named "
+            f"'{pod.default_container_name}'"
         )
-        if status is None:
-            message = (
-                f"Pod '{pod.metadata.name}' does not have a container named "
-                f"'{self._pod.default_container_name}'"
-            )
-            if self._pod.restarted_container_behavior == "warn":
-                logger.warning(message)
-                return
-            else:
-                raise RuntimeError(message)
-        if status.restart_count > self._pod.initial_restart_count:
-            last_state = status.last_state
-            terminated = last_state.terminated if last_state else None
-            last_reason = terminated.reason if terminated else "unknown"
-            message = (
-                f"Container '{status.name}' in pod '{pod.metadata.name}' has restarted "
-                f"{status.restart_count} time(s) (last reason: {last_reason}); "
-                "pod state is no longer guaranteed."
-            )
-            if self._pod.restarted_container_behavior == "warn":
-                logger.warning(message)
-            else:
-                raise RuntimeError(message)
+        if pod.restarted_container_behavior == "warn":
+            logger.warning(message)
+            return
+        else:
+            raise RuntimeError(message)
+    if status.restart_count > pod.initial_restart_count:
+        last_state = status.last_state
+        terminated = last_state.terminated if last_state else None
+        last_reason = terminated.reason if terminated else "unknown"
+        message = (
+            f"Container '{status.name}' in pod '{k8s_pod.metadata.name}' has restarted "
+            f"{status.restart_count} time(s) (last reason: {last_reason}); "
+            "pod state is no longer guaranteed."
+        )
+        if pod.restarted_container_behavior == "warn":
+            logger.warning(message)
+        else:
+            raise RuntimeError(message)
 
 
 def _send_keepalive(ws_client: WSClient, stop: threading.Event) -> None:

--- a/src/k8s_sandbox/_pod/pod.py
+++ b/src/k8s_sandbox/_pod/pod.py
@@ -7,7 +7,7 @@ from inspect_ai.util import ExecResult
 
 from k8s_sandbox._pod.execute import ExecuteOperation
 from k8s_sandbox._pod.executor import PodOpExecutor
-from k8s_sandbox._pod.op import PodInfo
+from k8s_sandbox._pod.op import PodInfo, check_for_pod_restart
 from k8s_sandbox._pod.read import ReadFileOperation
 from k8s_sandbox._pod.write import WriteFileOperation
 
@@ -34,6 +34,10 @@ class Pod:
             initial_restart_count,
             restarted_container_behavior,
         )
+
+    async def check_for_pod_restart(self) -> None:
+        """Check if the pod has been replaced or its container has restarted."""
+        await self._run_async(lambda: check_for_pod_restart(self.info))
 
     async def exec(
         self,

--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Generator, Literal, cast, overload
 
+import websocket
 from inspect_ai.solver._task_state import sample_state
 from inspect_ai.util import (
     ComposeConfig,
@@ -20,7 +21,10 @@ from inspect_ai.util import (
     is_dockerfile,
     sandboxenv,
 )
+from kubernetes.client.exceptions import ApiException
 from pydantic import BaseModel, TypeAdapter
+from tenacity import retry_if_exception, stop_after_attempt, wait_exponential_jitter
+from tenacity.asyncio import AsyncRetrying
 
 from k8s_sandbox._helm import (
     DEFAULT_CHART,
@@ -42,6 +46,7 @@ from k8s_sandbox._manager import (
     uninstall_unmanaged_release,
 )
 from k8s_sandbox._pod import Pod
+from k8s_sandbox._pod.error import ExecutableNotFoundError, GetReturncodeError, PodError
 from k8s_sandbox._pod.executor import PodOpExecutor
 from k8s_sandbox._prereqs import validate_prereqs
 from k8s_sandbox.compose._compose import (
@@ -52,6 +57,36 @@ from k8s_sandbox.compose._compose import (
 )
 
 MIN_DESIRED_SOFT = 100000
+
+_TRANSIENT_TYPES = (
+    ApiException,
+    websocket.WebSocketException,
+    ConnectionError,
+    OSError,
+    PodError,
+    GetReturncodeError,
+)
+
+# ExecutableNotFoundError and RuntimeError don't match _TRANSIENT_TYPES today,
+# but are listed defensively: if _TRANSIENT_TYPES ever gains a parent class they
+# inherit from, these entries prevent accidental retries of permanent failures.
+# PermissionError and TimeoutError are OSError subclasses and MUST be excluded.
+_PERMANENT_TYPES = (
+    ExecutableNotFoundError,
+    RuntimeError,
+    PermissionError,
+    TimeoutError,
+)
+
+_exec_retry = AsyncRetrying(
+    stop=stop_after_attempt(5),
+    wait=wait_exponential_jitter(initial=1, max=10),
+    retry=retry_if_exception(
+        lambda e: isinstance(e, _TRANSIENT_TYPES)
+        and not isinstance(e, _PERMANENT_TYPES)
+    ),
+    reraise=True,
+)
 
 
 @sandboxenv(name="k8s")
@@ -223,9 +258,15 @@ class K8sSandboxEnvironment(SandboxEnvironment):
         )
         if user is None:
             user = self._config.default_user
+
         op = "K8s execute command in Pod"
         with self._log_op(op, expected_exceptions, **log_kwargs):
-            result = await self._pod.exec(cmd, input, cwd, env or {}, user, timeout)
+            await self._pod.check_for_pod_restart()
+            async for attempt in _exec_retry:
+                with attempt:
+                    result = await self._pod.exec(
+                        cmd, input, cwd, env or {}, user, timeout
+                    )
             log_trace(f"Completed: {op}.", **(log_kwargs | {"result": result}))
             return result
 

--- a/test/k8s_sandbox/pod/test_execute.py
+++ b/test/k8s_sandbox/pod/test_execute.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from kubernetes.stream.ws_client import WSClient  # type: ignore
 
-from k8s_sandbox._pod.error import GetReturncodeError
+from k8s_sandbox._pod.error import PodError
 from k8s_sandbox._pod.execute import ExecuteOperation
 
 
@@ -145,33 +145,24 @@ class TestBrokenPipeWithoutSentinel:
         error: Exception,
     ) -> MagicMock:
         ws = MagicMock(spec=WSClient)
-        closed = False
-
-        def close_ws(**kwargs: object) -> None:
-            nonlocal closed
-            closed = True
-
-        ws.close.side_effect = close_ws
-        ws.is_open.side_effect = lambda: not closed
-        ws.peek_stderr.return_value = b""
+        ws.is_open.return_value = True
         ws.update.side_effect = error
-        ws.read_channel.return_value = ""
         return ws
 
     def test_broken_pipe_without_sentinel_raises(self) -> None:
-        """BrokenPipe before sentinel → break → get_returncode fails."""
+        """BrokenPipe before sentinel → PodError."""
         ws = self._make_dead_ws(BrokenPipeError("socket closed"))
 
         executor = ExecuteOperation(MagicMock())
-        with pytest.raises(GetReturncodeError):
+        with pytest.raises(PodError, match="WebSocket connection lost"):
             executor._handle_shell_output(ws, user=None, timeout=None)
 
     def test_connection_reset_without_sentinel_raises(self) -> None:
-        """ConnectionReset before sentinel → same behavior."""
+        """ConnectionReset before sentinel → PodError."""
         ws = self._make_dead_ws(
             ConnectionResetError("connection reset"),
         )
 
         executor = ExecuteOperation(MagicMock())
-        with pytest.raises(GetReturncodeError):
+        with pytest.raises(PodError, match="WebSocket connection lost"):
             executor._handle_shell_output(ws, user=None, timeout=None)

--- a/test/k8s_sandbox/test_exec_retry.py
+++ b/test/k8s_sandbox/test_exec_retry.py
@@ -1,0 +1,180 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import websocket
+from inspect_ai.util import ExecResult, OutputLimitExceededError
+from kubernetes.client.exceptions import ApiException
+from tenacity import wait_none
+
+from k8s_sandbox._pod.error import (
+    ExecutableNotFoundError,
+    GetReturncodeError,
+    PodError,
+)
+from k8s_sandbox._sandbox_environment import (
+    K8sError,
+    K8sSandboxEnvironment,
+    _exec_retry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_retry_wait(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable tenacity's exponential backoff in tests."""
+    monkeypatch.setattr(_exec_retry, "wait", wait_none())
+
+
+def _make_sandbox_with_mock_pod() -> tuple[K8sSandboxEnvironment, AsyncMock]:
+    """Create a K8sSandboxEnvironment with a mocked _pod.exec.
+
+    Returns the sandbox and the mock _pod.exec coroutine for configuring
+    side_effect and asserting call_count.
+    """
+    sandbox = object.__new__(K8sSandboxEnvironment)
+    sandbox._pod = MagicMock()
+    sandbox._pod.info = MagicMock()
+    sandbox._pod.info.name = "test-pod"
+    sandbox._config = MagicMock()
+    sandbox._config.default_user = None
+    sandbox.release = MagicMock()
+    sandbox.release.task_name = "test-task"
+
+    sandbox._pod.check_for_pod_restart = AsyncMock()
+    mock_exec = AsyncMock()
+    sandbox._pod.exec = mock_exec
+    return sandbox, mock_exec
+
+
+def _success_result() -> ExecResult[str]:
+    return ExecResult(success=True, returncode=0, stdout="ok", stderr="")
+
+
+class TestExecRetryTransient:
+    """Transient errors should be retried up to 5 times."""
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            pytest.param(
+                ApiException(status=503, reason="Service Unavailable"),
+                id="ApiException",
+            ),
+            pytest.param(
+                websocket.WebSocketConnectionClosedException("gone"),
+                id="WebSocketException",
+            ),
+            pytest.param(
+                ConnectionError("connection refused"),
+                id="ConnectionError",
+            ),
+            pytest.param(
+                OSError("socket error"),
+                id="OSError",
+            ),
+            pytest.param(
+                PodError("WebSocket connection lost", pod="test-pod"),
+                id="PodError",
+            ),
+            pytest.param(
+                GetReturncodeError("no return code"),
+                id="GetReturncodeError",
+            ),
+        ],
+    )
+    async def test_transient_error_is_retried(self, error: Exception) -> None:
+        sandbox, mock_exec = _make_sandbox_with_mock_pod()
+        mock_exec.side_effect = [error, _success_result()]
+
+        result = await sandbox.exec(["echo", "hello"])
+
+        assert result.success
+        assert result.stdout == "ok"
+        assert mock_exec.call_count == 2
+
+    async def test_transient_error_retried_multiple_times(self) -> None:
+        sandbox, mock_exec = _make_sandbox_with_mock_pod()
+        mock_exec.side_effect = [
+            ApiException(status=503, reason="Service Unavailable"),
+            ApiException(status=503, reason="Service Unavailable"),
+            _success_result(),
+        ]
+
+        result = await sandbox.exec(["echo", "hello"])
+
+        assert result.success
+        assert mock_exec.call_count == 3
+
+
+class TestExecRetryPermanent:
+    """Permanent errors should NOT be retried."""
+
+    @pytest.mark.parametrize(
+        "error, expected_exception",
+        [
+            pytest.param(
+                ExecutableNotFoundError("/bin/sh not found"),
+                K8sError,
+                id="ExecutableNotFoundError",
+            ),
+            pytest.param(
+                RuntimeError("Pod UID mismatch"),
+                K8sError,
+                id="RuntimeError",
+            ),
+            pytest.param(
+                PermissionError("permission denied"),
+                PermissionError,
+                id="PermissionError",
+            ),
+        ],
+    )
+    async def test_permanent_error_is_not_retried(
+        self, error: Exception, expected_exception: type[Exception]
+    ) -> None:
+        sandbox, mock_exec = _make_sandbox_with_mock_pod()
+        mock_exec.side_effect = error
+
+        with pytest.raises(expected_exception):
+            await sandbox.exec(["echo", "hello"])
+
+        assert mock_exec.call_count == 1
+
+
+class TestExecRetryExpectedExceptions:
+    """Expected exceptions should pass through without retry."""
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            pytest.param(TimeoutError("timed out"), id="TimeoutError"),
+            pytest.param(
+                UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte"),
+                id="UnicodeDecodeError",
+            ),
+            pytest.param(
+                OutputLimitExceededError(limit_str="10MB", truncated_output="..."),
+                id="OutputLimitExceededError",
+            ),
+        ],
+    )
+    async def test_expected_exception_passes_through(self, error: Exception) -> None:
+        sandbox, mock_exec = _make_sandbox_with_mock_pod()
+        mock_exec.side_effect = error
+
+        with pytest.raises(type(error)):
+            await sandbox.exec(["echo", "hello"])
+
+        assert mock_exec.call_count == 1
+
+
+class TestExecRetryExhausted:
+    """After 5 failed attempts, the error should propagate."""
+
+    async def test_retries_exhausted_raises_k8s_error(self) -> None:
+        sandbox, mock_exec = _make_sandbox_with_mock_pod()
+        mock_exec.side_effect = ApiException(status=503, reason="Service Unavailable")
+
+        with pytest.raises(K8sError):
+            await sandbox.exec(["echo", "hello"])
+
+        assert mock_exec.call_count == 5

--- a/uv.lock
+++ b/uv.lock
@@ -871,6 +871,7 @@ dependencies = [
     { name = "inspect-ai" },
     { name = "jsonschema" },
     { name = "kubernetes" },
+    { name = "tenacity" },
 ]
 
 [package.optional-dependencies]
@@ -900,6 +901,7 @@ requires-dist = [
     { name = "pytest-env", marker = "extra == 'dev'", specifier = ">=1.2.0" },
     { name = "pytest-repeat", marker = "extra == 'dev'", specifier = ">=0.9.3" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.6" },
+    { name = "tenacity", specifier = ">=8.0.0" },
     { name = "types-jsonschema", marker = "extra == 'dev'", specifier = ">=4.23.0.20241208" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12" },
 ]


### PR DESCRIPTION
## Summary

- Adds tenacity-based retry to `K8sSandboxEnvironment.exec()` so transient K8s errors (API server rotation, dropped WebSockets) are retried transparently
- Propagates `BrokenPipeError`/`ConnectionResetError` during exec streaming as `PodError` instead of silently swallowing them
- 5 attempts with exponential jitter backoff (1-10s), matching the pattern used by Daytona and Modal providers

## Details

**Retry classification** uses positive matching on transient types with explicit exclusion of permanent types:

- **Transient (retried):** `ApiException`, `WebSocketException`, `ConnectionError`, `OSError`, `PodError`, `GetReturncodeError`
- **Permanent (not retried):** `ExecutableNotFoundError`, `RuntimeError`, `PermissionError`, `TimeoutError`

`PermissionError` and `TimeoutError` must be explicitly excluded because they are `OSError` subclasses.

The retry decorator wraps `self._pod.exec()` inside `_log_op`, so tenacity sees raw exceptions and `_log_op` only sees the final failure after retries are exhausted.

Based on the approach discussed in [inspect_ai#3468](https://github.com/UKGovernmentBEIS/inspect_ai/pull/3468) and [inspect_sandboxes@93b016d](https://github.com/meridianlabs-ai/inspect_sandboxes/commit/93b016d).

## Test plan

- [x] 14 unit tests covering transient retry, permanent no-retry, expected exception passthrough, and retry exhaustion
- [x] Existing `test_execute.py` tests updated for `PodError` propagation
- [x] Manual verification against our live K8s cluster