### PR TITLE
fix: retry port assertions in network policy tests

### DIFF
--- a/test/k8s_sandbox/utils.py
+++ b/test/k8s_sandbox/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator, Literal, cast
@@ -43,24 +44,37 @@ async def install_sandbox_environments(
 
 
 async def assert_proper_ports_are_open(
-    sandbox_env: K8sSandboxEnvironment, host_to_mapped_ports
+    sandbox_env: K8sSandboxEnvironment,
+    host_to_mapped_ports,
+    retries: int = 3,
+    retry_delay: float = 2.0,
 ) -> None:
     hostname = host_to_mapped_ports["host"]
     open_ports = host_to_mapped_ports["open_ports"]
     closed_ports = host_to_mapped_ports["closed_ports"]
 
-    expected_open_results = [
-        await sandbox_env.exec(
-            ["nc", "-vz", "-w", "5", hostname, open_port], timeout=10
-        )
-        for open_port in open_ports
-    ]
-    expected_closed_results = [
-        await sandbox_env.exec(
-            ["nc", "-vz", "-w", "5", hostname, closed_port], timeout=10
-        )
-        for closed_port in closed_ports
-    ]
+    for attempt in range(retries):
+        expected_open_results = [
+            await sandbox_env.exec(
+                ["nc", "-vz", "-w", "5", hostname, open_port], timeout=10
+            )
+            for open_port in open_ports
+        ]
+        expected_closed_results = [
+            await sandbox_env.exec(
+                ["nc", "-vz", "-w", "5", hostname, closed_port], timeout=10
+            )
+            for closed_port in closed_ports
+        ]
+
+        open_ok = all(r.returncode == 0 for r in expected_open_results)
+        closed_ok = all(r.returncode != 0 for r in expected_closed_results)
+
+        if open_ok and closed_ok:
+            return
+
+        if attempt < retries - 1:
+            await asyncio.sleep(retry_delay)
 
     for result in expected_open_results:
         assert result.returncode == 0


### PR DESCRIPTION
## Summary

Some of the test_network_policy tests are [a bit flaky](https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/actions/runs/24077416732/job/70229230250?pr=177#step:6:1289).

- Adds retry logic (3 attempts, 2s delay) to `assert_proper_ports_are_open` in test utils
- Fixes flaky `test_only_specified_ports_are_open_no_networks[host_to_mapped_ports0]` failures in CI
- The `nc` port checks can fail transiently when Cilium policies haven't propagated or HTTP servers aren't listening yet

## Context

In CI, there's a race between pod startup / Cilium policy application and the connectivity checks, causing sporadic `AssertionError`.
