### PR TITLE
feat: add INSPECT_K8S_DEFAULT_NAMESPACE env var override

### DIFF
--- a/docs/docs/tips/configuration.md
+++ b/docs/docs/tips/configuration.md
@@ -23,6 +23,19 @@ export INSPECT_HELM_LABELS="ci-branch=my-feature,run-id=42"
 ```
 
 
+## Default namespace override { #default-namespace }
+
+By default, the namespace for sandbox pods is determined from the kubeconfig context or
+the service account token mount (when running in-cluster). You can override this by
+setting the `INSPECT_K8S_DEFAULT_NAMESPACE` environment variable.
+
+```sh
+export INSPECT_K8S_DEFAULT_NAMESPACE=my-sandbox-namespace
+```
+
+When set, this takes precedence over both kubeconfig and in-cluster namespace resolution.
+
+
 ## Targeting specific or multiple kubeconfig contexts
 
 Your

--- a/src/k8s_sandbox/_kubernetes_api.py
+++ b/src/k8s_sandbox/_kubernetes_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import threading
 from pathlib import Path
 from typing import TypedDict, cast
@@ -51,6 +52,9 @@ def get_default_namespace(context_name: str | None) -> str:
 
     If the namespace is not specified, "default" is returned.
     """
+    env_namespace = os.environ.get("INSPECT_K8S_DEFAULT_NAMESPACE", "").strip()
+    if env_namespace:
+        return env_namespace
     instance = _Config.get_instance()
     if instance.in_cluster:
         try:

--- a/test/k8s_sandbox/test_kubernetes_api.py
+++ b/test/k8s_sandbox/test_kubernetes_api.py
@@ -176,3 +176,66 @@ class TestGetDefaultNamespace:
         namespace = get_default_namespace(context_name=None)
 
         assert namespace == "my-namespace"
+
+
+class TestInspectK8sDefaultNamespace:
+    """Tests for INSPECT_K8S_DEFAULT_NAMESPACE env var override."""
+
+    def test_env_var_overrides_incluster(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Env var takes precedence over in-cluster namespace."""
+        monkeypatch.setenv("INSPECT_K8S_DEFAULT_NAMESPACE", "sandbox-ns")
+        assert get_default_namespace(context_name=None) == "sandbox-ns"
+
+    @patch("k8s_sandbox._kubernetes_api.config")
+    def test_env_var_overrides_kubeconfig(
+        self, mock_config: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Env var takes precedence over kubeconfig context namespace."""
+        from kubernetes.config import ConfigException
+
+        typed_config = cast(_ConfigMock, mock_config)
+        typed_config.load_incluster_config.side_effect = ConfigException()
+        typed_config.load_kube_config.return_value = None
+        typed_config.list_kube_config_contexts.return_value = (
+            [{"name": "test", "context": {"namespace": "kubeconfig-ns"}}],
+            {"name": "test", "context": {"namespace": "kubeconfig-ns"}},
+        )
+        monkeypatch.setenv("INSPECT_K8S_DEFAULT_NAMESPACE", "override-ns")
+
+        assert get_default_namespace(context_name=None) == "override-ns"
+
+    @patch("k8s_sandbox._kubernetes_api.config")
+    def test_unset_falls_through(
+        self, mock_config: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When unset, existing behavior is preserved."""
+        from kubernetes.config import ConfigException
+
+        monkeypatch.delenv("INSPECT_K8S_DEFAULT_NAMESPACE", raising=False)
+        typed_config = cast(_ConfigMock, mock_config)
+        typed_config.load_incluster_config.side_effect = ConfigException()
+        typed_config.load_kube_config.return_value = None
+        typed_config.list_kube_config_contexts.return_value = (
+            [{"name": "test", "context": {"namespace": "kubeconfig-ns"}}],
+            {"name": "test", "context": {"namespace": "kubeconfig-ns"}},
+        )
+
+        assert get_default_namespace(context_name=None) == "kubeconfig-ns"
+
+    @patch("k8s_sandbox._kubernetes_api.config")
+    def test_empty_string_falls_through(
+        self, mock_config: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty string is treated as unset."""
+        from kubernetes.config import ConfigException
+
+        monkeypatch.setenv("INSPECT_K8S_DEFAULT_NAMESPACE", "")
+        typed_config = cast(_ConfigMock, mock_config)
+        typed_config.load_incluster_config.side_effect = ConfigException()
+        typed_config.load_kube_config.return_value = None
+        typed_config.list_kube_config_contexts.return_value = (
+            [{"name": "test", "context": {"namespace": "kubeconfig-ns"}}],
+            {"name": "test", "context": {"namespace": "kubeconfig-ns"}},
+        )
+
+        assert get_default_namespace(context_name=None) == "kubeconfig-ns"


### PR DESCRIPTION
## Summary

- Adds `INSPECT_K8S_DEFAULT_NAMESPACE` env var to override the default namespace for sandbox pod creation
- When set, takes precedence over both in-cluster (SA token mount) and kubeconfig namespace resolution
- When unset or empty, existing behavior is unchanged

## Test plan

Tested on METR's infra.