### PR TITLE
fix: include cause type and message in K8sError str() — closes #195

### DIFF
--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -368,8 +368,18 @@ class K8sSandboxEnvironment(SandboxEnvironment):
                 # Whilst Inspect's trace_action will have logged the exception, log it
                 # at ERROR level here for user visibility.
                 log_error(f"Error during: {op}.", cause=e, **log_kwargs)
-                # Enrich the unexpected exception with additional context.
-                raise K8sError(f"Error during: {op}.", **log_kwargs) from e
+                # Enrich the unexpected exception with additional context. The
+                # cause's type and short message are included in the K8sError's
+                # own message so callers reading str(error) (e.g. an LLM agent
+                # reading the bash tool's error string) can distinguish a
+                # transient infra failure like PodReplacedError from
+                # destructive-class errors. The original exception remains
+                # reachable via __cause__ for callers that walk the chain.
+                raise K8sError(
+                    f"Error during: {op}.",
+                    cause=f"{type(e).__name__}: {e}",
+                    **log_kwargs,
+                ) from e
 
     @classmethod
     def config_deserialize(cls, config: dict[str, Any]) -> BaseModel:


### PR DESCRIPTION
Closes #195.

## Problem

When an op fails because the pod was replaced (typed `PodReplacedError` from #193 is chained via `raise K8sError(...) from e` in `_sandbox_environment._log_op`), the `K8sError` that propagates to the caller currently has a `__str__` of:

```
Error during: K8s execute command in Pod. {"pod": "...", "cmd": "..."}
```

— no mention of "pod replaced", no UIDs, no cause type. The original `PodReplacedError` is reachable via `K8sError.__cause__`, but LLM agents reading the bash tool's error string only see `str(error)` and have no way to distinguish a transient infra error from "your files are gone".

## Fix

Include the cause's type name and short message as a `cause` kwarg on the `K8sError` formatted message, so callers without exception-chain awareness can react.

```python
raise K8sError(
    f"Error during: {op}.",
    cause=f"{type(e).__name__}: {e}",
    **log_kwargs,
) from e
```

`raise X from e` semantics are unchanged — the original exception remains reachable via `__cause__` for callers that walk the chain.

## After

```
Error during: K8s execute command in Pod. {"pod": "...", "cmd": "...", "cause": "PodReplacedError: Pod ... was replaced (uid ... -> ...)"}
```

Now agents can grep for `PodReplacedError` or any other typed cause and treat the failure differently from a generic destructive error.

## Note

The existing `log_error` call directly above (which already received the full Exception object as `cause=e` and was JSON-serialized via `format_log_message`) is unchanged — only the `K8sError` construction is updated.