### PR TITLE
Propagate caller context into pod-op worker thread (fixes #200, subsumes #196 transcript fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- Propagate the caller's context into the pod-operation worker thread (`PodOpExecutor.queue_operation` now runs the operation under a `contextvars.copy_context()` snapshot). Previously `run_in_executor` started the worker with an empty context, so ContextVar-based config set in the calling async context was silently lost. Fixes `INSPECT_SANDBOX_MAX_EXEC_OUTPUT_SIZE` (and other exec-limit overrides) having no effect on k8s, and ensures `restarted_container_behavior="warn"` warnings reach the eval transcript ([#200](https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/issues/200)).
-- Raise typed `PodReplacedError` / `ContainerRestartedError` (instead of `RuntimeError`) when a pod operation detects the pod has been replaced or its container restarted, and refresh the cached pod identity so subsequent operations target the new pod instead of looping against a stale UID. `restarted_container_behavior="warn"` now also refreshes (previously left the cached UID stale).
+- Propagate the caller's context into the pod-operation worker thread to ensure that Inspect sandbox config overrides are honoured.
+- Raise typed `PodReplacedError` / `ContainerRestartedError` (instead of `RuntimeError`) when a pod operation detects the pod has been replaced or its container restarted, and refresh the cached pod identity so subsequent operations target the new pod instead of looping against a stale UID. `restarted_container_behavior="warn"` now also refreshes (previously left the cached UID stale).  
 - Fix `exec(input=...)` failing with "Connection reset by peer" for large inputs (e.g. injecting a ~28 MiB binary): stdin is now written to the pod in ≤1 MiB WebSocket frames instead of a single oversized frame. `write_file` shares the same chunking helper.
 
 ## 2026-05-07 0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Propagate the caller's context into the pod-operation worker thread (`PodOpExecutor.queue_operation` now runs the operation under a `contextvars.copy_context()` snapshot). Previously `run_in_executor` started the worker with an empty context, so ContextVar-based config set in the calling async context was silently lost. Fixes `INSPECT_SANDBOX_MAX_EXEC_OUTPUT_SIZE` (and other exec-limit overrides) having no effect on k8s, and ensures `restarted_container_behavior="warn"` warnings reach the eval transcript ([#200](https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/issues/200)).
 - Raise typed `PodReplacedError` / `ContainerRestartedError` (instead of `RuntimeError`) when a pod operation detects the pod has been replaced or its container restarted, and refresh the cached pod identity so subsequent operations target the new pod instead of looping against a stale UID. `restarted_container_behavior="warn"` now also refreshes (previously left the cached UID stale).
 - Fix `exec(input=...)` failing with "Connection reset by peer" for large inputs (e.g. injecting a ~28 MiB binary): stdin is now written to the pod in ≤1 MiB WebSocket frames instead of a single oversized frame. `write_file` shares the same chunking helper.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Propagate the caller's context into the pod-operation worker thread to ensure that Inspect sandbox config overrides are honoured.
-- Raise typed `PodReplacedError` / `ContainerRestartedError` (instead of `RuntimeError`) when a pod operation detects the pod has been replaced or its container restarted, and refresh the cached pod identity so subsequent operations target the new pod instead of looping against a stale UID. `restarted_container_behavior="warn"` now also refreshes (previously left the cached UID stale).  
+- Raise typed `PodReplacedError` / `ContainerRestartedError` (instead of `RuntimeError`) when a pod operation detects the pod has been replaced or its container restarted, and refresh the cached pod identity so subsequent operations target the new pod instead of looping against a stale UID. `restarted_container_behavior="warn"` now also refreshes (previously left the cached UID stale).
 - Fix `exec(input=...)` failing with "Connection reset by peer" for large inputs (e.g. injecting a ~28 MiB binary): stdin is now written to the pod in ≤1 MiB WebSocket frames instead of a single oversized frame. `write_file` shares the same chunking helper.
 
 ## 2026-05-07 0.5.0

--- a/src/k8s_sandbox/_pod/executor.py
+++ b/src/k8s_sandbox/_pod/executor.py
@@ -80,7 +80,8 @@ class PodOpExecutor:
         """
         async with concurrency("pod-op", self._max_workers):
             # run_in_executor does not propagate the caller's context into the
-            # worker thread, so pass it directly to preserve Inspect config overrides
+            # worker thread, so pass it directly to preserve Inspect
+            # sandbox config overrides
             context = contextvars.copy_context()
             return await asyncio.get_event_loop().run_in_executor(
                 self._executor, lambda: context.run(callable)

--- a/src/k8s_sandbox/_pod/executor.py
+++ b/src/k8s_sandbox/_pod/executor.py
@@ -80,11 +80,7 @@ class PodOpExecutor:
         """
         async with concurrency("pod-op", self._max_workers):
             # run_in_executor does not propagate the caller's context into the
-            # worker thread (PEP 567: a new thread starts with an empty context).
-            # Snapshot it here so ContextVar-based config set in the calling async
-            # context is visible to the operation. Without this, inspect_ai's
-            # per-operation overrides (exec output-size limit, transcript capture)
-            # are silently lost on the worker thread. See issue #200.
+            # worker thread, so pass it directly to preserve Inspect config overrides
             context = contextvars.copy_context()
             return await asyncio.get_event_loop().run_in_executor(
                 self._executor, lambda: context.run(callable)

--- a/src/k8s_sandbox/_pod/executor.py
+++ b/src/k8s_sandbox/_pod/executor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import os
 from concurrent.futures import ThreadPoolExecutor
 from typing import Callable, TypeVar
@@ -78,6 +79,13 @@ class PodOpExecutor:
         This method is async-safe but not thread-safe.
         """
         async with concurrency("pod-op", self._max_workers):
+            # run_in_executor does not propagate the caller's context into the
+            # worker thread (PEP 567: a new thread starts with an empty context).
+            # Snapshot it here so ContextVar-based config set in the calling async
+            # context is visible to the operation. Without this, inspect_ai's
+            # per-operation overrides (exec output-size limit, transcript capture)
+            # are silently lost on the worker thread. See issue #200.
+            context = contextvars.copy_context()
             return await asyncio.get_event_loop().run_in_executor(
-                self._executor, callable
+                self._executor, lambda: context.run(callable)
             )

--- a/test/k8s_sandbox/pod/test_executor.py
+++ b/test/k8s_sandbox/pod/test_executor.py
@@ -88,7 +88,6 @@ async def test_queue_more_operations_than_max_workers(monkeypatch: MonkeyPatch) 
 async def test_queue_operation_propagates_caller_context(
     monkeypatch: MonkeyPatch,
 ) -> None:
-
     monkeypatch.setenv("INSPECT_MAX_POD_OPS", "1")
     executor = PodOpExecutor.get_instance()
     var: contextvars.ContextVar[str] = contextvars.ContextVar(

--- a/test/k8s_sandbox/pod/test_executor.py
+++ b/test/k8s_sandbox/pod/test_executor.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import threading
 from time import sleep
 from typing import Generator
@@ -82,6 +83,25 @@ async def test_queue_more_operations_than_max_workers(monkeypatch: MonkeyPatch) 
     assert result2 == (2, "pod-op-executor_1")
     # The third operation should be executed by one of the two existing workers.
     assert result3 == (3, "pod-op-executor_0") or result3 == (3, "pod-op-executor_1")
+
+
+async def test_queue_operation_propagates_caller_context(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # The worker callable reads ContextVar-based config (inspect_ai's exec
+    # output-size limit, transcript capture). run_in_executor does not carry the
+    # caller's context into the worker thread, so queue_operation must snapshot
+    # it. See issue #200.
+    monkeypatch.setenv("INSPECT_MAX_POD_OPS", "1")
+    executor = PodOpExecutor.get_instance()
+    var: contextvars.ContextVar[str] = contextvars.ContextVar(
+        "test_var", default="default"
+    )
+    var.set("override")
+
+    seen = await executor.queue_operation(var.get)
+
+    assert seen == "override"
 
 
 def _synchronous_operation(value: int) -> tuple[int, str]:

--- a/test/k8s_sandbox/pod/test_executor.py
+++ b/test/k8s_sandbox/pod/test_executor.py
@@ -88,10 +88,7 @@ async def test_queue_more_operations_than_max_workers(monkeypatch: MonkeyPatch) 
 async def test_queue_operation_propagates_caller_context(
     monkeypatch: MonkeyPatch,
 ) -> None:
-    # The worker callable reads ContextVar-based config (inspect_ai's exec
-    # output-size limit, transcript capture). run_in_executor does not carry the
-    # caller's context into the worker thread, so queue_operation must snapshot
-    # it. See issue #200.
+
     monkeypatch.setenv("INSPECT_MAX_POD_OPS", "1")
     executor = PodOpExecutor.get_instance()
     var: contextvars.ContextVar[str] = contextvars.ContextVar(


### PR DESCRIPTION
## Summary

Closes #200. PR #196 and issue #200 are two symptoms of one bug, and this fixes both at the source.

`PodOpExecutor.queue_operation` dispatched the synchronous pod operation via `run_in_executor` with no context snapshot. Per [PEP 567](https://peps.python.org/pep-0567/) a new thread starts with an empty context, so any `ContextVar` set in the calling async context was invisible to the worker thread.

inspect_ai keeps a couple of pieces of per-operation state in ContextVars that the k8s provider reads **on the worker thread**, so both were silently lost:

- **`INSPECT_SANDBOX_MAX_EXEC_OUTPUT_SIZE`** (and any `_max_exec_output_size_var` override) — the worker-thread `LimitedBuffer` (`execute.py`) read the 10 MiB module default instead of the override, making the exec output limit un-tunable on k8s (#200).
- **transcript capture** (`inspect_ai.log._transcript`) — `restarted_container_behavior="warn"` warnings, logged from the worker thread, never reached the eval transcript (#196).

## The fix

Snapshot the context inside `queue_operation` and run the operation under it:

```python
context = contextvars.copy_context()
return await asyncio.get_event_loop().run_in_executor(
    self._executor, lambda: context.run(callable)
)
```

`copy_context()` is evaluated inside `queue_operation`, within the live async context that holds the overrides, so the worker runs against a snapshot that includes them. This fixes **all** ContextVar-based config crossing the thread hop, not just these two.

## Tests

- New unit test in `test_executor.py`: a `ContextVar` set by the caller is visible inside the `queue_operation` worker callable. Fails against the previous implementation, passes now.
- `pytest -m "not req_k8s"` green (323 passed); ruff + mypy clean.

## E2E validation (minikube, via `inspect eval`, before/after)

- **Issue #200 — exec limit override:** bash command emitting 15 MB with `INSPECT_SANDBOX_MAX_EXEC_OUTPUT_SIZE=20000000`. Before: fails with `OutputLimitExceededError: ... 10 MiB ...` (worker read the default). After: succeeds (override reached the worker).
- **PR #196 — warn-mode warning in transcript:** real pod replacement (`kubectl delete pod`; the StatefulSet recreates it with a new UID), warn mode, run against this branch's `pod.py` (warning still logged from the worker thread, *not* PR #196's restructuring). Before: warning on stderr but **0** LoggerEvents in the transcript. After: **1** LoggerEvent (`Pod '...' has been replaced ...`) captured.

## Relationship to #196

This lands the transcript fix at the executor layer, which subsumes #196's logging bug. #196's `_detect_and_refresh` split is no longer required to get the warning into the transcript; its docs corrections and typed-error/raise work still stand independently. Suggest deciding how to sequence the two — e.g. rebase #196 to keep the docs + raise changes and drop (or keep, as a cleanliness change) the worker/event-loop split.
