### PR TITLE
Don't raise runuser error when user command writes to stderr

### DIFF
--- a/src/k8s_sandbox/_pod/execute.py
+++ b/src/k8s_sandbox/_pod/execute.py
@@ -116,7 +116,7 @@ class ExecuteOperation(PodOperation):
     def _handle_shell_output(
         self, ws_client: WSClient, user: str | None, timeout: int | None
     ) -> ExecResult[str]:
-        def stream_output() -> ExecResult[str]:
+        def stream_output() -> tuple[ExecResult[str], bool]:
             stdout = LimitedBuffer(limits.MAX_EXEC_OUTPUT_SIZE)
             stderr = LimitedBuffer(limits.MAX_EXEC_OUTPUT_SIZE)
             returncode: int | None = None
@@ -151,17 +151,21 @@ class ExecuteOperation(PodOperation):
                         "WebSocket connection lost during exec",
                         pod=self._pod.name,
                     ) from e
+            saw_completed_sentinel = returncode is not None
             # returncode won't be set if setup commands e.g. `cd` failed.
             if returncode is None:
                 returncode = get_returncode(ws_client)
-            return ExecResult(
-                success=returncode == 0,
-                returncode=returncode,
-                stdout=str(stdout),
-                stderr=str(stderr),
+            return (
+                ExecResult(
+                    success=returncode == 0,
+                    returncode=returncode,
+                    stdout=str(stdout),
+                    stderr=str(stderr),
+                ),
+                saw_completed_sentinel,
             )
 
-        result = stream_output()
+        result, saw_completed_sentinel = stream_output()
         # 124 is the exit code for the `timeout` command.
         if timeout is not None and result.returncode == 124:
             raise TimeoutError(f"Command timed out after {timeout}s. {result}")
@@ -169,9 +173,10 @@ class ExecuteOperation(PodOperation):
         # PermissionError for exit code 126 and stderr containing "permission denied".
         if result.returncode == 126 and "permission denied" in result.stderr.casefold():
             raise PermissionError(f"Permission denied executing command. {result}")
-        # Only parse runuser errors if the user parameter was set. Don't raise errors if
-        # the user-supplied command happened to use `runuser` itself.
-        if result.returncode != 0 and user is not None:
+        # Only parse runuser errors if the wrapper failed before it could run the
+        # shell script and write our sentinel. If the sentinel was seen, any runuser
+        # stderr came from the user-supplied command.
+        if result.returncode != 0 and user is not None and not saw_completed_sentinel:
             self._check_for_runuser_error(result.stderr, user)
         return result
 

--- a/test/k8s_sandbox/pod/test_execute.py
+++ b/test/k8s_sandbox/pod/test_execute.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from kubernetes.stream.ws_client import WSClient  # type: ignore
@@ -157,11 +157,67 @@ class TestBrokenPipeWithoutSentinel:
         with pytest.raises(PodError, match="WebSocket connection lost"):
             executor._handle_shell_output(ws, user=None, timeout=None)
 
+
+class TestRunuserErrors:
+    def test_user_command_runuser_error_with_sentinel_returns_result(self) -> None:
+        ws = _make_ws_client(
+            stdout_frames=[b"<completed-sentinel-value-1>"],
+            stderr_frames=[b"runuser: user foo does not exist\n"],
+        )
+
+        executor = ExecuteOperation(MagicMock())
+        result = executor._handle_shell_output(ws, user="nobody", timeout=None)
+
+        assert result.returncode == 1
+        assert result.stderr == "runuser: user foo does not exist\n"
+
+    def test_wrapper_runuser_error_without_sentinel_raises(self) -> None:
+        ws = MagicMock(spec=WSClient)
+        current_stderr: bytes | None = None
+
+        ws.is_open.side_effect = [True, False]
+        ws.close.return_value = None
+
+        def update(timeout: float | None = None) -> None:
+            nonlocal current_stderr
+            current_stderr = b"runuser: user foo does not exist\n"
+
+        def peek_stderr(**kwargs: object) -> bytes:
+            return current_stderr or b""
+
+        def read_stderr(**kwargs: object) -> bytes:
+            nonlocal current_stderr
+            data = current_stderr or b""
+            current_stderr = None
+            return data
+
+        ws.update.side_effect = update
+        ws.peek_stderr.side_effect = peek_stderr
+        ws.read_stderr.side_effect = read_stderr
+        ws.peek_stdout.return_value = b""
+
+        with patch("k8s_sandbox._pod.execute.get_returncode", return_value=1):
+            executor = ExecuteOperation(MagicMock())
+            with pytest.raises(RuntimeError, match="does not appear to exist"):
+                executor._handle_shell_output(ws, user="foo", timeout=None)
+
+    def test_non_runuser_error_without_sentinel_returns_result(self) -> None:
+        ws = MagicMock(spec=WSClient)
+        ws.is_open.return_value = False
+
+        executor = ExecuteOperation(MagicMock())
+        with patch("k8s_sandbox._pod.execute.get_returncode", return_value=1):
+            result = executor._handle_shell_output(ws, user="foo", timeout=None)
+
+        assert result.returncode == 1
+
+
+class TestConnectionResetWithoutSentinel:
     def test_connection_reset_without_sentinel_raises(self) -> None:
         """ConnectionReset before sentinel → PodError."""
-        ws = self._make_dead_ws(
-            ConnectionResetError("connection reset"),
-        )
+        ws = MagicMock(spec=WSClient)
+        ws.is_open.return_value = True
+        ws.update.side_effect = ConnectionResetError("connection reset")
 
         executor = ExecuteOperation(MagicMock())
         with pytest.raises(PodError, match="WebSocket connection lost"):


### PR DESCRIPTION
## Summary

Slack thread: https://inspectcommunity.slack.com/archives/C0805HJTK8U/p1778142484642579

When `exec()` is called with a `user=` parameter, the wrapper script runs the user's command via `runuser`. Afterwards, `_handle_shell_output` scans stderr for `runuser: user X does not exist` / `may not be used by non-root users` and converts those into descriptive `RuntimeError`s pointing at the docs.

This check ran on any non-zero exit, so a user-supplied command that happened to write one of those substrings to stderr, or that invoked `runuser` itself, was misreported as a configuration error rather than surfacing the command's actual failure.

The fix tracks whether the wrapper's completed-sentinel was observed on stdout. If it was, the `runuser` invocation succeeded and any stderr is from the user command, so we skip the parse. If it wasn't, the wrapper failed before the user command ran, and the existing translation is still useful.