### PR TITLE
Recover from pod replacement instead of looping on stale UID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Raise typed `PodReplacedError` / `ContainerRestartedError` (instead of `RuntimeError`) when a pod operation detects the pod has been replaced or its container restarted, and refresh the cached pod identity so subsequent operations target the new pod instead of looping against a stale UID. `restarted_container_behavior="warn"` now also refreshes (previously left the cached UID stale).
+
 ## 2026-05-07 0.5.0
 
 - Fixes for transient errors in sandbox operations

--- a/src/k8s_sandbox/__init__.py
+++ b/src/k8s_sandbox/__init__.py
@@ -2,15 +2,21 @@
 
 from k8s_sandbox._pod import GetReturncodeError, PodError
 from k8s_sandbox._sandbox_environment import (
-    K8sError,
     K8sSandboxEnvironment,
     K8sSandboxEnvironmentConfig,
 )
+from k8s_sandbox.error import (
+    ContainerRestartedError,
+    K8sError,
+    PodReplacedError,
+)
 
 __all__ = [
+    "ContainerRestartedError",
     "GetReturncodeError",
-    "PodError",
     "K8sError",
     "K8sSandboxEnvironment",
     "K8sSandboxEnvironmentConfig",
+    "PodError",
+    "PodReplacedError",
 ]

--- a/src/k8s_sandbox/_pod/op.py
+++ b/src/k8s_sandbox/_pod/op.py
@@ -152,7 +152,11 @@ def check_for_pod_restart(pod: PodInfo) -> None:
             new_uid=k8s_pod.metadata.uid,
             new_restart_count=new_restart_count,
         )
-    assert k8s_pod.status.container_statuses is not None
+    if k8s_pod.status.container_statuses is None:
+        # Kubelet hasn't published container statuses yet (briefly possible
+        # right after pod scheduling). Nothing to compare against — skip the
+        # restart-count check rather than asserting.
+        return
     status = next(
         (
             container_status

--- a/src/k8s_sandbox/_pod/op.py
+++ b/src/k8s_sandbox/_pod/op.py
@@ -9,6 +9,7 @@ from kubernetes.stream import stream  # type: ignore
 from kubernetes.stream.ws_client import RESIZE_CHANNEL, WSClient  # type: ignore
 
 from k8s_sandbox._kubernetes_api import k8s_client
+from k8s_sandbox.error import ContainerRestartedError, PodReplacedError
 
 # The duration to wait for an initial response from the k8s API server.
 # The initial response is received before the command is necessarily complete, so
@@ -118,25 +119,39 @@ class PodOperation(ABC):
             return
         ws_client._all = _IgnoredIO()
 
-    def _check_for_pod_restart(self):
-        check_for_pod_restart(self._pod)
-
 
 def check_for_pod_restart(pod: PodInfo) -> None:
-    """Check if the pod has been replaced or its container has restarted."""
+    """Check whether the pod has been replaced or its container has restarted.
+
+    Always raises a typed exception when a change is detected; callers
+    (typically ``Pod._check_for_pod_restart_sync``) are responsible for
+    applying the ``restarted_container_behavior`` policy and refreshing any
+    cached identity.
+
+    Raises:
+        PodReplacedError: the pod's UID has changed since ``pod.uid``.
+        ContainerRestartedError: the default container's restart count has
+            increased since ``pod.initial_restart_count``.
+        RuntimeError: the named container is no longer present on the pod
+            (treated as a permanent misconfiguration).
+    """
     api = k8s_client(pod.context_name)
     k8s_pod = api.read_namespaced_pod(name=pod.name, namespace=pod.namespace)
     assert k8s_pod.metadata is not None
+    assert k8s_pod.metadata.uid is not None
     assert k8s_pod.status is not None
     if k8s_pod.metadata.uid != pod.uid:
-        message = (
-            f"Pod UID mismatch: expected {pod.uid}, got {k8s_pod.metadata.uid} "
-            f"for {k8s_pod.metadata.name}"
+        # Capture the new pod's restart count for the default container so the
+        # caller can refresh its full cached identity atomically.
+        new_restart_count = _restart_count_for(
+            k8s_pod.status.container_statuses, pod.default_container_name
         )
-        if pod.restarted_container_behavior == "warn":
-            logger.warning(message)
-        else:
-            raise RuntimeError(message)
+        raise PodReplacedError(
+            pod_name=pod.name,
+            old_uid=pod.uid,
+            new_uid=k8s_pod.metadata.uid,
+            new_restart_count=new_restart_count,
+        )
     assert k8s_pod.status.container_statuses is not None
     status = next(
         (
@@ -147,28 +162,34 @@ def check_for_pod_restart(pod: PodInfo) -> None:
         None,
     )
     if status is None:
-        message = (
+        raise RuntimeError(
             f"Pod '{k8s_pod.metadata.name}' does not have a container named "
             f"'{pod.default_container_name}'"
         )
-        if pod.restarted_container_behavior == "warn":
-            logger.warning(message)
-            return
-        else:
-            raise RuntimeError(message)
     if status.restart_count > pod.initial_restart_count:
         last_state = status.last_state
         terminated = last_state.terminated if last_state else None
-        last_reason = terminated.reason if terminated else "unknown"
-        message = (
-            f"Container '{status.name}' in pod '{k8s_pod.metadata.name}' has restarted "
-            f"{status.restart_count} time(s) (last reason: {last_reason}); "
-            "pod state is no longer guaranteed."
+        last_reason = (
+            terminated.reason if terminated and terminated.reason else "unknown"
         )
-        if pod.restarted_container_behavior == "warn":
-            logger.warning(message)
-        else:
-            raise RuntimeError(message)
+        raise ContainerRestartedError(
+            pod_name=pod.name,
+            container_name=status.name,
+            restart_count=status.restart_count,
+            last_reason=last_reason,
+        )
+
+
+def _restart_count_for(
+    container_statuses, container_name: str
+) -> int:
+    if not container_statuses:
+        return 0
+    status = next(
+        (cs for cs in container_statuses if cs.name == container_name),
+        None,
+    )
+    return status.restart_count if status is not None else 0
 
 
 def _send_keepalive(ws_client: WSClient, stop: threading.Event) -> None:

--- a/src/k8s_sandbox/_pod/pod.py
+++ b/src/k8s_sandbox/_pod/pod.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import dataclasses
+import logging
 from pathlib import Path
 from typing import IO, Callable, Literal, TypeVar
 
@@ -10,8 +12,11 @@ from k8s_sandbox._pod.executor import PodOpExecutor
 from k8s_sandbox._pod.op import PodInfo, check_for_pod_restart
 from k8s_sandbox._pod.read import ReadFileOperation
 from k8s_sandbox._pod.write import WriteFileOperation
+from k8s_sandbox.error import ContainerRestartedError, PodReplacedError
 
 T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
 
 
 class Pod:
@@ -25,7 +30,7 @@ class Pod:
         initial_restart_count: int,
         restarted_container_behavior: Literal["warn", "raise"],
     ) -> None:
-        self.info = PodInfo(
+        self._info = PodInfo(
             name,
             namespace,
             context_name,
@@ -35,9 +40,52 @@ class Pod:
             restarted_container_behavior,
         )
 
+    @property
+    def info(self) -> PodInfo:
+        """The current cached pod identity.
+
+        Note that ``uid`` and ``initial_restart_count`` may be replaced by
+        ``check_for_pod_restart`` if a replacement or restart is observed.
+        """
+        return self._info
+
     async def check_for_pod_restart(self) -> None:
-        """Check if the pod has been replaced or its container has restarted."""
-        await self._run_async(lambda: check_for_pod_restart(self.info))
+        """Check whether the pod has been replaced or its container has restarted.
+
+        On detection, refreshes the cached identity (``uid`` and/or
+        ``initial_restart_count``) so subsequent operations target the new pod
+        without re-raising the same condition. Whether the detection raises is
+        governed by ``restarted_container_behavior``:
+
+        - ``"warn"``: log a warning and return normally.
+        - ``"raise"``: raise ``PodReplacedError`` or ``ContainerRestartedError``.
+        """
+        await self._run_async(self._check_for_pod_restart_sync)
+
+    def _check_for_pod_restart_sync(self) -> None:
+        try:
+            check_for_pod_restart(self._info)
+        except PodReplacedError as e:
+            # Refresh cached identity atomically (frozen dataclass replacement
+            # is an attribute assignment, which is atomic in CPython).
+            self._info = dataclasses.replace(
+                self._info,
+                uid=e.new_uid,
+                initial_restart_count=e.new_restart_count,
+            )
+            if self._info.restarted_container_behavior == "warn":
+                logger.warning(str(e))
+                return
+            raise
+        except ContainerRestartedError as e:
+            self._info = dataclasses.replace(
+                self._info,
+                initial_restart_count=e.restart_count,
+            )
+            if self._info.restarted_container_behavior == "warn":
+                logger.warning(str(e))
+                return
+            raise
 
     async def exec(
         self,
@@ -92,7 +140,8 @@ class Pod:
             elapsed. This is enforced by the `timeout` command on the pod. This will not
             terminate background processes started by cmd.
         """
-        executor = ExecuteOperation(self.info)
+        await self.check_for_pod_restart()
+        executor = ExecuteOperation(self._info)
         result = await self._run_async(
             lambda: executor.exec(cmd, stdin, cwd, env, user, timeout)
         )
@@ -114,7 +163,8 @@ class Pod:
           dst (Path): The path to write the file to on the pod. Relative paths will be
             resolved relative to the pod's default working directory.
         """
-        writer = WriteFileOperation(self.info)
+        await self.check_for_pod_restart()
+        writer = WriteFileOperation(self._info)
         await self._run_async(lambda: writer.write_file(src, dst))
 
     async def read_file(self, src: Path, dst: IO[bytes]) -> None:
@@ -129,7 +179,8 @@ class Pod:
             relative to the pod's default working directory.
           dst (IO[bytes]): A file-like object to write the file to on the client system.
         """
-        reader = ReadFileOperation(self.info)
+        await self.check_for_pod_restart()
+        reader = ReadFileOperation(self._info)
         await self._run_async(lambda: reader.read_file(src, dst))
 
     async def _run_async(self, callable: Callable[[], T]) -> T:

--- a/src/k8s_sandbox/_pod/read.py
+++ b/src/k8s_sandbox/_pod/read.py
@@ -17,7 +17,6 @@ from k8s_sandbox._pod.op import (
 
 class ReadFileOperation(PodOperation):
     def read_file(self, src: Path, dst: IO[bytes]) -> None:
-        self._check_for_pod_restart()
         with self._start_read_command(src) as ws_client:
             self._handle_stream_output(ws_client, dst)
 

--- a/src/k8s_sandbox/_pod/write.py
+++ b/src/k8s_sandbox/_pod/write.py
@@ -16,7 +16,6 @@ from k8s_sandbox._pod.op import (
 
 class WriteFileOperation(PodOperation):
     def write_file(self, src: IO[bytes], dst: Path) -> None:
-        self._check_for_pod_restart()
         file_size = self._get_file_size(src)
         with self._start_write_command(dst, file_size) as ws_client:
             self._write_data_to_stdin(ws_client, src)

--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -34,7 +34,6 @@ from k8s_sandbox._helm import (
 )
 from k8s_sandbox._kubernetes_api import validate_context_name
 from k8s_sandbox._logger import (
-    format_log_message,
     inspect_trace_action,
     log_error,
     log_trace,
@@ -55,6 +54,15 @@ from k8s_sandbox.compose._compose import (
     is_docker_compose_file,
     parse_docker_config,
 )
+from k8s_sandbox.error import (
+    ContainerRestartedError,
+    K8sError,
+    PodReplacedError,
+)
+
+# Re-exported for backwards compatibility with callers that import K8sError
+# from this module.
+__all__ = ["K8sError", "PodReplacedError", "ContainerRestartedError"]
 
 MIN_DESIRED_SOFT = 100000
 
@@ -257,18 +265,22 @@ class K8sSandboxEnvironment(SandboxEnvironment):
     ) -> ExecResult[str]:
         log_kwargs = dict(cmd=cmd, stdin=input, cwd=cwd, env=env, timeout=timeout)
         # Do not log these at error level or re-raise as enriched K8sError.
+        # PodReplacedError / ContainerRestartedError are self-describing typed
+        # exceptions; let them propagate to callers (e.g. agent-side handlers)
+        # without being wrapped as opaque K8sErrors.
         expected_exceptions = (
             TimeoutError,
             UnicodeDecodeError,
             PermissionError,
             OutputLimitExceededError,
+            PodReplacedError,
+            ContainerRestartedError,
         )
         if user is None:
             user = self._config.default_user
 
         op = "K8s execute command in Pod"
         with self._log_op(op, expected_exceptions, **log_kwargs):
-            await self._pod.check_for_pod_restart()
             async for attempt in _retry():
                 with attempt:
                     result = await self._pod.exec(
@@ -287,7 +299,12 @@ class K8sSandboxEnvironment(SandboxEnvironment):
                 temp_file.write(contents)
             temp_file.seek(0)
             # Do not log these at error level or re-raise as enriched K8sError.
-            expected_exceptions = (PermissionError, IsADirectoryError)
+            expected_exceptions = (
+                PermissionError,
+                IsADirectoryError,
+                PodReplacedError,
+                ContainerRestartedError,
+            )
             with self._log_op("K8s write file to Pod", expected_exceptions, file=file):
                 async for attempt in _retry():
                     with attempt:
@@ -311,6 +328,8 @@ class K8sSandboxEnvironment(SandboxEnvironment):
                 PermissionError,
                 IsADirectoryError,
                 OutputLimitExceededError,
+                PodReplacedError,
+                ContainerRestartedError,
             )
             with self._log_op("K8s read file from Pod", expected_exceptions, file=file):
                 async for attempt in _retry():
@@ -421,16 +440,6 @@ class K8sSandboxEnvironmentConfig(BaseModel, frozen=True):
     restarted_container_behavior: Literal["warn", "raise"] = "warn"
     max_pod_ops: int | None = None
     """Maximum number of concurrent pod operations. Defaults to cpu_count * 4."""
-
-
-class K8sError(Exception):
-    """An error that occurred during a Kubernetes operation.
-
-    This will typically cause the eval to fail.
-    """
-
-    def __init__(self, message: str, **kwargs: Any):
-        super().__init__(format_log_message(message, **kwargs))
 
 
 def _key_to_pascal(key: str) -> str:

--- a/src/k8s_sandbox/error.py
+++ b/src/k8s_sandbox/error.py
@@ -1,0 +1,90 @@
+"""Exception types raised by k8s_sandbox operations."""
+
+from typing import Any
+
+from k8s_sandbox._logger import format_log_message
+
+
+class K8sError(Exception):
+    """An error that occurred during a Kubernetes operation.
+
+    This will typically cause the eval to fail.
+    """
+
+    def __init__(self, message: str, **kwargs: Any):  # noqa: D107
+        super().__init__(format_log_message(message, **kwargs))
+
+
+class PodReplacedError(K8sError):
+    """The pod's UID has changed since it was first observed.
+
+    Typically caused by eviction (e.g. node disk/memory pressure, OOM) followed
+    by the controlling workload (StatefulSet/Deployment) recreating the pod
+    with the same name but a fresh UID. The previous pod is gone, along with
+    any state held in its filesystem or memory that did not reside on a
+    persistent volume.
+
+    The sandbox provider refreshes its cached pod identity when this is
+    raised, so subsequent operations target the new pod and will not re-raise
+    ``PodReplacedError`` unless yet another replacement occurs.
+    """
+
+    def __init__(  # noqa: D107
+        self,
+        *,
+        pod_name: str,
+        old_uid: str,
+        new_uid: str,
+        new_restart_count: int,
+        **kwargs: Any,
+    ):
+        self.pod_name = pod_name
+        self.old_uid = old_uid
+        self.new_uid = new_uid
+        self.new_restart_count = new_restart_count
+        super().__init__(
+            f"Pod '{pod_name}' has been replaced "
+            f"(old UID {old_uid}, new UID {new_uid})",
+            pod=pod_name,
+            old_uid=old_uid,
+            new_uid=new_uid,
+            **kwargs,
+        )
+
+
+class ContainerRestartedError(K8sError):
+    """A container in the pod has restarted since the pod was first observed.
+
+    The pod itself is the same (same UID), but the container's process was
+    restarted (OOM, crash, liveness probe failure, etc.). Files on disk
+    survive; in-memory state and any background processes started by the agent
+    do not.
+
+    The sandbox provider refreshes its cached restart count when this is
+    raised, so subsequent operations will not re-raise
+    ``ContainerRestartedError`` unless a further restart occurs.
+    """
+
+    def __init__(  # noqa: D107
+        self,
+        *,
+        pod_name: str,
+        container_name: str,
+        restart_count: int,
+        last_reason: str,
+        **kwargs: Any,
+    ):
+        self.pod_name = pod_name
+        self.container_name = container_name
+        self.restart_count = restart_count
+        self.last_reason = last_reason
+        super().__init__(
+            f"Container '{container_name}' in pod '{pod_name}' has restarted "
+            f"{restart_count} time(s) (last reason: {last_reason}); "
+            "in-memory pod state is no longer guaranteed",
+            pod=pod_name,
+            container=container_name,
+            restart_count=restart_count,
+            last_reason=last_reason,
+            **kwargs,
+        )

--- a/test/k8s_sandbox/pod/test_check_for_pod_restart.py
+++ b/test/k8s_sandbox/pod/test_check_for_pod_restart.py
@@ -40,6 +40,18 @@ def test_no_change_does_not_raise():
         check_for_pod_restart(_pod_info())
 
 
+def test_missing_container_statuses_skips_restart_check():
+    # Briefly possible right after pod scheduling: same UID but kubelet
+    # hasn't published container_statuses yet. Must not assert.
+    pod = MagicMock()
+    pod.metadata.uid = "uid-1"
+    pod.metadata.name = "agent-env-abc-default-0"
+    pod.status.container_statuses = None
+    with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
+        mock_client.return_value.read_namespaced_pod.return_value = pod
+        check_for_pod_restart(_pod_info(uid="uid-1"))
+
+
 def test_pod_replaced_raises_typed_with_new_restart_count():
     with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
         mock_client.return_value.read_namespaced_pod.return_value = _k8s_pod(

--- a/test/k8s_sandbox/pod/test_check_for_pod_restart.py
+++ b/test/k8s_sandbox/pod/test_check_for_pod_restart.py
@@ -1,0 +1,127 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from k8s_sandbox._pod.op import PodInfo, check_for_pod_restart
+from k8s_sandbox._pod.pod import Pod
+from k8s_sandbox.error import ContainerRestartedError, PodReplacedError
+
+
+def _k8s_pod(uid: str, container_name: str, restart_count: int) -> MagicMock:
+    pod = MagicMock()
+    pod.metadata.uid = uid
+    pod.metadata.name = "agent-env-abc-default-0"
+    status = MagicMock()
+    status.name = container_name
+    status.restart_count = restart_count
+    status.last_state.terminated.reason = "OOMKilled"
+    pod.status.container_statuses = [status]
+    return pod
+
+
+def _pod_info(uid: str = "uid-1", restart_count: int = 0) -> PodInfo:
+    return PodInfo(
+        name="agent-env-abc-default-0",
+        namespace="ns",
+        context_name=None,
+        default_container_name="default",
+        uid=uid,
+        initial_restart_count=restart_count,
+        restarted_container_behavior="raise",
+    )
+
+
+def test_no_change_does_not_raise():
+    with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
+        mock_client.return_value.read_namespaced_pod.return_value = _k8s_pod(
+            uid="uid-1", container_name="default", restart_count=0
+        )
+        # Should not raise
+        check_for_pod_restart(_pod_info())
+
+
+def test_pod_replaced_raises_typed_with_new_restart_count():
+    with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
+        mock_client.return_value.read_namespaced_pod.return_value = _k8s_pod(
+            uid="uid-NEW", container_name="default", restart_count=2
+        )
+        with pytest.raises(PodReplacedError) as excinfo:
+            check_for_pod_restart(_pod_info(uid="uid-OLD", restart_count=0))
+    err = excinfo.value
+    assert err.old_uid == "uid-OLD"
+    assert err.new_uid == "uid-NEW"
+    assert err.new_restart_count == 2
+    assert err.pod_name == "agent-env-abc-default-0"
+
+
+def test_container_restarted_raises_typed():
+    with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
+        mock_client.return_value.read_namespaced_pod.return_value = _k8s_pod(
+            uid="uid-1", container_name="default", restart_count=3
+        )
+        with pytest.raises(ContainerRestartedError) as excinfo:
+            check_for_pod_restart(_pod_info(uid="uid-1", restart_count=1))
+    err = excinfo.value
+    assert err.restart_count == 3
+    assert err.container_name == "default"
+    assert err.last_reason == "OOMKilled"
+
+
+def _make_pod(restarted_container_behavior: str = "raise") -> Pod:
+    return Pod(
+        name="agent-env-abc-default-0",
+        namespace="ns",
+        context_name=None,
+        default_container_name="default",
+        uid="uid-OLD",
+        initial_restart_count=0,
+        restarted_container_behavior=restarted_container_behavior,  # type: ignore[arg-type]
+    )
+
+
+def test_pod_auto_refreshes_uid_after_replacement():
+    pod = _make_pod()
+    with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
+        mock_client.return_value.read_namespaced_pod.return_value = _k8s_pod(
+            uid="uid-NEW", container_name="default", restart_count=2
+        )
+        with pytest.raises(PodReplacedError):
+            pod._check_for_pod_restart_sync()
+    # Cached identity is refreshed so a subsequent call against the new pod
+    # does NOT re-raise.
+    assert pod.info.uid == "uid-NEW"
+    assert pod.info.initial_restart_count == 2
+    with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
+        mock_client.return_value.read_namespaced_pod.return_value = _k8s_pod(
+            uid="uid-NEW", container_name="default", restart_count=2
+        )
+        pod._check_for_pod_restart_sync()  # no raise
+
+
+def test_warn_mode_logs_and_does_not_raise_but_still_refreshes(caplog):
+    pod = _make_pod(restarted_container_behavior="warn")
+    with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
+        mock_client.return_value.read_namespaced_pod.return_value = _k8s_pod(
+            uid="uid-NEW", container_name="default", restart_count=0
+        )
+        with caplog.at_level("WARNING"):
+            pod._check_for_pod_restart_sync()
+    assert pod.info.uid == "uid-NEW"
+    assert any("has been replaced" in r.message for r in caplog.records)
+
+
+def test_pod_auto_refreshes_restart_count_after_container_restart():
+    pod = _make_pod()
+    with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
+        mock_client.return_value.read_namespaced_pod.return_value = _k8s_pod(
+            uid="uid-OLD", container_name="default", restart_count=4
+        )
+        with pytest.raises(ContainerRestartedError):
+            pod._check_for_pod_restart_sync()
+    assert pod.info.initial_restart_count == 4
+    # Same restart_count next time → no raise.
+    with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
+        mock_client.return_value.read_namespaced_pod.return_value = _k8s_pod(
+            uid="uid-OLD", container_name="default", restart_count=4
+        )
+        pod._check_for_pod_restart_sync()


### PR DESCRIPTION
## Summary

When a pod was evicted and recreated by its StatefulSet (same name, new UID), `check_for_pod_restart` raised an untyped `RuntimeError` and never refreshed the cached `PodInfo.uid`. Every subsequent operation re-read the same stale UID and re-raised, so any caller that handled or retried the error kept hitting the same dead pod for the lifetime of the sample .

This PR raises typed `PodReplacedError` / `ContainerRestartedError` (both `K8sError` subclasses) so callers can recognise the condition without string-matching, and refreshes the cached pod identity inside `Pod` when either fires. The typed exception is raised on the actual transition; subsequent operations target the new pod.

One behaviour change worth flagging: `restarted_container_behavior="warn"` now also refreshes the cached identity. Previously it logged but left the stale UID in place, which caused weird downstream "no such file" errors on the next exec.