### PR TITLE
feat: retry transient errors in read_file and write_file

### DIFF
--- a/docs/docs/design/limitations.md
+++ b/docs/docs/design/limitations.md
@@ -151,6 +151,12 @@ chart](../helm/built-in-chart.md#dns). Or, if using a custom Helm chart, conside
 the `hostAliases` field in the Pod spec
 ([docs](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/)).
 
+## Transient errors are automatically retried
+
+Transient network or infrastructure errors during `exec()`, `read_file()`, and `write_file()` are automatically retried. These are typically caused by issues such as a node becoming unhealthy, a Pod being rescheduled, or the Kubernetes control plane being overloaded.
+
+Note that retries cannot guarantee idempotency — if a command partially executed before the error, it may run again on retry.
+
 ## Must run as root to use the `user` parameter in `exec()` { #exec-user }
 
 In Kubernetes, a container runs as a single user. The user can be specified in the

--- a/docs/docs/design/limitations.md
+++ b/docs/docs/design/limitations.md
@@ -151,26 +151,6 @@ chart](../helm/built-in-chart.md#dns). Or, if using a custom Helm chart, conside
 the `hostAliases` field in the Pod spec
 ([docs](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/)).
 
-## Transient network or infrastructure issues during `exec()` won't be retried
-
-The following exceptions have occasionally been observed during calls to `exec()`,
-`read_file()` or `write_file()`:
-
-* `WebSocketBadStatusException: pod does not exist` (re-raised as `ApiException`)
-* `WebSocketBadStatusException: container not found` (re-raised as `ApiException`)
-* `WebSocketBadStatusException: Handshake status 500 Internal Server Error` (re-raised
-  as `ApiException`)
-* `WebSocketConnectionClosedException: Connection to remote host was lost`
-* `SSLEOFError: EOF occurred in violation of protocol`
-
-These are likely due to transient network or infrastructure issues. For example, when a
-node becomes unhealthy and the Pod is rescheduled.
-
-The `k8s_sandbox` package will not retry the remote command execution when any of these
-(or other) exceptions are raised because it cannot assume that the command is idempotent
-and that the command did not at least start executing. This will result in that sample
-of the eval failing.
-
 ## Must run as root to use the `user` parameter in `exec()` { #exec-user }
 
 In Kubernetes, a container runs as a single user. The user can be specified in the

--- a/docs/docs/design/limitations.md
+++ b/docs/docs/design/limitations.md
@@ -153,7 +153,7 @@ the `hostAliases` field in the Pod spec
 
 ## Transient errors are automatically retried
 
-Transient network or infrastructure errors during `exec()`, `read_file()`, and `write_file()` are automatically retried. These are typically caused by issues such as a node becoming unhealthy, a Pod being rescheduled, or the Kubernetes control plane being overloaded.
+Transient network or infrastructure errors during `exec()`, `read_file()`, and `write_file()` are automatically retried (up to 5 times). These are typically caused by issues such as a node becoming unhealthy, a Pod being rescheduled, or the Kubernetes control plane being overloaded.
 
 Note that retries cannot guarantee idempotency — if a command partially executed before the error, it may run again on retry.
 

--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -81,7 +81,7 @@ _PERMANENT_TYPES = (
 )
 
 
-def _exec_retry() -> AsyncRetrying:
+def _retry() -> AsyncRetrying:
     # Must create a new instance per call: AsyncRetrying.__aiter__ returns
     # `self` and mutates _retry_state, so a shared instance is not safe for
     # concurrent use.
@@ -269,7 +269,7 @@ class K8sSandboxEnvironment(SandboxEnvironment):
         op = "K8s execute command in Pod"
         with self._log_op(op, expected_exceptions, **log_kwargs):
             await self._pod.check_for_pod_restart()
-            async for attempt in _exec_retry():
+            async for attempt in _retry():
                 with attempt:
                     result = await self._pod.exec(
                         cmd, input, cwd, env or {}, user, timeout
@@ -289,7 +289,7 @@ class K8sSandboxEnvironment(SandboxEnvironment):
             # Do not log these at error level or re-raise as enriched K8sError.
             expected_exceptions = (PermissionError, IsADirectoryError)
             with self._log_op("K8s write file to Pod", expected_exceptions, file=file):
-                async for attempt in _exec_retry:
+                async for attempt in _retry():
                     with attempt:
                         temp_file.seek(0)
                         await self._pod.write_file(temp_file.file, Path(file))
@@ -313,7 +313,7 @@ class K8sSandboxEnvironment(SandboxEnvironment):
                 OutputLimitExceededError,
             )
             with self._log_op("K8s read file from Pod", expected_exceptions, file=file):
-                async for attempt in _exec_retry:
+                async for attempt in _retry():
                     with attempt:
                         temp_file.seek(0)
                         temp_file.truncate()

--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -76,6 +76,8 @@ _PERMANENT_TYPES = (
     RuntimeError,
     PermissionError,
     TimeoutError,
+    FileNotFoundError,
+    IsADirectoryError,
 )
 
 _exec_retry = AsyncRetrying(
@@ -282,7 +284,10 @@ class K8sSandboxEnvironment(SandboxEnvironment):
             # Do not log these at error level or re-raise as enriched K8sError.
             expected_exceptions = (PermissionError, IsADirectoryError)
             with self._log_op("K8s write file to Pod", expected_exceptions, file=file):
-                await self._pod.write_file(temp_file.file, Path(file))
+                async for attempt in _exec_retry:
+                    with attempt:
+                        temp_file.seek(0)
+                        await self._pod.write_file(temp_file.file, Path(file))
 
     @overload
     async def read_file(self, file: str, text: Literal[True] = True) -> str: ...
@@ -303,7 +308,11 @@ class K8sSandboxEnvironment(SandboxEnvironment):
                 OutputLimitExceededError,
             )
             with self._log_op("K8s read file from Pod", expected_exceptions, file=file):
-                await self._pod.read_file(Path(file), temp_file)
+                async for attempt in _exec_retry:
+                    with attempt:
+                        temp_file.seek(0)
+                        temp_file.truncate()
+                        await self._pod.read_file(Path(file), temp_file)
                 temp_file.seek(0)
                 return (
                     temp_file.read() if not text else temp_file.read().decode("utf-8")

--- a/test/k8s_sandbox/test_exec_retry.py
+++ b/test/k8s_sandbox/test_exec_retry.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -24,25 +25,47 @@ def _no_retry_wait(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(_exec_retry, "wait", wait_none())
 
 
-def _make_sandbox_with_mock_pod() -> tuple[K8sSandboxEnvironment, AsyncMock]:
-    """Create a K8sSandboxEnvironment with a mocked _pod.exec.
+def _make_sandbox() -> tuple[K8sSandboxEnvironment, MagicMock]:
+    """Create a K8sSandboxEnvironment with mocked internals.
 
-    Returns the sandbox and the mock _pod.exec coroutine for configuring
-    side_effect and asserting call_count.
+    Returns the sandbox and the mock pod (MagicMock) so callers can assign
+    specific AsyncMock methods without mypy method-assign errors.
     """
     sandbox = object.__new__(K8sSandboxEnvironment)
-    sandbox._pod = MagicMock()
-    sandbox._pod.info = MagicMock()
-    sandbox._pod.info.name = "test-pod"
+    mock_pod = MagicMock()
+    sandbox._pod = mock_pod
+    mock_pod.info = MagicMock()
+    mock_pod.info.name = "test-pod"
     sandbox._config = MagicMock()
     sandbox._config.default_user = None
     sandbox.release = MagicMock()
     sandbox.release.task_name = "test-task"
+    mock_pod.check_for_pod_restart = AsyncMock()
+    return sandbox, mock_pod
 
-    sandbox._pod.check_for_pod_restart = AsyncMock()
+
+def _make_sandbox_with_mock_pod() -> tuple[K8sSandboxEnvironment, AsyncMock]:
+    """Create a K8sSandboxEnvironment with a mocked _pod.exec."""
+    sandbox, mock_pod = _make_sandbox()
     mock_exec = AsyncMock()
-    sandbox._pod.exec = mock_exec
+    mock_pod.exec = mock_exec
     return sandbox, mock_exec
+
+
+def _make_sandbox_with_mock_read() -> tuple[K8sSandboxEnvironment, AsyncMock]:
+    """Create a K8sSandboxEnvironment with a mocked _pod.read_file."""
+    sandbox, mock_pod = _make_sandbox()
+    mock_read = AsyncMock()
+    mock_pod.read_file = mock_read
+    return sandbox, mock_read
+
+
+def _make_sandbox_with_mock_write() -> tuple[K8sSandboxEnvironment, AsyncMock]:
+    """Create a K8sSandboxEnvironment with a mocked _pod.write_file."""
+    sandbox, mock_pod = _make_sandbox()
+    mock_write = AsyncMock()
+    mock_pod.write_file = mock_write
+    return sandbox, mock_write
 
 
 def _success_result() -> ExecResult[str]:
@@ -178,3 +201,160 @@ class TestExecRetryExhausted:
             await sandbox.exec(["echo", "hello"])
 
         assert mock_exec.call_count == 5
+
+
+# -- read_file retry tests --
+
+
+def _read_file_side_effect(error: Exception, content: bytes = b"file-content"):
+    """Return a side_effect that fails once then writes content to dst."""
+    calls = 0
+
+    async def impl(src: Path, dst):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise error
+        dst.write(content)
+
+    return impl
+
+
+class TestReadFileRetryTransient:
+    """Transient errors during read_file should be retried."""
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            pytest.param(
+                ApiException(status=503, reason="Service Unavailable"),
+                id="ApiException",
+            ),
+            pytest.param(
+                websocket.WebSocketConnectionClosedException("gone"),
+                id="WebSocketException",
+            ),
+            pytest.param(
+                ConnectionError("connection refused"),
+                id="ConnectionError",
+            ),
+            pytest.param(
+                PodError("WebSocket connection lost", pod="test-pod"),
+                id="PodError",
+            ),
+        ],
+    )
+    async def test_transient_error_is_retried(self, error: Exception) -> None:
+        sandbox, mock_read = _make_sandbox_with_mock_read()
+        mock_read.side_effect = _read_file_side_effect(error)
+
+        contents = await sandbox.read_file("/tmp/test.txt")
+
+        assert contents == "file-content"
+        assert mock_read.call_count == 2
+
+
+class TestReadFileRetryPermanent:
+    """Permanent errors during read_file should NOT be retried."""
+
+    async def test_permission_error_not_retried(self) -> None:
+        sandbox, mock_read = _make_sandbox_with_mock_read()
+        mock_read.side_effect = PermissionError("permission denied")
+
+        with pytest.raises(PermissionError):
+            await sandbox.read_file("/tmp/test.txt")
+
+        assert mock_read.call_count == 1
+
+    async def test_file_not_found_not_retried(self) -> None:
+        sandbox, mock_read = _make_sandbox_with_mock_read()
+        mock_read.side_effect = FileNotFoundError("no such file")
+
+        with pytest.raises(FileNotFoundError):
+            await sandbox.read_file("/tmp/test.txt")
+
+        assert mock_read.call_count == 1
+
+
+class TestReadFileRetryExhausted:
+    """After 5 failed attempts, read_file should propagate the error."""
+
+    async def test_retries_exhausted_raises_k8s_error(self) -> None:
+        sandbox, mock_read = _make_sandbox_with_mock_read()
+        mock_read.side_effect = ApiException(status=503, reason="Service Unavailable")
+
+        with pytest.raises(K8sError):
+            await sandbox.read_file("/tmp/test.txt")
+
+        assert mock_read.call_count == 5
+
+
+# -- write_file retry tests --
+
+
+class TestWriteFileRetryTransient:
+    """Transient errors during write_file should be retried."""
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            pytest.param(
+                ApiException(status=503, reason="Service Unavailable"),
+                id="ApiException",
+            ),
+            pytest.param(
+                websocket.WebSocketConnectionClosedException("gone"),
+                id="WebSocketException",
+            ),
+            pytest.param(
+                ConnectionError("connection refused"),
+                id="ConnectionError",
+            ),
+            pytest.param(
+                PodError("WebSocket connection lost", pod="test-pod"),
+                id="PodError",
+            ),
+        ],
+    )
+    async def test_transient_error_is_retried(self, error: Exception) -> None:
+        sandbox, mock_write = _make_sandbox_with_mock_write()
+        mock_write.side_effect = [error, None]
+
+        await sandbox.write_file("/tmp/test.txt", "hello")
+
+        assert mock_write.call_count == 2
+
+
+class TestWriteFileRetryPermanent:
+    """Permanent errors during write_file should NOT be retried."""
+
+    async def test_permission_error_not_retried(self) -> None:
+        sandbox, mock_write = _make_sandbox_with_mock_write()
+        mock_write.side_effect = PermissionError("permission denied")
+
+        with pytest.raises(PermissionError):
+            await sandbox.write_file("/tmp/test.txt", "hello")
+
+        assert mock_write.call_count == 1
+
+    async def test_is_a_directory_not_retried(self) -> None:
+        sandbox, mock_write = _make_sandbox_with_mock_write()
+        mock_write.side_effect = IsADirectoryError("is a directory")
+
+        with pytest.raises(IsADirectoryError):
+            await sandbox.write_file("/tmp/test.txt", "hello")
+
+        assert mock_write.call_count == 1
+
+
+class TestWriteFileRetryExhausted:
+    """After 5 failed attempts, write_file should propagate the error."""
+
+    async def test_retries_exhausted_raises_k8s_error(self) -> None:
+        sandbox, mock_write = _make_sandbox_with_mock_write()
+        mock_write.side_effect = ApiException(status=503, reason="Service Unavailable")
+
+        with pytest.raises(K8sError):
+            await sandbox.write_file("/tmp/test.txt", "hello")
+
+        assert mock_write.call_count == 5

--- a/test/k8s_sandbox/test_exec_retry.py
+++ b/test/k8s_sandbox/test_exec_retry.py
@@ -22,14 +22,14 @@ from k8s_sandbox._sandbox_environment import (
 @pytest.fixture(autouse=True)
 def _no_retry_wait(monkeypatch: pytest.MonkeyPatch) -> None:
     """Disable tenacity's exponential backoff in tests."""
-    original = _sandbox_environment._exec_retry
+    original = _sandbox_environment._retry
 
     def _fast_retry():
         r = original()
         r.wait = wait_none()
         return r
 
-    monkeypatch.setattr(_sandbox_environment, "_exec_retry", _fast_retry)
+    monkeypatch.setattr(_sandbox_environment, "_retry", _fast_retry)
 
 
 def _make_sandbox() -> tuple[K8sSandboxEnvironment, MagicMock]:


### PR DESCRIPTION
## Summary
- Extends exec() retry logic (tenacity, 5 attempts, exponential jitter backoff 1-10s) to `read_file()` and `write_file()`
- Temp file is seeked/truncated between retry attempts so retries start fresh
- Adds `FileNotFoundError` and `IsADirectoryError` to permanent (non-retried) error types — both are `OSError` subclasses that would otherwise match the transient `OSError` catch
- Removes the outdated "exec not retried" section from `limitations.md`

## Test plan
- [x] 28 unit tests pass (`test/k8s_sandbox/test_exec_retry.py`) — 14 existing exec tests + 14 new read/write tests
- [x] E2e diagnostic (see #181) confirmed: FAIL without retry on parent branch, PASS with retry on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)