### PR TITLE
Regenerate agent-env README (helm-docs drift)

### DIFF
--- a/src/k8s_sandbox/resources/helm/agent-env/README.md
+++ b/src/k8s_sandbox/resources/helm/agent-env/README.md
@@ -17,7 +17,7 @@
 | imagePullSecrets | list | `[]` | References to pre-existing secrets that contain registry credentials. |
 | labels | object | `{}` | A dict of labels to apply to resources within the agent environment. |
 | networks | object | `{}` | Defines network names that can be attached to services in order to specify subsets of services that can communicate with one another. |
-| serviceAccountName | string | `nil` | Service account name. When set, a ServiceAccount is created with this name and pods will use it. This must be a ServiceAccount name which doesn't already exist. |
+| serviceAccountName | string | `nil` | Service account name. When set, a ServiceAccount is created with this name and pods will use it. |
 | services | object | see [values.yaml](./values.yaml) | A collection of services to deploy within the agent environment. A service can connect to another service using DNS, e.g. `http://nginx:80`. |
 | services.default | object | see [values.yaml](./values.yaml) | The default service, this is required for the agent environment to function. |
 | services.default.additionalDnsRecords | list | `[]` | A list of additional domains which will resolve to this service from within the agent environment (e.g. example.com). If one or more records are provided, `dnsRecord` is automatically set to true. |


### PR DESCRIPTION
## Summary

`helm-docs` has drifted from `values.yaml`'s `serviceAccountName` annotation since #190 landed, which makes the `helm-docs-built` pre-commit hook fail on every subsequent PR (red CI for everyone). Pure regen: the new wording is verbatim what `helm-docs` produces from the current `values.yaml`.