### PR TITLE
Prepare release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 - Prefer kubeconfig over in-cluster config to preserve the configured namespace
 - Configurable K8s client token refresh
 - Add `INSPECT_K8S_DEFAULT_NAMESPACE` env var to override the default namespace
-- Pass comma-separated `key=value` labels from env var `INSPECT_HELM_LABELS` to `helm install --labels`
-- Log a warning when no GPU node is available during `helm install`, so users know the wait is expected rather than a hang
 - Use `--wait=legacy` with Helm 4.x to avoid kstatus treating unscheduled pods as permanently failed
+- Log a warning when no GPU node is available during `helm install`, so users know the wait is expected rather than a hang
+- Pass comma-separated `key=value` labels from env var `INSPECT_HELM_LABELS` to `helm install --labels`
 
 ## 2026-03-04 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,12 @@
 
 ## 2026-05-07 0.5.0
 
-- Retry transient errors in `read_file` and `write_file`
+- Fixes for transient errors in sandbox operations
 - Prefer kubeconfig over in-cluster config to preserve the configured namespace
 - Configurable K8s client token refresh
 - Add `INSPECT_K8S_DEFAULT_NAMESPACE` env var to override the default namespace
-- Retry transient K8s API errors in `exec()`
 - Add `INSPECT_HELM_LABELS` env var to apply `key=value` labels to Helm releases
-- Catch `BrokenPipeError`/`ConnectionResetError` when streaming exec output
 - Warn when `helm install` is waiting on GPU node provisioning, so users know it's not a hang
-- Send WebSocket keepalive frames during `exec()` to prevent idle-timeout disconnects
 - Use `--wait=legacy` with Helm 4.x (avoids kstatus treating unscheduled pods as permanently failed)
 
 ## 2026-03-04 0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
-## Unreleased
+## 2026-05-07 0.5.0
 
-- Use `--wait=legacy` with Helm 4.x to avoid kstatus treating unscheduled pods as permanently failed
-- Log a warning when no GPU node is available during `helm install`, so users know the wait is expected rather than a hang
-- Pass comma-separated `key=value` labels from env var `INSPECT_HELM_LABELS` to `helm install --labels`
+- Use `--wait=legacy` with Helm 4.x (avoids kstatus treating unscheduled pods as permanently failed)
+- Warn when `helm install` is waiting on GPU node provisioning, so users know it's not a hang
+- Add `INSPECT_HELM_LABELS` env var to apply `key=value` labels to Helm releases
+- Send WebSocket keepalive frames during `exec()` to prevent idle-timeout disconnects
+- Catch `BrokenPipeError`/`ConnectionResetError` when streaming exec output
+- Retry transient K8s API errors in `exec()`
+- Retry transient errors in `read_file` and `write_file`
+- Add `INSPECT_K8S_DEFAULT_NAMESPACE` env var to override the default namespace
+- Configurable K8s client token refresh
+- Prefer kubeconfig over in-cluster config to preserve the configured namespace
 
 ## 2026-03-04 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,16 @@
 
 ## 2026-05-07 0.5.0
 
-- Use `--wait=legacy` with Helm 4.x (avoids kstatus treating unscheduled pods as permanently failed)
-- Warn when `helm install` is waiting on GPU node provisioning, so users know it's not a hang
-- Add `INSPECT_HELM_LABELS` env var to apply `key=value` labels to Helm releases
-- Send WebSocket keepalive frames during `exec()` to prevent idle-timeout disconnects
-- Catch `BrokenPipeError`/`ConnectionResetError` when streaming exec output
-- Retry transient K8s API errors in `exec()`
 - Retry transient errors in `read_file` and `write_file`
-- Add `INSPECT_K8S_DEFAULT_NAMESPACE` env var to override the default namespace
-- Configurable K8s client token refresh
 - Prefer kubeconfig over in-cluster config to preserve the configured namespace
+- Configurable K8s client token refresh
+- Add `INSPECT_K8S_DEFAULT_NAMESPACE` env var to override the default namespace
+- Retry transient K8s API errors in `exec()`
+- Add `INSPECT_HELM_LABELS` env var to apply `key=value` labels to Helm releases
+- Catch `BrokenPipeError`/`ConnectionResetError` when streaming exec output
+- Warn when `helm install` is waiting on GPU node provisioning, so users know it's not a hang
+- Send WebSocket keepalive frames during `exec()` to prevent idle-timeout disconnects
+- Use `--wait=legacy` with Helm 4.x (avoids kstatus treating unscheduled pods as permanently failed)
 
 ## 2026-03-04 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 - Prefer kubeconfig over in-cluster config to preserve the configured namespace
 - Configurable K8s client token refresh
 - Add `INSPECT_K8S_DEFAULT_NAMESPACE` env var to override the default namespace
-- Add `INSPECT_HELM_LABELS` env var to apply `key=value` labels to Helm releases
-- Warn when `helm install` is waiting on GPU node provisioning, so users know it's not a hang
-- Use `--wait=legacy` with Helm 4.x (avoids kstatus treating unscheduled pods as permanently failed)
+- Pass comma-separated `key=value` labels from env var `INSPECT_HELM_LABELS` to `helm install --labels`
+- Log a warning when no GPU node is available during `helm install`, so users know the wait is expected rather than a hang
+- Use `--wait=legacy` with Helm 4.x to avoid kstatus treating unscheduled pods as permanently failed
 
 ## 2026-03-04 0.4.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inspect-k8s-sandbox"
-version = "0.4.1"
+version = "0.5.0"
 description = "A Kubernetes Sandbox Environment for Inspect"
 authors = [{name = "UK AI Security Institute"}]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -839,7 +839,7 @@ wheels = [
 
 [[package]]
 name = "inspect-k8s-sandbox"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "inspect-ai" },


### PR DESCRIPTION
Bumps version 0.4.1 → 0.5.0 and rolls up the changelog for the 13 commits merged since v0.4.0 (2026-03-04).