### PR TITLE
feat: surface container crash diagnostics on Helm install failure

### DIFF
--- a/src/k8s_sandbox/_diagnostics.py
+++ b/src/k8s_sandbox/_diagnostics.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import logging
+
+from kubernetes.client import CoreV1Api, V1ContainerStatus  # type: ignore
+
+from k8s_sandbox._kubernetes_api import k8s_client
+
+logger = logging.getLogger(__name__)
+
+
+def describe_release_pods(
+    context_name: str | None, namespace: str, release_name: str
+) -> str | None:
+    """Summarise the state of a Helm release's pods for inclusion in error messages.
+
+    Reads container states, termination reasons and exit codes from the Kubernetes API
+    so that failures which Helm reports only generically (e.g. "Pod is in the Pending
+    phase" or "Containers in CrashLoop state") can be attributed to a concrete cause
+    such as ImagePullBackOff or OOMKilled.
+
+    This is best-effort: it is intended to be called from error-handling paths, so any
+    failure while gathering diagnostics is swallowed and results in None rather than
+    masking the original error.
+
+    Args:
+        context_name: The kubeconfig context name, or None for the current context.
+        namespace: The namespace the release was installed into.
+        release_name: The Helm release name (used to select its pods).
+
+    Returns:
+        A human-readable, multi-line summary, or None if no useful diagnostics could be
+        gathered.
+    """
+    try:
+        return _collect_diagnostics(context_name, namespace, release_name)
+    except Exception:
+        logger.debug("Failed to collect pod diagnostics.", exc_info=True)
+        return None
+
+
+def _collect_diagnostics(
+    context_name: str | None, namespace: str, release_name: str
+) -> str | None:
+    client = k8s_client(context_name)
+    pods = client.list_namespaced_pod(
+        namespace, label_selector=f"app.kubernetes.io/instance={release_name}"
+    )
+    lines: list[str] = []
+    pod_names: set[str] = set()
+    for pod in pods.items:
+        if pod.metadata is None:
+            continue
+        pod_names.add(pod.metadata.name)
+        if pod.status is None:
+            continue
+        for container in pod.status.container_statuses or []:
+            line = _describe_container(container)
+            if line is not None:
+                lines.append(line)
+
+    lines.extend(_describe_warning_events(client, namespace, pod_names))
+
+    if not lines:
+        return None
+    return "\n".join(lines)
+
+
+def _describe_warning_events(
+    client: CoreV1Api, namespace: str, pod_names: set[str]
+) -> list[str]:
+    """Return formatted Warning events that involve any of the given pods."""
+    events = client.list_namespaced_event(namespace, field_selector="type=Warning")
+    lines: list[str] = []
+    for event in events.items:
+        involved = event.involved_object
+        if involved is None or involved.name not in pod_names:
+            continue
+        lines.append(f"event ({event.reason}): {event.message}")
+    return lines
+
+
+def _describe_container(container: V1ContainerStatus) -> str | None:
+    """Describe a single container's problematic state, or None if it looks healthy."""
+    state = container.state
+    last_state = container.last_state
+    waiting = state.waiting if state else None
+    terminated = state.terminated if state else None
+    last_terminated = last_state.terminated if last_state else None
+
+    parts: list[str] = []
+    if waiting is not None:
+        detail = waiting.reason or "Waiting"
+        if waiting.message:
+            detail += f": {waiting.message}"
+        parts.append(f"waiting ({detail})")
+    if terminated is not None:
+        parts.append(
+            f"terminated {terminated.reason} (exit code {terminated.exit_code})"
+        )
+    if terminated is None and last_terminated is not None:
+        # A crash-looping container is currently "waiting"; the reason it keeps dying
+        # (e.g. OOMKilled, exit 137) lives in its previous termination.
+        parts.append(
+            f"last terminated {last_terminated.reason} "
+            f"(exit code {last_terminated.exit_code})"
+        )
+
+    if not parts:
+        return None
+
+    line = f"container '{container.name}': " + "; ".join(parts)
+    if container.restart_count:
+        line += f", restarted {container.restart_count} time(s)"
+    if container.image:
+        line += f" [image: {container.image}]"
+    return line

--- a/src/k8s_sandbox/_diagnostics.py
+++ b/src/k8s_sandbox/_diagnostics.py
@@ -49,7 +49,7 @@ def _collect_diagnostics(
     lines: list[str] = []
     pod_names: set[str] = set()
     for pod in pods.items:
-        if pod.metadata is None:
+        if pod.metadata is None or pod.metadata.name is None:
             continue
         pod_names.add(pod.metadata.name)
         if pod.status is None:

--- a/src/k8s_sandbox/_diagnostics.py
+++ b/src/k8s_sandbox/_diagnostics.py
@@ -54,6 +54,13 @@ def _collect_diagnostics(
         pod_names.add(pod.metadata.name)
         if pod.status is None:
             continue
+        # Init containers run to completion before the app containers start, so a
+        # failing init container leaves the app container merely "waiting
+        # (PodInitializing)"; the actionable cause is in the init container's status.
+        for container in pod.status.init_container_statuses or []:
+            line = _describe_container(container, is_init=True)
+            if line is not None:
+                lines.append(line)
         for container in pod.status.container_statuses or []:
             line = _describe_container(container)
             if line is not None:
@@ -80,7 +87,9 @@ def _describe_warning_events(
     return lines
 
 
-def _describe_container(container: V1ContainerStatus) -> str | None:
+def _describe_container(
+    container: V1ContainerStatus, is_init: bool = False
+) -> str | None:
     """Describe a single container's problematic state, or None if it looks healthy."""
     state = container.state
     last_state = container.last_state
@@ -109,7 +118,8 @@ def _describe_container(container: V1ContainerStatus) -> str | None:
     if not parts:
         return None
 
-    line = f"container '{container.name}': " + "; ".join(parts)
+    kind = "init container" if is_init else "container"
+    line = f"{kind} '{container.name}': " + "; ".join(parts)
     if container.restart_count:
         line += f", restarted {container.restart_count} time(s)"
     if container.image:

--- a/src/k8s_sandbox/_helm.py
+++ b/src/k8s_sandbox/_helm.py
@@ -14,6 +14,7 @@ from inspect_ai.util import ExecResult, concurrency
 from kubernetes.client.exceptions import ApiException  # type: ignore
 from shortuuid import uuid
 
+from k8s_sandbox._diagnostics import describe_release_pods
 from k8s_sandbox._kubernetes_api import get_default_namespace, k8s_client
 from k8s_sandbox._logger import (
     format_log_message,
@@ -330,7 +331,7 @@ class Release:
             with suppress(Exception, asyncio.CancelledError):
                 await watcher
         if not result.success:
-            self._raise_install_error(result)
+            await self._raise_install_error(result)
 
     async def _watch_for_scheduling_events(self) -> None:
         """Poll for FailedScheduling events and log once if GPU provisioning is needed.
@@ -376,7 +377,7 @@ class Release:
         except asyncio.CancelledError:
             pass
 
-    def _raise_install_error(self, result: ExecResult[str]) -> NoReturn:
+    async def _raise_install_error(self, result: ExecResult[str]) -> NoReturn:
         # When concurrent helm operations are modifying the same resource quota, the
         # following error occasionally occurs. Retry.
         if re.search(
@@ -391,6 +392,19 @@ class Release:
                 error=result.stderr,
             )
             raise _ResourceQuotaModifiedError(result.stderr)
+        # Helm only reports the generic symptom (e.g. a pod not becoming ready). Read
+        # the pods' container states so the concrete cause (ImagePullBackOff, OOMKilled,
+        # FailedScheduling, ...) is surfaced. Best-effort: None if it can't be gathered.
+        # The Kubernetes client is synchronous, so run it in a thread (as
+        # get_sandbox_pods and the scheduling watcher do) to avoid blocking the loop.
+        loop = asyncio.get_running_loop()
+        diagnostics = await loop.run_in_executor(
+            None,
+            lambda: describe_release_pods(
+                self._context_name, self._namespace, self.release_name
+            ),
+        )
+        extra: dict[str, Any] = {"pod_diagnostics": diagnostics} if diagnostics else {}
         if re.search(r"context deadline exceeded", result.stderr):
             _raise_runtime_error(
                 f"Helm install timed out (context deadline exceeded). The configured "
@@ -400,9 +414,13 @@ class Release:
                 f"{INSPECT_HELM_TIMEOUT} environment variable.",
                 release=self.release_name,
                 result=result,
+                **extra,
             )
         _raise_runtime_error(
-            "Helm install failed.", release=self.release_name, result=result
+            "Helm install failed.",
+            release=self.release_name,
+            result=result,
+            **extra,
         )
 
 

--- a/test/k8s_sandbox/test_diagnostics.py
+++ b/test/k8s_sandbox/test_diagnostics.py
@@ -4,6 +4,7 @@ from kubernetes.client import (  # type: ignore
     CoreV1Event,
     CoreV1EventList,
     V1ContainerState,
+    V1ContainerStateRunning,
     V1ContainerStateTerminated,
     V1ContainerStateWaiting,
     V1ContainerStatus,

--- a/test/k8s_sandbox/test_diagnostics.py
+++ b/test/k8s_sandbox/test_diagnostics.py
@@ -1,0 +1,134 @@
+from unittest.mock import MagicMock, patch
+
+from kubernetes.client import (  # type: ignore
+    CoreV1Event,
+    CoreV1EventList,
+    V1ContainerState,
+    V1ContainerStateTerminated,
+    V1ContainerStateWaiting,
+    V1ContainerStatus,
+    V1ObjectMeta,
+    V1ObjectReference,
+    V1Pod,
+    V1PodList,
+    V1PodStatus,
+)
+
+from k8s_sandbox._diagnostics import describe_release_pods
+
+
+def _pod(name: str, phase: str, container_statuses, labels=None) -> V1Pod:
+    return V1Pod(
+        metadata=V1ObjectMeta(name=name, labels=labels or {}),
+        status=V1PodStatus(phase=phase, container_statuses=container_statuses),
+    )
+
+
+def _patch_client(pods, events=None):
+    client = MagicMock()
+    client.list_namespaced_pod.return_value = V1PodList(items=pods)
+    client.list_namespaced_event.return_value = CoreV1EventList(items=events or [])
+    return patch("k8s_sandbox._diagnostics.k8s_client", return_value=client)
+
+
+def test_surfaces_oom_killed_reason_exit_code_and_restart_count() -> None:
+    container = V1ContainerStatus(
+        name="default",
+        image="busybox:1.36",
+        image_id="",
+        ready=False,
+        restart_count=3,
+        state=V1ContainerState(
+            waiting=V1ContainerStateWaiting(reason="CrashLoopBackOff")
+        ),
+        last_state=V1ContainerState(
+            terminated=V1ContainerStateTerminated(reason="OOMKilled", exit_code=137)
+        ),
+    )
+    pods = [_pod("rel-default", "Running", [container])]
+
+    with _patch_client(pods):
+        summary = describe_release_pods(None, "default", "rel")
+
+    assert summary is not None
+    assert "default" in summary  # container name
+    assert "OOMKilled" in summary
+    assert "137" in summary
+    assert "3" in summary  # restart count
+
+
+def test_surfaces_image_pull_backoff_reason_message_and_image() -> None:
+    container = V1ContainerStatus(
+        name="default",
+        image="nonexistent.invalid/nope:latest",
+        image_id="",
+        ready=False,
+        restart_count=0,
+        state=V1ContainerState(
+            waiting=V1ContainerStateWaiting(
+                reason="ImagePullBackOff",
+                message='Back-off pulling image "nonexistent.invalid/nope:latest"',
+            )
+        ),
+    )
+    pods = [_pod("rel-default", "Pending", [container])]
+
+    with _patch_client(pods):
+        summary = describe_release_pods(None, "default", "rel")
+
+    assert summary is not None
+    assert "ImagePullBackOff" in summary
+    assert "Back-off pulling image" in summary
+    assert "nonexistent.invalid/nope:latest" in summary
+
+
+def test_surfaces_failed_scheduling_event_when_pod_has_no_container_statuses() -> None:
+    # An unschedulable pod stays Pending with no container statuses; the actionable
+    # detail is in a FailedScheduling Warning event.
+    pods = [_pod("rel-default", "Pending", container_statuses=None)]
+    events = [
+        CoreV1Event(
+            metadata=V1ObjectMeta(name="evt-1"),
+            involved_object=V1ObjectReference(name="rel-default"),
+            reason="FailedScheduling",
+            message="0/1 nodes available: 1 Insufficient cpu",
+            type="Warning",
+        )
+    ]
+
+    with _patch_client(pods, events) as mock_client_factory:
+        summary = describe_release_pods(None, "default", "rel")
+
+    assert summary is not None
+    assert "FailedScheduling" in summary
+    assert "Insufficient cpu" in summary
+    # Warning events are filtered server-side rather than in Python.
+    mock_client_factory.return_value.list_namespaced_event.assert_called_once_with(
+        "default", field_selector="type=Warning"
+    )
+
+
+def test_returns_none_and_does_not_raise_when_api_call_fails() -> None:
+    # describe_release_pods runs from error-handling paths; it must never raise and mask
+    # the original failure.
+    with patch("k8s_sandbox._diagnostics.k8s_client", side_effect=RuntimeError("boom")):
+        summary = describe_release_pods(None, "default", "rel")
+
+    assert summary is None
+
+
+def test_returns_none_when_all_containers_healthy_and_no_events() -> None:
+    container = V1ContainerStatus(
+        name="default",
+        image="busybox:1.36",
+        image_id="",
+        ready=True,
+        restart_count=0,
+        state=V1ContainerState(running={"started_at": None}),
+    )
+    pods = [_pod("rel-default", "Running", [container])]
+
+    with _patch_client(pods):
+        summary = describe_release_pods(None, "default", "rel")
+
+    assert summary is None

--- a/test/k8s_sandbox/test_diagnostics.py
+++ b/test/k8s_sandbox/test_diagnostics.py
@@ -180,7 +180,7 @@ def test_returns_none_when_all_containers_healthy_and_no_events() -> None:
         image_id="",
         ready=True,
         restart_count=0,
-        state=V1ContainerState(running={"started_at": None}),
+        state=V1ContainerState(running=V1ContainerStateRunning(started_at=None)),
     )
     pods = [_pod("rel-default", "Running", [container])]
 

--- a/test/k8s_sandbox/test_diagnostics.py
+++ b/test/k8s_sandbox/test_diagnostics.py
@@ -17,10 +17,20 @@ from kubernetes.client import (  # type: ignore
 from k8s_sandbox._diagnostics import describe_release_pods
 
 
-def _pod(name: str, phase: str, container_statuses, labels=None) -> V1Pod:
+def _pod(
+    name: str,
+    phase: str,
+    container_statuses,
+    labels=None,
+    init_container_statuses=None,
+) -> V1Pod:
     return V1Pod(
         metadata=V1ObjectMeta(name=name, labels=labels or {}),
-        status=V1PodStatus(phase=phase, container_statuses=container_statuses),
+        status=V1PodStatus(
+            phase=phase,
+            container_statuses=container_statuses,
+            init_container_statuses=init_container_statuses,
+        ),
     )
 
 
@@ -80,6 +90,51 @@ def test_surfaces_image_pull_backoff_reason_message_and_image() -> None:
     assert "ImagePullBackOff" in summary
     assert "Back-off pulling image" in summary
     assert "nonexistent.invalid/nope:latest" in summary
+
+
+def test_surfaces_failing_init_container_cause() -> None:
+    # A failing init container leaves the app container merely "waiting
+    # (PodInitializing)"; the actionable cause lives in the init container's status.
+    init_container = V1ContainerStatus(
+        name="setup",
+        image="busybox:1.36",
+        image_id="",
+        ready=False,
+        restart_count=2,
+        state=V1ContainerState(
+            waiting=V1ContainerStateWaiting(reason="CrashLoopBackOff")
+        ),
+        last_state=V1ContainerState(
+            terminated=V1ContainerStateTerminated(reason="Error", exit_code=1)
+        ),
+    )
+    app_container = V1ContainerStatus(
+        name="default",
+        image="busybox:1.36",
+        image_id="",
+        ready=False,
+        restart_count=0,
+        state=V1ContainerState(
+            waiting=V1ContainerStateWaiting(reason="PodInitializing")
+        ),
+    )
+    pods = [
+        _pod(
+            "rel-default",
+            "Pending",
+            container_statuses=[app_container],
+            init_container_statuses=[init_container],
+        )
+    ]
+
+    with _patch_client(pods):
+        summary = describe_release_pods(None, "default", "rel")
+
+    assert summary is not None
+    assert "init container 'setup'" in summary
+    assert "Error" in summary
+    assert "exit code 1" in summary
+    assert "restarted 2 time(s)" in summary
 
 
 def test_surfaces_failed_scheduling_event_when_pod_has_no_container_statuses() -> None:

--- a/test/k8s_sandbox/test_helm.py
+++ b/test/k8s_sandbox/test_helm.py
@@ -734,3 +734,47 @@ async def test_helm_labels_appear_on_release_secret(
             assert secret_labels.labels.get(key) == value
     finally:
         await release.uninstall(quiet=True)
+
+
+async def test_install_error_includes_pod_diagnostics() -> None:
+    release = Release(
+        __file__,
+        chart_path=Path("/non_existent_chart"),
+        values_source=ValuesSource.none(),
+        context_name=None,
+    )
+    result = ExecResult(
+        success=False,
+        returncode=1,
+        stdout="",
+        stderr="Error: INSTALLATION FAILED: resource Pod/default/x not ready.\n",
+    )
+    diagnostics = "container 'default': last terminated OOMKilled (exit code 137)"
+
+    with patch("k8s_sandbox._helm.describe_release_pods", return_value=diagnostics):
+        with pytest.raises(RuntimeError) as excinfo:
+            await release._raise_install_error(result)
+
+    assert "OOMKilled" in str(excinfo.value)
+    assert "137" in str(excinfo.value)
+
+
+async def test_install_error_omits_diagnostics_when_unavailable() -> None:
+    release = Release(
+        __file__,
+        chart_path=Path("/non_existent_chart"),
+        values_source=ValuesSource.none(),
+        context_name=None,
+    )
+    result = ExecResult(
+        success=False,
+        returncode=1,
+        stdout="",
+        stderr="Error: INSTALLATION FAILED: resource Pod/default/x not ready.\n",
+    )
+
+    with patch("k8s_sandbox._helm.describe_release_pods", return_value=None):
+        with pytest.raises(RuntimeError) as excinfo:
+            await release._raise_install_error(result)
+
+    assert "Helm install failed." in str(excinfo.value)


### PR DESCRIPTION
## Problem

When a sandbox pod fails to become ready, the error surfaced to the caller contains
only Helm's generic symptom, which often does not distinguish between different
failures or doesn't convey the details that it could. Observed on a local `kind` 
cluster (helm v4.2.0):

| Failure | What Helm reports |
| --- | --- |
| Bad image | `Helm install timed out (context deadline exceeded) … Pod is in the Pending phase` |
| Unschedulable | `Pod could not be scheduled` |
| App crash (exit 1) | `Containers in CrashLoop state: default` |
| OOM kill (exit 137) | `Containers in CrashLoop state: default` |

The actionable details (`ImagePullBackOff`, `OOMKilled`, exit code, the failing image, 
the `FailedScheduling` reason) are present in the Kubernetes API but is not propagated.

## Change

On Helm install failure, read the release's pod container states and recent `Warning`
events from the Kubernetes API and append them to the raised error as `pod_diagnostics`
(alongside the existing `release` and `result`). After this change, the same four
failures now include:

| Failure | Added `pod_diagnostics` |
| --- | --- |
| Bad image | `waiting (ImagePullBackOff: … ErrImagePull: …) [image: nonexistent.invalid/no-such-image:latest]` |
| Unschedulable | `event (FailedScheduling): 0/1 nodes are available: 1 Insufficient cpu` |
| App crash | `last terminated Error (exit code 1), restarted N time(s)` |
| OOM kill | `terminated OOMKilled (exit code 137), restarted N time(s)` |

## Safety

- Diagnostics gathering is **best-effort**: the whole helper is wrapped so any failure
  while collecting them returns `None` and the original install error is raised
  unchanged. It can never mask the real failure.
- **Container/pod states and event messages only — no container log content** is read,
  to avoid surfacing agent-generated or sensitive output.

## Async / blocking IO

The Kubernetes Python client is synchronous. Rather than introduce an async-client
dependency, the diagnostics helper stays synchronous and is run in a thread via
`run_in_executor` at the call site, matching how `get_sandbox_pods` and
`_watch_for_scheduling_events` already offload blocking K8s calls. `_raise_install_error`
becomes `async` accordingly.

Alternatives considered:
- **Per-call `run_in_executor` inside the helper** (mirroring `get_sandbox_pods`
  line-for-line) — viable, but keeping `_diagnostics.py` free of `asyncio` keeps it pure
  and unit-testable without an event loop (the diagnostics tests are plain synchronous
  functions), and wraps the two K8s calls in a single thread hop.
  - **Async client (`kubernetes_asyncio`)** — this would be a new dependency and a second
  auth/config path, inconsistent with the rest of the package, it seems, which uses the
  synchronous client throughout.

## Testing

- Unit tests (`test/k8s_sandbox/test_diagnostics.py`) cover OOMKilled, ImagePullBackOff,
  FailedScheduling events (including the server-side `field_selector="type=Warning"`),
  the error-safety guarantee, and the healthy/no-op case, using real
  `kubernetes.client` model objects with only the API boundary mocked.
- Integration tests (`test/k8s_sandbox/test_helm.py`) confirm the diagnostics are
  threaded into the raised error and omitted cleanly when unavailable.
- Verified end-to-end on a `kind` cluster (helm v4.2.0): drove the real
  `Release.install()` path against deliberately-failing pods (image-pull, crash-loop,
  unschedulable, OOM) and confirmed the `pod_diagnostics` above, including that
  `field_selector="type=Warning"` returns the `FailedScheduling`/`Failed`/`BackOff`
  events.
- `ruff check`, `ruff format`, `mypy`, and the full unit suite all pass.
