### PR TITLE
fix: create new AsyncRetrying instance per exec call to avoid concurrency bug

### DIFF
--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -78,15 +78,20 @@ _PERMANENT_TYPES = (
     TimeoutError,
 )
 
-_exec_retry = AsyncRetrying(
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=10),
-    retry=retry_if_exception(
-        lambda e: isinstance(e, _TRANSIENT_TYPES)
-        and not isinstance(e, _PERMANENT_TYPES)
-    ),
-    reraise=True,
-)
+
+def _exec_retry() -> AsyncRetrying:
+    # Must create a new instance per call: AsyncRetrying.__aiter__ returns
+    # `self` and mutates _retry_state, so a shared instance is not safe for
+    # concurrent use.
+    return AsyncRetrying(
+        stop=stop_after_attempt(5),
+        wait=wait_exponential_jitter(initial=1, max=10),
+        retry=retry_if_exception(
+            lambda e: isinstance(e, _TRANSIENT_TYPES)
+            and not isinstance(e, _PERMANENT_TYPES)
+        ),
+        reraise=True,
+    )
 
 
 @sandboxenv(name="k8s")
@@ -262,7 +267,7 @@ class K8sSandboxEnvironment(SandboxEnvironment):
         op = "K8s execute command in Pod"
         with self._log_op(op, expected_exceptions, **log_kwargs):
             await self._pod.check_for_pod_restart()
-            async for attempt in _exec_retry:
+            async for attempt in _exec_retry():
                 with attempt:
                     result = await self._pod.exec(
                         cmd, input, cwd, env or {}, user, timeout

--- a/test/k8s_sandbox/test_exec_retry.py
+++ b/test/k8s_sandbox/test_exec_retry.py
@@ -6,6 +6,7 @@ from inspect_ai.util import ExecResult, OutputLimitExceededError
 from kubernetes.client.exceptions import ApiException
 from tenacity import wait_none
 
+from k8s_sandbox import _sandbox_environment
 from k8s_sandbox._pod.error import (
     ExecutableNotFoundError,
     GetReturncodeError,
@@ -14,14 +15,20 @@ from k8s_sandbox._pod.error import (
 from k8s_sandbox._sandbox_environment import (
     K8sError,
     K8sSandboxEnvironment,
-    _exec_retry,
 )
 
 
 @pytest.fixture(autouse=True)
 def _no_retry_wait(monkeypatch: pytest.MonkeyPatch) -> None:
     """Disable tenacity's exponential backoff in tests."""
-    monkeypatch.setattr(_exec_retry, "wait", wait_none())
+    original = _sandbox_environment._exec_retry
+
+    def _fast_retry():
+        r = original()
+        r.wait = wait_none()
+        return r
+
+    monkeypatch.setattr(_sandbox_environment, "_exec_retry", _fast_retry)
 
 
 def _make_sandbox_with_mock_pod() -> tuple[K8sSandboxEnvironment, AsyncMock]:


### PR DESCRIPTION
## Summary

Got #176 load tested some more, and ran into this issue when running with high concurrency. Apparently Tenacity's retry configuration are not safe for concurrency!

### Details

- `_exec_retry` was a module-level `AsyncRetrying` singleton shared across all concurrent `exec()` calls
- tenacity's `AsyncRetrying.__aiter__` [returns `self`](https://github.com/jd/tenacity/blob/main/tenacity/asyncio/__init__.py) and overwrites `_retry_state` on each iteration, so concurrent coroutines corrupt each other's retry state
- This caused `UnboundLocalError: cannot access local variable 'result'` when one coroutine's retry loop ended prematurely due to another coroutine's state being read
- Fix: change `_exec_retry` from a singleton to a factory function that returns a fresh instance per call

See [tenacity#93](https://github.com/jd/tenacity/issues/93) — the maintainer confirms async retry state is per-instance, not per-call.