### PR TITLE
Fix connection reset when piping large input to exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Raise typed `PodReplacedError` / `ContainerRestartedError` (instead of `RuntimeError`) when a pod operation detects the pod has been replaced or its container restarted, and refresh the cached pod identity so subsequent operations target the new pod instead of looping against a stale UID. `restarted_container_behavior="warn"` now also refreshes (previously left the cached UID stale).
+- Fix `exec(input=...)` failing with "Connection reset by peer" for large inputs (e.g. injecting a ~28 MiB binary): stdin is now written to the pod in ≤1 MiB WebSocket frames instead of a single oversized frame. `write_file` shares the same chunking helper.
 
 ## 2026-05-07 0.5.0
 

--- a/src/k8s_sandbox/_pod/execute.py
+++ b/src/k8s_sandbox/_pod/execute.py
@@ -32,7 +32,7 @@ class ExecuteOperation(PodOperation):
         with self._interactive_shell(user) as ws_client:
             # Write the script to the shell's stdin rather than passing it as a command
             # argument (-c) to better support potentially long commands.
-            ws_client.write_stdin(shell_script)
+            self._write_stdin_chunked(ws_client, shell_script)
             result = self._handle_shell_output(ws_client, user, timeout)
         return result
 

--- a/src/k8s_sandbox/_pod/op.py
+++ b/src/k8s_sandbox/_pod/op.py
@@ -26,6 +26,10 @@ API_TIMEOUT = 60
 # [1] https://github.com/kubernetes/kubernetes/blob/db9fcfeed29b860d8dd7188bc1903c4709977890/staging/src/k8s.io/kubelet/pkg/cri/streaming/server.go#L100-L105
 # [2] https://github.com/kubernetes/kubernetes/blob/77b02b7ad40d36cd803856de5ba5922c947cb0aa/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/conn.go#L348-L356
 _KEEPALIVE_INTERVAL_SECONDS = 30
+# Maximum size of a single WebSocket stdin frame. Larger single writes (tens of
+# MiB) make the kubelet/API-server/TLS layer reset the connection
+# (ConnectionResetError / ssl.SSLEOFError), so stdin is written in chunks.
+_STDIN_CHUNK_SIZE = 1024**2  # 1 MiB
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +64,16 @@ class PodOperation(ABC):
 
     def __init__(self, pod: PodInfo):
         self._pod = pod
+
+    def _write_stdin_chunked(self, ws_client: WSClient, data: str | bytes) -> None:
+        """Write ``data`` to the stdin channel in ``_STDIN_CHUNK_SIZE`` frames.
+
+        Used by both exec and write_file (see ``_STDIN_CHUNK_SIZE`` for why we
+        chunk). The slice type is preserved: ``str`` -> text frames, ``bytes``
+        -> binary frames.
+        """
+        for i in range(0, len(data), _STDIN_CHUNK_SIZE):
+            ws_client.write_stdin(data[i : i + _STDIN_CHUNK_SIZE])
 
     def create_websocket_client_for_exec(
         self, **kwargs

--- a/src/k8s_sandbox/_pod/pod.py
+++ b/src/k8s_sandbox/_pod/pod.py
@@ -147,25 +147,20 @@ class Pod:
         )
         return result
 
-    async def write_file(self, src: IO[bytes], dst: Path) -> None:
+    async def write_file(self, data: bytes, dst: Path) -> None:
         """
-        Copy a file-like object (src) from the client to a path on the pod (dst).
+        Write ``data`` from the client to a path on the pod (dst).
 
         Existing files on the pod will be overwritten.
 
-        The source will be read from its current position to the end of the file. The
-        file position will be restored after the copy. The file-like object must be
-        opened in binary mode.
-
         Args:
-          src (IO[bytes]): The file-like object which contains the contents to be
-            written to the pod.
+          data (bytes): The contents to write to the pod.
           dst (Path): The path to write the file to on the pod. Relative paths will be
             resolved relative to the pod's default working directory.
         """
         await self.check_for_pod_restart()
         writer = WriteFileOperation(self._info)
-        await self._run_async(lambda: writer.write_file(src, dst))
+        await self._run_async(lambda: writer.write_file(data, dst))
 
     async def read_file(self, src: Path, dst: IO[bytes]) -> None:
         """

--- a/src/k8s_sandbox/_pod/write.py
+++ b/src/k8s_sandbox/_pod/write.py
@@ -1,8 +1,7 @@
-import io
 import shlex
 from contextlib import contextmanager
 from pathlib import Path
-from typing import IO, Generator
+from typing import Generator
 
 from kubernetes.stream.ws_client import WSClient  # type: ignore[import-untyped]
 
@@ -15,18 +14,10 @@ from k8s_sandbox._pod.op import (
 
 
 class WriteFileOperation(PodOperation):
-    def write_file(self, src: IO[bytes], dst: Path) -> None:
-        file_size = self._get_file_size(src)
-        with self._start_write_command(dst, file_size) as ws_client:
-            self._write_data_to_stdin(ws_client, src)
+    def write_file(self, data: bytes, dst: Path) -> None:
+        with self._start_write_command(dst, len(data)) as ws_client:
+            self._write_stdin_chunked(ws_client, data)
             self._handle_stream_output(ws_client)
-
-    def _get_file_size(self, file: IO[bytes]) -> int:
-        original_position = file.tell()
-        file.seek(0, io.SEEK_END)
-        file_size = file.tell()
-        file.seek(original_position)
-        return file_size
 
     @contextmanager
     def _start_write_command(
@@ -50,15 +41,6 @@ class WriteFileOperation(PodOperation):
             # Read stdout and stderr as text. Has no effect on stdin.
             binary=False,
         )
-
-    def _write_data_to_stdin(self, ws_client: WSClient, src: IO[bytes]) -> None:
-        original_position = src.tell()
-        # Write the src in chunks of 1MiB as large writes (~100MiB) result in
-        # ssl.SSLEOFError.
-        chunk_size = 1024**2  # 1 MiB
-        while data := src.read(chunk_size):
-            ws_client.write_stdin(data)
-        src.seek(original_position)
 
     def _handle_stream_output(self, ws_client: WSClient) -> None:
         # Wait until the websocket connection is closed. All stderr will be stored by us

--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -285,21 +285,13 @@ class K8sSandboxEnvironment(SandboxEnvironment):
             return result
 
     async def write_file(self, file: str, contents: str | bytes) -> None:
-        # Write contents to a temporary file on the client system and pass the file
-        # handle.
-        with tempfile.NamedTemporaryFile("w+b") as temp_file:
-            if isinstance(contents, str):
-                temp_file.write(contents.encode("utf-8"))
-            else:
-                temp_file.write(contents)
-            temp_file.seek(0)
-            # Do not log these at error level or re-raise as enriched K8sError.
-            expected_exceptions = (PermissionError, IsADirectoryError)
-            with self._log_op("K8s write file to Pod", expected_exceptions, file=file):
-                async for attempt in _retry():
-                    with attempt:
-                        temp_file.seek(0)
-                        await self._pod.write_file(temp_file.file, Path(file))
+        data = contents.encode("utf-8") if isinstance(contents, str) else contents
+        # Do not log these at error level or re-raise as enriched K8sError.
+        expected_exceptions = (PermissionError, IsADirectoryError)
+        with self._log_op("K8s write file to Pod", expected_exceptions, file=file):
+            async for attempt in _retry():
+                with attempt:
+                    await self._pod.write_file(data, Path(file))
 
     @overload
     async def read_file(self, file: str, text: Literal[True] = True) -> str: ...

--- a/test/k8s_sandbox/pod/test_execute.py
+++ b/test/k8s_sandbox/pod/test_execute.py
@@ -1,8 +1,12 @@
+from contextlib import contextmanager
+from typing import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
+from inspect_ai.util import ExecResult
 from kubernetes.stream.ws_client import WSClient  # type: ignore
 
+import k8s_sandbox._pod.op as op_module
 from k8s_sandbox._pod.error import PodError
 from k8s_sandbox._pod.execute import ExecuteOperation
 
@@ -222,3 +226,37 @@ class TestConnectionResetWithoutSentinel:
         executor = ExecuteOperation(MagicMock())
         with pytest.raises(PodError, match="WebSocket connection lost"):
             executor._handle_shell_output(ws, user=None, timeout=None)
+
+
+class TestExecChunksStdin:
+    def test_exec_writes_shell_script_in_chunks(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Tiny chunk size (patched in op.py, where _write_stdin_chunked reads it)
+        # plus stubbed shell creation + output handling, so only the write path runs.
+        monkeypatch.setattr(op_module, "_STDIN_CHUNK_SIZE", 16)
+        ws = MagicMock(spec=WSClient)
+
+        @contextmanager
+        def fake_interactive_shell(
+            user: str | None,
+        ) -> Generator[MagicMock, None, None]:
+            yield ws
+
+        op = ExecuteOperation(MagicMock())
+        monkeypatch.setattr(op, "_interactive_shell", fake_interactive_shell)
+        sentinel = ExecResult(success=True, returncode=0, stdout="", stderr="")
+        monkeypatch.setattr(op, "_handle_shell_output", lambda *a, **k: sentinel)
+
+        # The assembled script (base64 input + pipeline) is several hundred bytes,
+        # well above the 16-byte chunk size, so it splits into many frames.
+        result = op.exec(
+            ["cat"], stdin=b"x" * 100, cwd=None, env={}, user=None, timeout=None
+        )
+
+        expected_script = op._build_shell_script(["cat"], b"x" * 100, None, {}, None)
+        written = "".join(call.args[0] for call in ws.write_stdin.call_args_list)
+        assert written == expected_script
+        assert ws.write_stdin.call_count > 1
+        assert all(len(c.args[0]) <= 16 for c in ws.write_stdin.call_args_list)
+        assert result is sentinel

--- a/test/k8s_sandbox/pod/test_op.py
+++ b/test/k8s_sandbox/pod/test_op.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock
+
+import pytest
+from kubernetes.stream.ws_client import WSClient  # type: ignore[import-untyped]
+
+import k8s_sandbox._pod.op as op_module
+from k8s_sandbox._pod.op import PodOperation
+
+
+class _ConcretePodOp(PodOperation):
+    """A concrete PodOperation so the base-class helper can be exercised."""
+
+
+def _make_op() -> _ConcretePodOp:
+    return _ConcretePodOp(MagicMock())
+
+
+@pytest.mark.parametrize(
+    ("chunk_size", "data", "expected"),
+    [
+        (4, b"abcdefghij", [b"abcd", b"efgh", b"ij"]),
+        (1024, b"hello", [b"hello"]),
+        (4, "abcdefg", ["abcd", "efg"]),  # str in -> str frames out
+        (4, b"", []),
+        (4, b"abcdefgh", [b"abcd", b"efgh"]),  # exact multiple, no trailing write
+    ],
+)
+def test_write_stdin_chunked(
+    monkeypatch: pytest.MonkeyPatch,
+    chunk_size: int,
+    data: str | bytes,
+    expected: list[bytes | str],
+) -> None:
+    monkeypatch.setattr(op_module, "_STDIN_CHUNK_SIZE", chunk_size)
+    ws = MagicMock(spec=WSClient)
+
+    _make_op()._write_stdin_chunked(ws, data)
+
+    assert [call.args[0] for call in ws.write_stdin.call_args_list] == expected
+
+
+def test_write_stdin_chunked_default_chunk_size_splits_oversized_payload() -> None:
+    # Regression guard: a payload one byte over the chunk size must split into
+    # more than one frame.
+    ws = MagicMock(spec=WSClient)
+
+    _make_op()._write_stdin_chunked(ws, b"x" * (op_module._STDIN_CHUNK_SIZE + 1))
+
+    assert op_module._STDIN_CHUNK_SIZE == 1024**2
+    assert ws.write_stdin.call_count == 2
+    assert len(ws.write_stdin.call_args_list[0].args[0]) == op_module._STDIN_CHUNK_SIZE

--- a/test/k8s_sandbox/pod/test_write.py
+++ b/test/k8s_sandbox/pod/test_write.py
@@ -1,0 +1,36 @@
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Generator
+from unittest.mock import MagicMock
+
+import pytest
+from kubernetes.stream.ws_client import WSClient  # type: ignore[import-untyped]
+
+import k8s_sandbox._pod.op as op_module
+from k8s_sandbox._pod.write import WriteFileOperation
+
+
+def test_write_file_writes_data_via_chunked_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(op_module, "_STDIN_CHUNK_SIZE", 4)
+    op = WriteFileOperation(MagicMock())
+    ws = MagicMock(spec=WSClient)
+    captured: dict[str, int] = {}
+
+    @contextmanager
+    def fake_start_write_command(
+        dst: Path, file_size: int
+    ) -> Generator[MagicMock, None, None]:
+        captured["file_size"] = file_size
+        yield ws
+
+    monkeypatch.setattr(op, "_start_write_command", fake_start_write_command)
+    monkeypatch.setattr(op, "_handle_stream_output", lambda ws_client: None)
+    data = b"abcdefghij"
+
+    op.write_file(data, Path("/tmp/dst"))
+
+    assert captured["file_size"] == len(data)
+    assert b"".join(call.args[0] for call in ws.write_stdin.call_args_list) == data
+    assert ws.write_stdin.call_count > 1

--- a/test/k8s_sandbox/test_sandbox.py
+++ b/test/k8s_sandbox/test_sandbox.py
@@ -175,6 +175,21 @@ async def test_exec_stdin_as_bytes(
     assert actual == binary_data
 
 
+async def test_exec_with_large_stdin(sandbox: K8sSandboxEnvironment) -> None:
+    # Regression: a large input= was sent as one oversized WebSocket frame and
+    # the connection reset. 30 MiB is comfortably past the failure threshold.
+    size = 30 * 1024**2  # 30 MiB
+    pattern = bytes(range(256))
+    large = (pattern * (size // len(pattern) + 1))[:size]
+
+    # No timeout: a 30 MiB transfer can exceed the few-second timeouts used by
+    # the smaller stdin tests above.
+    await sandbox.exec(["bash", "-c", "cat > /tmp/large-stdin.bin"], input=large)
+
+    actual = await sandbox.read_file("/tmp/large-stdin.bin", text=False)
+    assert actual == large
+
+
 async def test_exec_cwd_absolute(sandbox: K8sSandboxEnvironment) -> None:
     result = await sandbox.exec(["pwd"], cwd="/tmp", timeout=10)
 

--- a/test/k8s_sandbox/test_sandbox.py
+++ b/test/k8s_sandbox/test_sandbox.py
@@ -175,21 +175,6 @@ async def test_exec_stdin_as_bytes(
     assert actual == binary_data
 
 
-async def test_exec_with_large_stdin(sandbox: K8sSandboxEnvironment) -> None:
-    # Regression: a large input= was sent as one oversized WebSocket frame and
-    # the connection reset. 30 MiB is comfortably past the failure threshold.
-    size = 30 * 1024**2  # 30 MiB
-    pattern = bytes(range(256))
-    large = (pattern * (size // len(pattern) + 1))[:size]
-
-    # No timeout: a 30 MiB transfer can exceed the few-second timeouts used by
-    # the smaller stdin tests above.
-    await sandbox.exec(["bash", "-c", "cat > /tmp/large-stdin.bin"], input=large)
-
-    actual = await sandbox.read_file("/tmp/large-stdin.bin", text=False)
-    assert actual == large
-
-
 async def test_exec_cwd_absolute(sandbox: K8sSandboxEnvironment) -> None:
     result = await sandbox.exec(["pwd"], cwd="/tmp", timeout=10)
 


### PR DESCRIPTION
## Summary

`SandboxEnvironment.exec(input=...)` fails with `[Errno 104] Connection reset by peer` once the input reaches a few tens of MiB. The input is base64-inlined into the shell script and the entire script is sent as a single WebSocket stdin frame, which the API server rejects by resetting the connection. Inspect's checkpointing hit this injecting a ~28 MiB `restic` binary into a sandbox. This writes pod stdin in <=1 MiB frames instead.

Also cleanup the write_file path that did an unnecessarily complicated "write-temp-file", "pass IO[bytes]", "get-size-of-temp-file", "read-temp-file-back".

## Test plan

- [x] Tested end to end in a dev cluster.