### PR TITLE
feat: add configurable K8s client token refresh

### DIFF
--- a/docs/docs/tips/configuration.md
+++ b/docs/docs/tips/configuration.md
@@ -36,6 +36,21 @@ export INSPECT_K8S_DEFAULT_NAMESPACE=my-sandbox-namespace
 When set, this takes precedence over both kubeconfig and in-cluster namespace resolution.
 
 
+## Kubernetes client refresh { #client-refresh }
+
+By default, the Kubernetes API client is created once and reused for the lifetime of the
+process. On clusters where service account tokens have a short lifetime (e.g. EKS 1.35
+caps tokens at 24 hours), long-running evaluations may encounter 401 Unauthorized errors
+when the cached token expires. You can set `INSPECT_K8S_CLIENT_REFRESH_SECONDS` to
+periodically re-create the client, causing it to re-read the token from disk.
+
+```sh
+export INSPECT_K8S_CLIENT_REFRESH_SECONDS=600   # refresh every 10 minutes
+```
+
+Disabled by default (unset or `0`).
+
+
 ## Targeting specific or multiple kubeconfig contexts
 
 Your

--- a/src/k8s_sandbox/_kubernetes_api.py
+++ b/src/k8s_sandbox/_kubernetes_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+import time
 from pathlib import Path
 from typing import TypedDict, cast
 
@@ -16,6 +17,20 @@ logger = logging.getLogger(__name__)
 _thread_local = threading.local()
 
 _INCLUSTER_NAMESPACE_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+INSPECT_K8S_CLIENT_REFRESH_SECONDS = "INSPECT_K8S_CLIENT_REFRESH_SECONDS"
+
+
+def _get_client_refresh_seconds() -> int:
+    name = INSPECT_K8S_CLIENT_REFRESH_SECONDS
+    raw = os.environ.get(name, "0")
+    try:
+        value = int(raw)
+    except ValueError:
+        raise ValueError(f"{name} must be a non-negative int: '{raw}'.")
+    if value < 0:
+        raise ValueError(f"{name} must be a non-negative int: '{value}'.")
+    return value
 
 
 class _KubeContext(TypedDict):
@@ -177,32 +192,46 @@ class _Config:
 
 
 class _ThreadLocalClientFactory:
-    """Each instance of this class assumes that only one thread may access it."""
+    """Each instance of this class assumes that only one thread may access it.
+
+    When INSPECT_K8S_CLIENT_REFRESH_SECONDS is set to a positive value, cached
+    clients are discarded and re-created after that many seconds. This causes
+    the kubernetes library to re-read the token file from disk, picking up
+    tokens rotated by the kubelet.
+    """
 
     def __init__(self) -> None:
-        self._current_context_client: client.CoreV1Api | None = None
-        self._clients: dict[str, client.CoreV1Api] = {}
+        self._clients: dict[str | None, client.CoreV1Api] = {}
+        self._created_at: dict[str | None, float] = {}
 
     def get_client(self, context_name: str | None) -> client.CoreV1Api:
+        self._maybe_refresh(context_name)
+        if context_name not in self._clients:
+            self._clients[context_name] = self._create_client(context_name)
+            self._created_at[context_name] = time.monotonic()
+        return self._clients[context_name]
+
+    def _maybe_refresh(self, context_name: str | None) -> None:
+        refresh_seconds = _get_client_refresh_seconds()
+        if refresh_seconds <= 0:
+            return
+        if context_name not in self._created_at:
+            return
+        age = time.monotonic() - self._created_at[context_name]
+        if age < refresh_seconds:
+            return
+        old_client = self._clients.pop(context_name, None)
+        del self._created_at[context_name]
+        if old_client is not None:
+            old_client.api_client.close()  # type: ignore[attr-defined]
+
+    def _create_client(self, context_name: str | None) -> client.CoreV1Api:
         if context_name is None:
-            return self._get_or_create_client_for_current_context()
-        return self._get_or_create_client_for_named_context(context_name)
-
-    def _get_or_create_client_for_current_context(self) -> client.CoreV1Api:
-        if self._current_context_client is None:
-            self._current_context_client = client.CoreV1Api()
-        return self._current_context_client
-
-    def _get_or_create_client_for_named_context(
-        self, context_name: str
-    ) -> client.CoreV1Api:
-        if context_name in self._clients:
-            return self._clients[context_name]
-        api_client = self._create_client_for_named_context(context_name)
-        self._clients[context_name] = api_client
-        return api_client
-
-    def _create_client_for_named_context(self, context_name: str) -> client.CoreV1Api:
+            if _Config.get_instance().in_cluster:
+                # In-cluster config sets up the global default Configuration with
+                # built-in token refresh (re-reads every 60s). Use it directly.
+                return client.CoreV1Api()
+            return client.CoreV1Api(api_client=config.new_client_from_config())
         return client.CoreV1Api(
             api_client=config.new_client_from_config(context=context_name)
         )

--- a/test/k8s_sandbox/test_kubernetes_api.py
+++ b/test/k8s_sandbox/test_kubernetes_api.py
@@ -1,6 +1,7 @@
 """Tests for Kubernetes API configuration loading."""
 
 import importlib
+import time
 from pathlib import Path
 from typing import Iterator, Protocol, Self, cast
 from unittest.mock import MagicMock, patch
@@ -239,3 +240,124 @@ class TestInspectK8sDefaultNamespace:
         )
 
         assert get_default_namespace(context_name=None) == "kubeconfig-ns"
+
+
+_get_client_refresh_seconds = getattr(_KUBE_API, "_get_client_refresh_seconds")
+
+
+class TestClientRefreshSeconds:
+    """Tests for _get_client_refresh_seconds env var parsing."""
+
+    def test_unset_returns_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("INSPECT_K8S_CLIENT_REFRESH_SECONDS", raising=False)
+        assert _get_client_refresh_seconds() == 0
+
+    def test_zero_returns_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("INSPECT_K8S_CLIENT_REFRESH_SECONDS", "0")
+        assert _get_client_refresh_seconds() == 0
+
+    def test_positive_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("INSPECT_K8S_CLIENT_REFRESH_SECONDS", "600")
+        assert _get_client_refresh_seconds() == 600
+
+    def test_negative_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("INSPECT_K8S_CLIENT_REFRESH_SECONDS", "-1")
+        with pytest.raises(ValueError, match="must be a non-negative int"):
+            _get_client_refresh_seconds()
+
+    def test_non_integer_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("INSPECT_K8S_CLIENT_REFRESH_SECONDS", "abc")
+        with pytest.raises(ValueError, match="must be a non-negative int"):
+            _get_client_refresh_seconds()
+
+
+_ThreadLocalClientFactory = getattr(_KUBE_API, "_ThreadLocalClientFactory")
+
+
+class TestClientRefresh:
+    """Tests for _ThreadLocalClientFactory client refresh behavior."""
+
+    @patch("k8s_sandbox._kubernetes_api.config")
+    @patch("k8s_sandbox._kubernetes_api._get_client_refresh_seconds", return_value=0)
+    def test_client_cached_when_refresh_disabled(
+        self, _mock_refresh: MagicMock, mock_config: MagicMock
+    ) -> None:
+        """When refresh is disabled, the same client is returned every time."""
+        mock_config.new_client_from_config.return_value = MagicMock()
+        factory = _ThreadLocalClientFactory()
+        client1 = factory.get_client("ctx")
+        client2 = factory.get_client("ctx")
+        assert client1 is client2
+        mock_config.new_client_from_config.assert_called_once()
+
+    @patch("k8s_sandbox._kubernetes_api.config")
+    @patch("k8s_sandbox._kubernetes_api._get_client_refresh_seconds", return_value=1)
+    def test_client_refreshed_when_expired(
+        self, _mock_refresh: MagicMock, mock_config: MagicMock
+    ) -> None:
+        """When refresh is enabled and client is stale, a new client is created."""
+        mock_api_client_1 = MagicMock()
+        mock_api_client_2 = MagicMock()
+        mock_config.new_client_from_config.side_effect = [
+            mock_api_client_1,
+            mock_api_client_2,
+        ]
+        factory = _ThreadLocalClientFactory()
+        client1 = factory.get_client("ctx")
+
+        # Backdate the creation time so it appears expired.
+        factory._created_at["ctx"] = time.monotonic() - 2
+
+        client2 = factory.get_client("ctx")
+        assert client1 is not client2
+        assert mock_config.new_client_from_config.call_count == 2
+        mock_api_client_1.close.assert_called_once()
+
+    @patch("k8s_sandbox._kubernetes_api.config")
+    @patch("k8s_sandbox._kubernetes_api._get_client_refresh_seconds", return_value=1)
+    def test_client_not_refreshed_when_young(
+        self, _mock_refresh: MagicMock, mock_config: MagicMock
+    ) -> None:
+        """When refresh is enabled but client is young, cached client is returned."""
+        mock_config.new_client_from_config.return_value = MagicMock()
+        factory = _ThreadLocalClientFactory()
+        client1 = factory.get_client("ctx")
+        client2 = factory.get_client("ctx")
+        assert client1 is client2
+        mock_config.new_client_from_config.assert_called_once()
+
+    @patch("k8s_sandbox._kubernetes_api.config")
+    @patch("k8s_sandbox._kubernetes_api._get_client_refresh_seconds", return_value=1)
+    def test_current_context_client_refreshed(
+        self, _mock_refresh: MagicMock, mock_config: MagicMock
+    ) -> None:
+        """Current-context client (context_name=None) is also refreshed."""
+        Config._instance = Config(contexts=None, current_context=None, in_cluster=False)  # type: ignore[call-arg]
+        mock_api_client_1 = MagicMock()
+        mock_api_client_2 = MagicMock()
+        mock_config.new_client_from_config.side_effect = [
+            mock_api_client_1,
+            mock_api_client_2,
+        ]
+        factory = _ThreadLocalClientFactory()
+        client1 = factory.get_client(None)
+
+        factory._created_at[None] = time.monotonic() - 2
+
+        client2 = factory.get_client(None)
+        assert client1 is not client2
+        assert mock_config.new_client_from_config.call_count == 2
+        mock_api_client_1.close.assert_called_once()
+
+    @patch("k8s_sandbox._kubernetes_api.client")
+    @patch("k8s_sandbox._kubernetes_api.config")
+    @patch("k8s_sandbox._kubernetes_api._get_client_refresh_seconds", return_value=0)
+    def test_incluster_uses_default_client(
+        self, _mock_refresh: MagicMock, mock_config: MagicMock, mock_client: MagicMock
+    ) -> None:
+        """In-cluster mode uses client.CoreV1Api() (built-in token refresh)."""
+        Config._instance = Config(contexts=None, current_context=None, in_cluster=True)  # type: ignore[call-arg]
+        factory = _ThreadLocalClientFactory()
+        factory.get_client(None)
+        mock_client.CoreV1Api.assert_called_once_with()
+        mock_config.new_client_from_config.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds `INSPECT_K8S_CLIENT_REFRESH_SECONDS` env var to periodically re-create cached Kubernetes API clients, causing the `kubernetes` library to re-read rotated service account tokens from disk
- Disabled by default (unset or `0`). Set to e.g. `600` to refresh clients every 10 minutes.

## Context

The `kubernetes` Python library's `KubeConfigLoader` reads the token file once and caches it in memory forever. EKS 1.35 caps JWT lifetime at 24h (down from 365 days on 1.33). Long-running evals hit 401s when the cached token expires.

The fix adds a max-age mechanism to `_ThreadLocalClientFactory`. When a cached client exceeds the configured age, it is discarded (with `api_client.close()`) and a fresh one is created via `config.new_client_from_config()`, which re-reads the token file from disk.

In-cluster mode (`load_incluster_config`) is unaffected — it already has built-in 60s token refresh.

## Test plan

Tested on METR's infra.