### PR TITLE
fix: surface restart/replacement warning in the eval transcript; clarify limitations docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Raise typed `PodReplacedError` / `ContainerRestartedError` (instead of `RuntimeError`) when a pod operation detects the pod has been replaced or its container restarted, and refresh the cached pod identity so subsequent operations target the new pod instead of looping against a stale UID. `restarted_container_behavior="warn"` now also refreshes (previously left the cached UID stale).
+- The `restarted_container_behavior="warn"` warning is now recorded in the eval transcript (visible in `inspect view`), not just on stderr. It was previously logged from a worker thread whose context Inspect's transcript capture could not see.
 
 ## 2026-05-07 0.5.0
 

--- a/docs/docs/design/limitations.md
+++ b/docs/docs/design/limitations.md
@@ -41,9 +41,27 @@ chart](../helm//built-in-chart.md#resource-requests-and-limits).
 
 You can reduce the impact of a container restarting by using persistent volumes.
 
-The framework will issue a warning if a container restarts during an eval. If you set
-the `restarted_container_behaviour` parameter to `raise`, the eval will fail the sample
-if it detects a container restart.
+The framework detects two kinds of state-loss events on every operation:
+
+* **Pod replacement** — the pod's UID has changed (the StatefulSet recreated it,
+  typically after eviction).
+* **Container restart** — the same pod's container process restarted in place
+  (`restart_count` increased).
+
+In both cases, in-memory state and any background processes started by the agent are
+lost, and anything written to the container's writable filesystem is reset. EmptyDir
+volumes survive container restarts but not pod replacements; PersistentVolume-backed
+paths survive both.
+
+By default (`restarted_container_behavior="warn"`), the framework logs a warning,
+refreshes its cached pod identity, and continues against the refreshed pod or
+container. The warning is recorded in Python `logging` and the eval transcript — it is
+not surfaced to the agent or solver.
+
+If you set `restarted_container_behavior="raise"`, the operation that detected the
+change instead raises a typed `PodReplacedError` or `ContainerRestartedError` (both
+`K8sError` subclasses). The cached identity is still refreshed, so a subsequent
+operation will target the refreshed pod.
 
 ??? question "Why not use Jobs over StatefulSets?"
 

--- a/docs/docs/design/limitations.md
+++ b/docs/docs/design/limitations.md
@@ -55,13 +55,17 @@ paths survive both.
 
 By default (`restarted_container_behavior="warn"`), the framework logs a warning,
 refreshes its cached pod identity, and continues against the refreshed pod or
-container. The warning is recorded in Python `logging` and the eval transcript — it is
-not surfaced to the agent or solver.
+container. The warning goes to Python `logging` (i.e. stderr/console) — it is not
+surfaced to the agent or solver, and it does not currently appear in the eval
+transcript.
 
 If you set `restarted_container_behavior="raise"`, the operation that detected the
-change instead raises a typed `PodReplacedError` or `ContainerRestartedError` (both
-`K8sError` subclasses). The cached identity is still refreshed, so a subsequent
-operation will target the refreshed pod.
+change raises instead of continuing. Internally a typed `PodReplacedError` or
+`ContainerRestartedError` is raised, but the sandbox `exec`/`read_file`/`write_file`
+methods re-wrap it as a `K8sError` with the typed error as its `__cause__`. To
+discriminate by type, catch `K8sError` and inspect `__cause__` rather than catching
+`PodReplacedError`/`ContainerRestartedError` directly. The cached identity is still
+refreshed, so a subsequent operation will target the refreshed pod.
 
 ??? question "Why not use Jobs over StatefulSets?"
 

--- a/docs/docs/design/limitations.md
+++ b/docs/docs/design/limitations.md
@@ -55,9 +55,8 @@ paths survive both.
 
 By default (`restarted_container_behavior="warn"`), the framework logs a warning,
 refreshes its cached pod identity, and continues against the refreshed pod or
-container. The warning goes to Python `logging` (i.e. stderr/console) — it is not
-surfaced to the agent or solver, and it does not currently appear in the eval
-transcript.
+container. The warning is emitted via Python `logging` and recorded in the eval
+transcript (visible in `inspect view`); it is not surfaced to the agent or solver.
 
 If you set `restarted_container_behavior="raise"`, the operation that detected the
 change raises instead of continuing. Internally a typed `PodReplacedError` or

--- a/src/k8s_sandbox/_pod/error.py
+++ b/src/k8s_sandbox/_pod/error.py
@@ -72,9 +72,11 @@ class ContainerRestartedError(K8sError):
     """A container in the pod has restarted since the pod was first observed.
 
     The pod itself is the same (same UID), but the container's process was
-    restarted (OOM, crash, liveness probe failure, etc.). Files on disk
-    survive; in-memory state and any background processes started by the agent
-    do not.
+    restarted (OOM, crash, liveness probe failure, etc.). In-memory state and
+    any background processes started by the agent are lost, and the container's
+    writable filesystem layer is reset to the image. Files on a mounted volume
+    survive: emptyDir volumes survive a container restart (but not a pod
+    replacement), and persistent volumes survive both.
 
     The sandbox provider refreshes its cached restart count when this is
     raised, so subsequent operations will not re-raise

--- a/src/k8s_sandbox/_pod/pod.py
+++ b/src/k8s_sandbox/_pod/pod.py
@@ -45,7 +45,7 @@ class Pod:
         """The current cached pod identity.
 
         Note that ``uid`` and ``initial_restart_count`` may be replaced by
-        ``check_for_pod_restart`` if a replacement or restart is observed.
+        ``_detect_and_refresh`` if a replacement or restart is observed.
         """
         return self._info
 
@@ -60,11 +60,32 @@ class Pod:
         - ``"warn"``: log a warning and return normally.
         - ``"raise"``: raise ``PodReplacedError`` or ``ContainerRestartedError``.
         """
-        await self._run_async(self._check_for_pod_restart_sync)
+        detected = await self._run_async(self._detect_and_refresh)
+        if detected is None:
+            return
+        # Apply the warn/raise policy here, on the event loop thread, rather
+        # than inside the PodOpExecutor worker. Inspect's logging-to-transcript
+        # capture is keyed on a contextvar that asyncio's run_in_executor does
+        # not propagate to the worker thread, so a warning logged there never
+        # reaches the sample transcript. Raising is unaffected (the exception
+        # surfaces here when awaited) but both branches are kept together.
+        if self._info.restarted_container_behavior == "warn":
+            logger.warning(str(detected))
+            return
+        raise detected
 
-    def _check_for_pod_restart_sync(self) -> None:
+    def _detect_and_refresh(
+        self,
+    ) -> PodReplacedError | ContainerRestartedError | None:
+        """Detect a pod replacement / container restart and refresh the identity.
+
+        Runs in a PodOpExecutor worker thread. Returns the detected exception
+        with the cached identity already refreshed, or ``None`` if no change was
+        detected. The caller applies the ``restarted_container_behavior`` policy.
+        """
         try:
             check_for_pod_restart(self._info)
+            return None
         except PodReplacedError as e:
             # Refresh cached identity atomically (frozen dataclass replacement
             # is an attribute assignment, which is atomic in CPython).
@@ -73,19 +94,13 @@ class Pod:
                 uid=e.new_uid,
                 initial_restart_count=e.new_restart_count,
             )
-            if self._info.restarted_container_behavior == "warn":
-                logger.warning(str(e))
-                return
-            raise
+            return e
         except ContainerRestartedError as e:
             self._info = dataclasses.replace(
                 self._info,
                 initial_restart_count=e.restart_count,
             )
-            if self._info.restarted_container_behavior == "warn":
-                logger.warning(str(e))
-                return
-            raise
+            return e
 
     async def exec(
         self,

--- a/test/k8s_sandbox/pod/test_check_for_pod_restart.py
+++ b/test/k8s_sandbox/pod/test_check_for_pod_restart.py
@@ -1,7 +1,9 @@
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from k8s_sandbox._pod import pod as pod_module
 from k8s_sandbox._pod.error import ContainerRestartedError, PodReplacedError
 from k8s_sandbox._pod.op import PodInfo, check_for_pod_restart
 from k8s_sandbox._pod.pod import Pod
@@ -91,14 +93,14 @@ def _make_pod(restarted_container_behavior: str = "raise") -> Pod:
     )
 
 
-def test_pod_auto_refreshes_uid_after_replacement():
+async def test_pod_auto_refreshes_uid_after_replacement():
     pod = _make_pod()
     with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
         mock_client.return_value.read_namespaced_pod.return_value = _k8s_pod(
             uid="uid-NEW", container_name="default", restart_count=2
         )
         with pytest.raises(PodReplacedError):
-            pod._check_for_pod_restart_sync()
+            await pod.check_for_pod_restart()
     # Cached identity is refreshed so a subsequent call against the new pod
     # does NOT re-raise.
     assert pod.info.uid == "uid-NEW"
@@ -107,33 +109,55 @@ def test_pod_auto_refreshes_uid_after_replacement():
         mock_client.return_value.read_namespaced_pod.return_value = _k8s_pod(
             uid="uid-NEW", container_name="default", restart_count=2
         )
-        pod._check_for_pod_restart_sync()  # no raise
+        await pod.check_for_pod_restart()  # no raise
 
 
-def test_warn_mode_logs_and_does_not_raise_but_still_refreshes(caplog):
+async def test_warn_mode_logs_and_does_not_raise_but_still_refreshes(caplog):
     pod = _make_pod(restarted_container_behavior="warn")
     with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
         mock_client.return_value.read_namespaced_pod.return_value = _k8s_pod(
             uid="uid-NEW", container_name="default", restart_count=0
         )
         with caplog.at_level("WARNING"):
-            pod._check_for_pod_restart_sync()
+            await pod.check_for_pod_restart()
     assert pod.info.uid == "uid-NEW"
     assert any("has been replaced" in r.message for r in caplog.records)
 
 
-def test_pod_auto_refreshes_restart_count_after_container_restart():
+async def test_warn_is_logged_on_calling_thread_not_executor_thread():
+    # Detection runs in a PodOpExecutor worker thread, but the warn-mode
+    # warning must be emitted on the calling (event loop) thread. Inspect's
+    # logging-to-transcript capture is contextvar-based and run_in_executor
+    # does not propagate the context to the worker, so a warning logged there
+    # would never reach the sample transcript. This guards that regression.
+    pod = _make_pod(restarted_container_behavior="warn")
+    calling_thread = threading.get_ident()
+    warn_threads: list[int] = []
+    with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
+        mock_client.return_value.read_namespaced_pod.return_value = _k8s_pod(
+            uid="uid-NEW", container_name="default", restart_count=0
+        )
+        with patch.object(
+            pod_module.logger,
+            "warning",
+            side_effect=lambda *a, **k: warn_threads.append(threading.get_ident()),
+        ):
+            await pod.check_for_pod_restart()
+    assert warn_threads == [calling_thread]
+
+
+async def test_pod_auto_refreshes_restart_count_after_container_restart():
     pod = _make_pod()
     with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
         mock_client.return_value.read_namespaced_pod.return_value = _k8s_pod(
             uid="uid-OLD", container_name="default", restart_count=4
         )
         with pytest.raises(ContainerRestartedError):
-            pod._check_for_pod_restart_sync()
+            await pod.check_for_pod_restart()
     assert pod.info.initial_restart_count == 4
     # Same restart_count next time → no raise.
     with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
         mock_client.return_value.read_namespaced_pod.return_value = _k8s_pod(
             uid="uid-OLD", container_name="default", restart_count=4
         )
-        pod._check_for_pod_restart_sync()
+        await pod.check_for_pod_restart()


### PR DESCRIPTION
SLOP ALERT

## Summary

Originally a docs-only clarification of the "Containers may restart" section of `docs/docs/design/limitations.md` (in light of #193). While validating the docs end-to-end against minikube, I found the documented behaviour was wrong in one place — the `restarted_container_behavior="warn"` warning never reached the eval transcript — so this PR now also fixes that, and the docs describe the corrected behaviour.

## The bug

`Pod.check_for_pod_restart` ran detection **and** the warn/raise policy inside a `PodOpExecutor` worker thread (via `loop.run_in_executor`). In warn mode the `logger.warning(...)` was emitted from that worker. Inspect's logging-to-transcript capture is keyed on a `ContextVar` (`inspect_ai.log._transcript`), and `run_in_executor` does not propagate the context into the worker thread — so `transcript()` there resolves to a detached default and the record is dropped. Net effect: the warning showed up on stderr but **not** in the eval transcript / `inspect view`.

Isolated with a minimal `inspect eval` (separate process): the same warning logged from the main thread is captured in the transcript; logged from a `run_in_executor` worker it is not.

## The fix

Split `check_for_pod_restart` so the worker only does the blocking k8s read + identity refresh (`_detect_and_refresh`, returns the detected exception or `None`), and the async method applies the warn/raise policy on the event-loop thread. The warning is now logged from the calling thread and reaches the sample transcript. Raise behaviour is unchanged (the exception already surfaced on the event-loop thread when awaited).

## Docs changes (`limitations.md`)

- Distinguishes the two state-loss events the framework detects (pod replacement / container restart).
- Corrects what state survives each:
  - emptyDir volumes survive container restarts but not pod replacements.
  - PersistentVolume-backed paths survive both.
  - Anything on the container's writable layer is lost in both cases.
- States that the warn-mode warning is recorded in the eval transcript and is not surfaced to the agent or solver.
- Notes that in `raise` mode the sandbox `exec`/`read_file`/`write_file` methods re-wrap the typed `PodReplacedError` / `ContainerRestartedError` as a `K8sError` with the typed error as `__cause__` (catch `K8sError` and inspect `__cause__`).
- Fixes `restarted_container_behaviour` → `restarted_container_behavior`. Note the British spelling does **not** raise — the config model ignores unknown fields (pydantic `extra='ignore'`), so a copy of the old docs silently stays on the default `"warn"`.
- Corrects the `ContainerRestartedError` docstring: "Files on disk survive" was imprecise — the container writable layer is reset on restart (confirmed e2e); only mounted volumes survive (emptyDir across a restart, persistent volumes across both).

## Tests

- New unit test asserts the warn-mode warning is logged on the calling thread, not the executor worker (fails against the previous implementation, passes now).
- Existing pod-restart tests updated to drive the async `check_for_pod_restart` (raise/refresh/warn paths).
- `pytest -m "not req_k8s"` green (315 passed); ruff + mypy clean.

## E2E validation (minikube, via `inspect eval`)

Real container restart (liveness-probe failure) and real pod replacement (`kubectl delete pod`), in `warn` and `raise` modes:

- Survival matches the docs exactly — emptyDir survives restart only; PV survives both; `/root` (writable layer) lost in both.
- warn mode: refreshes identity and continues; **transcript now contains the warning** (0 LoggerEvents before the fix, 2 after).
- raise mode: typed error raised (wrapped in `K8sError`, typed error as `__cause__`); identity still refreshed so the next op succeeds.
