### PR TITLE
fix: recheck for container restart after failed exec

### DIFF
--- a/src/k8s_sandbox/_diagnostics.py
+++ b/src/k8s_sandbox/_diagnostics.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import logging
+
+from kubernetes.client import CoreV1Api, V1ContainerStatus  # type: ignore
+
+from k8s_sandbox._kubernetes_api import k8s_client
+
+logger = logging.getLogger(__name__)
+
+
+def describe_release_pods(
+    context_name: str | None, namespace: str, release_name: str
+) -> str | None:
+    """Summarise the state of a Helm release's pods for inclusion in error messages.
+
+    Reads container states, termination reasons and exit codes from the Kubernetes API
+    so that failures which Helm reports only generically (e.g. "Pod is in the Pending
+    phase" or "Containers in CrashLoop state") can be attributed to a concrete cause
+    such as ImagePullBackOff or OOMKilled.
+
+    This is best-effort: it is intended to be called from error-handling paths, so any
+    failure while gathering diagnostics is swallowed and results in None rather than
+    masking the original error.
+
+    Args:
+        context_name: The kubeconfig context name, or None for the current context.
+        namespace: The namespace the release was installed into.
+        release_name: The Helm release name (used to select its pods).
+
+    Returns:
+        A human-readable, multi-line summary, or None if no useful diagnostics could be
+        gathered.
+    """
+    try:
+        return _collect_diagnostics(context_name, namespace, release_name)
+    except Exception:
+        logger.debug("Failed to collect pod diagnostics.", exc_info=True)
+        return None
+
+
+def _collect_diagnostics(
+    context_name: str | None, namespace: str, release_name: str
+) -> str | None:
+    client = k8s_client(context_name)
+    pods = client.list_namespaced_pod(
+        namespace, label_selector=f"app.kubernetes.io/instance={release_name}"
+    )
+    lines: list[str] = []
+    pod_names: set[str] = set()
+    for pod in pods.items:
+        if pod.metadata is None:
+            continue
+        pod_names.add(pod.metadata.name)
+        if pod.status is None:
+            continue
+        for container in pod.status.container_statuses or []:
+            line = _describe_container(container)
+            if line is not None:
+                lines.append(line)
+
+    lines.extend(_describe_warning_events(client, namespace, pod_names))
+
+    if not lines:
+        return None
+    return "\n".join(lines)
+
+
+def _describe_warning_events(
+    client: CoreV1Api, namespace: str, pod_names: set[str]
+) -> list[str]:
+    """Return formatted Warning events that involve any of the given pods."""
+    events = client.list_namespaced_event(namespace, field_selector="type=Warning")
+    lines: list[str] = []
+    for event in events.items:
+        involved = event.involved_object
+        if involved is None or involved.name not in pod_names:
+            continue
+        lines.append(f"event ({event.reason}): {event.message}")
+    return lines
+
+
+def _describe_container(container: V1ContainerStatus) -> str | None:
+    """Describe a single container's problematic state, or None if it looks healthy."""
+    state = container.state
+    last_state = container.last_state
+    waiting = state.waiting if state else None
+    terminated = state.terminated if state else None
+    last_terminated = last_state.terminated if last_state else None
+
+    parts: list[str] = []
+    if waiting is not None:
+        detail = waiting.reason or "Waiting"
+        if waiting.message:
+            detail += f": {waiting.message}"
+        parts.append(f"waiting ({detail})")
+    if terminated is not None:
+        parts.append(
+            f"terminated {terminated.reason} (exit code {terminated.exit_code})"
+        )
+    if terminated is None and last_terminated is not None:
+        # A crash-looping container is currently "waiting"; the reason it keeps dying
+        # (e.g. OOMKilled, exit 137) lives in its previous termination.
+        parts.append(
+            f"last terminated {last_terminated.reason} "
+            f"(exit code {last_terminated.exit_code})"
+        )
+
+    if not parts:
+        return None
+
+    line = f"container '{container.name}': " + "; ".join(parts)
+    if container.restart_count:
+        line += f", restarted {container.restart_count} time(s)"
+    if container.image:
+        line += f" [image: {container.image}]"
+    return line

--- a/src/k8s_sandbox/_helm.py
+++ b/src/k8s_sandbox/_helm.py
@@ -14,6 +14,7 @@ from inspect_ai.util import ExecResult, concurrency
 from kubernetes.client.exceptions import ApiException  # type: ignore
 from shortuuid import uuid
 
+from k8s_sandbox._diagnostics import describe_release_pods
 from k8s_sandbox._kubernetes_api import get_default_namespace, k8s_client
 from k8s_sandbox._logger import (
     format_log_message,
@@ -330,7 +331,7 @@ class Release:
             with suppress(Exception, asyncio.CancelledError):
                 await watcher
         if not result.success:
-            self._raise_install_error(result)
+            await self._raise_install_error(result)
 
     async def _watch_for_scheduling_events(self) -> None:
         """Poll for FailedScheduling events and log once if GPU provisioning is needed.
@@ -376,7 +377,7 @@ class Release:
         except asyncio.CancelledError:
             pass
 
-    def _raise_install_error(self, result: ExecResult[str]) -> NoReturn:
+    async def _raise_install_error(self, result: ExecResult[str]) -> NoReturn:
         # When concurrent helm operations are modifying the same resource quota, the
         # following error occasionally occurs. Retry.
         if re.search(
@@ -391,6 +392,19 @@ class Release:
                 error=result.stderr,
             )
             raise _ResourceQuotaModifiedError(result.stderr)
+        # Helm only reports the generic symptom (e.g. a pod not becoming ready). Read
+        # the pods' container states so the concrete cause (ImagePullBackOff, OOMKilled,
+        # FailedScheduling, ...) is surfaced. Best-effort: None if it can't be gathered.
+        # The Kubernetes client is synchronous, so run it in a thread (as
+        # get_sandbox_pods and the scheduling watcher do) to avoid blocking the loop.
+        loop = asyncio.get_running_loop()
+        diagnostics = await loop.run_in_executor(
+            None,
+            lambda: describe_release_pods(
+                self._context_name, self._namespace, self.release_name
+            ),
+        )
+        extra: dict[str, Any] = {"pod_diagnostics": diagnostics} if diagnostics else {}
         if re.search(r"context deadline exceeded", result.stderr):
             _raise_runtime_error(
                 f"Helm install timed out (context deadline exceeded). The configured "
@@ -400,9 +414,13 @@ class Release:
                 f"{INSPECT_HELM_TIMEOUT} environment variable.",
                 release=self.release_name,
                 result=result,
+                **extra,
             )
         _raise_runtime_error(
-            "Helm install failed.", release=self.release_name, result=result
+            "Helm install failed.",
+            release=self.release_name,
+            result=result,
+            **extra,
         )
 
 

--- a/src/k8s_sandbox/_pod/pod.py
+++ b/src/k8s_sandbox/_pod/pod.py
@@ -145,7 +145,43 @@ class Pod:
         result = await self._run_async(
             lambda: executor.exec(cmd, stdin, cwd, env, user, timeout)
         )
+        if not result.success:
+            await self._recheck_for_restart_after_failed_exec()
         return result
+
+    async def _recheck_for_restart_after_failed_exec(self) -> None:
+        """Re-check for restart after a failed exec to close the race window.
+
+        Always raises on detection regardless of restarted_container_behavior
+        — the exec already failed, so the restart is operationally relevant.
+        """
+        try:
+            await self._run_async(self._recheck_for_restart_sync)
+        except (PodReplacedError, ContainerRestartedError):
+            raise
+        except Exception:
+            logger.warning(
+                "Post-exec restart re-check failed; "
+                "returning original exec result",
+                exc_info=True,
+            )
+
+    def _recheck_for_restart_sync(self) -> None:
+        try:
+            check_for_pod_restart(self._info)
+        except PodReplacedError as e:
+            self._info = dataclasses.replace(
+                self._info,
+                uid=e.new_uid,
+                initial_restart_count=e.new_restart_count,
+            )
+            raise
+        except ContainerRestartedError as e:
+            self._info = dataclasses.replace(
+                self._info,
+                initial_restart_count=e.restart_count,
+            )
+            raise
 
     async def write_file(self, data: bytes, dst: Path) -> None:
         """

--- a/test/k8s_sandbox/pod/test_post_exec_restart_check.py
+++ b/test/k8s_sandbox/pod/test_post_exec_restart_check.py
@@ -1,0 +1,331 @@
+"""Tests for post-exec restart detection (issue #191).
+
+When a container restarts during the race window between
+check_for_pod_restart() and the actual exec, the K8s API hasn't yet
+updated restart_count. The pre-exec check passes, the exec fails
+(binary gone), and the caller gets an opaque failed ExecResult instead
+of a typed ContainerRestartedError.
+
+The fix: re-check for restart after a failed exec. If the race window
+has closed by then, surface the restart as the root cause.
+"""
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+from inspect_ai.util import ExecResult
+
+from k8s_sandbox._pod.error import ContainerRestartedError, PodReplacedError
+from k8s_sandbox._pod.op import PodInfo
+from k8s_sandbox._pod.pod import Pod
+
+
+def _k8s_pod(uid: str, container_name: str, restart_count: int) -> MagicMock:
+    """Build a mock K8s pod object returned by read_namespaced_pod."""
+    pod = MagicMock()
+    pod.metadata.uid = uid
+    pod.metadata.name = "agent-env-abc-default-0"
+    status = MagicMock()
+    status.name = container_name
+    status.restart_count = restart_count
+    status.last_state.terminated.reason = "OOMKilled"
+    pod.status.container_statuses = [status]
+    return pod
+
+
+def _make_pod(
+    uid: str = "uid-1",
+    restart_count: int = 0,
+    behavior: str = "raise",
+) -> Pod:
+    return Pod(
+        name="agent-env-abc-default-0",
+        namespace="ns",
+        context_name=None,
+        default_container_name="default",
+        uid=uid,
+        initial_restart_count=restart_count,
+        restarted_container_behavior=behavior,  # type: ignore[arg-type]
+    )
+
+
+def _failed_exec_result() -> ExecResult[str]:
+    """Simulate what happens when inspect-sandbox-tools binary is missing."""
+    return ExecResult(
+        success=False,
+        returncode=127,
+        stdout="",
+        stderr="timeout: failed to run command '/var/tmp/.da7be258e003d428/inspect-sandbox-tools': No such file or directory",
+    )
+
+
+def _success_exec_result() -> ExecResult[str]:
+    return ExecResult(success=True, returncode=0, stdout="ok", stderr="")
+
+
+# ---------------------------------------------------------------------------
+# Reproduction: demonstrate the current bug (race condition)
+# ---------------------------------------------------------------------------
+
+
+class TestRaceConditionBug:
+    """These tests document the race condition from issue #191.
+
+    The scenario:
+    1. Container restarts (OOM, etc)
+    2. Pre-exec check_for_pod_restart() passes (K8s API lag)
+    3. Exec fails (binary gone from wiped filesystem)
+    4. By the time we could re-check, restart_count has updated
+
+    Before the fix, step 3 returns a failed ExecResult and the caller
+    (inspect_ai's exec_remote) gets an opaque error. After the fix,
+    step 4 happens and ContainerRestartedError is raised.
+    """
+
+    async def test_race_window_restart_detected_on_recheck(self) -> None:
+        """The core race: pre-exec check passes, exec fails, post-exec
+        check detects the restart that happened during the window."""
+        pod = _make_pod(uid="uid-1", restart_count=0)
+
+        # Simulate the race: first API call sees restart_count=0 (stale),
+        # second API call sees restart_count=1 (updated).
+        k8s_pods = [
+            _k8s_pod(uid="uid-1", container_name="default", restart_count=0),
+            _k8s_pod(uid="uid-1", container_name="default", restart_count=1),
+        ]
+
+        with (
+            patch("k8s_sandbox._pod.op.k8s_client") as mock_client,
+            patch(
+                "k8s_sandbox._pod.pod.ExecuteOperation"
+            ) as mock_exec_cls,
+        ):
+            mock_client.return_value.read_namespaced_pod.side_effect = k8s_pods
+            mock_exec_cls.return_value.exec.return_value = _failed_exec_result()
+
+            with pytest.raises(ContainerRestartedError) as exc_info:
+                await pod.exec(
+                    cmd=["echo", "hello"],
+                    stdin=None,
+                    cwd=None,
+                    env={},
+                    user=None,
+                    timeout=None,
+                )
+
+            err = exc_info.value
+            assert err.restart_count == 1
+            assert err.last_reason == "OOMKilled"
+
+        # Identity should be refreshed
+        assert pod.info.initial_restart_count == 1
+
+    async def test_race_window_pod_replaced_on_recheck(self) -> None:
+        """Same race but the pod was replaced entirely (eviction)."""
+        pod = _make_pod(uid="uid-OLD", restart_count=0)
+
+        k8s_pods = [
+            # Pre-exec: still sees old UID (stale)
+            _k8s_pod(uid="uid-OLD", container_name="default", restart_count=0),
+            # Post-exec: new UID
+            _k8s_pod(uid="uid-NEW", container_name="default", restart_count=0),
+        ]
+
+        with (
+            patch("k8s_sandbox._pod.op.k8s_client") as mock_client,
+            patch(
+                "k8s_sandbox._pod.pod.ExecuteOperation"
+            ) as mock_exec_cls,
+        ):
+            mock_client.return_value.read_namespaced_pod.side_effect = k8s_pods
+            mock_exec_cls.return_value.exec.return_value = _failed_exec_result()
+
+            with pytest.raises(PodReplacedError) as exc_info:
+                await pod.exec(
+                    cmd=["echo", "hello"],
+                    stdin=None,
+                    cwd=None,
+                    env={},
+                    user=None,
+                    timeout=None,
+                )
+
+            err = exc_info.value
+            assert err.old_uid == "uid-OLD"
+            assert err.new_uid == "uid-NEW"
+
+        assert pod.info.uid == "uid-NEW"
+
+
+# ---------------------------------------------------------------------------
+# TDD specs: desired behavior after the fix
+# ---------------------------------------------------------------------------
+
+
+class TestPostExecRestartCheck:
+    """Specify the post-exec restart check behavior."""
+
+    async def test_failed_exec_no_restart_returns_exec_result(self) -> None:
+        """When exec fails but no restart happened, return the ExecResult
+        as-is. The caller can handle the failure normally."""
+        pod = _make_pod(uid="uid-1", restart_count=0)
+
+        # Both checks see restart_count=0 — no restart
+        k8s_pod_stable = _k8s_pod(
+            uid="uid-1", container_name="default", restart_count=0
+        )
+
+        with (
+            patch("k8s_sandbox._pod.op.k8s_client") as mock_client,
+            patch(
+                "k8s_sandbox._pod.pod.ExecuteOperation"
+            ) as mock_exec_cls,
+        ):
+            mock_client.return_value.read_namespaced_pod.return_value = (
+                k8s_pod_stable
+            )
+            mock_exec_cls.return_value.exec.return_value = _failed_exec_result()
+
+            result = await pod.exec(
+                cmd=["echo", "hello"],
+                stdin=None,
+                cwd=None,
+                env={},
+                user=None,
+                timeout=None,
+            )
+
+        assert not result.success
+        assert result.returncode == 127
+
+    async def test_successful_exec_no_post_check(self) -> None:
+        """When exec succeeds, don't bother with a post-exec restart check.
+        Verify only one API call (the pre-exec check)."""
+        pod = _make_pod(uid="uid-1", restart_count=0)
+
+        k8s_pod_stable = _k8s_pod(
+            uid="uid-1", container_name="default", restart_count=0
+        )
+
+        with (
+            patch("k8s_sandbox._pod.op.k8s_client") as mock_client,
+            patch(
+                "k8s_sandbox._pod.pod.ExecuteOperation"
+            ) as mock_exec_cls,
+        ):
+            mock_client.return_value.read_namespaced_pod.return_value = (
+                k8s_pod_stable
+            )
+            mock_exec_cls.return_value.exec.return_value = _success_exec_result()
+
+            result = await pod.exec(
+                cmd=["echo", "hello"],
+                stdin=None,
+                cwd=None,
+                env={},
+                user=None,
+                timeout=None,
+            )
+
+        assert result.success
+        # Only one API call: the pre-exec check
+        assert mock_client.return_value.read_namespaced_pod.call_count == 1
+
+    async def test_warn_mode_still_raises_after_failed_exec(self) -> None:
+        """Even in 'warn' mode, a restart detected after a failed exec
+        should raise. The warn policy means 'if you detect a restart but
+        the operation hasn't failed yet, just warn.' But if the operation
+        DID fail, the restart is the likely cause — surface it."""
+        pod = _make_pod(uid="uid-1", restart_count=0, behavior="warn")
+
+        k8s_pods = [
+            _k8s_pod(uid="uid-1", container_name="default", restart_count=0),
+            _k8s_pod(uid="uid-1", container_name="default", restart_count=1),
+        ]
+
+        with (
+            patch("k8s_sandbox._pod.op.k8s_client") as mock_client,
+            patch(
+                "k8s_sandbox._pod.pod.ExecuteOperation"
+            ) as mock_exec_cls,
+        ):
+            mock_client.return_value.read_namespaced_pod.side_effect = k8s_pods
+            mock_exec_cls.return_value.exec.return_value = _failed_exec_result()
+
+            with pytest.raises(ContainerRestartedError):
+                await pod.exec(
+                    cmd=["echo", "hello"],
+                    stdin=None,
+                    cwd=None,
+                    env={},
+                    user=None,
+                    timeout=None,
+                )
+
+    async def test_post_check_api_failure_does_not_mask_exec_result(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """If the post-exec restart check itself fails (e.g. K8s API
+        unreachable), don't mask the original exec failure. Return
+        the ExecResult and log a warning."""
+        pod = _make_pod(uid="uid-1", restart_count=0)
+
+        from kubernetes.client.exceptions import ApiException
+
+        with (
+            patch("k8s_sandbox._pod.op.k8s_client") as mock_client,
+            patch(
+                "k8s_sandbox._pod.pod.ExecuteOperation"
+            ) as mock_exec_cls,
+        ):
+            # Pre-exec check passes, post-exec check fails with API error
+            mock_client.return_value.read_namespaced_pod.side_effect = [
+                _k8s_pod(uid="uid-1", container_name="default", restart_count=0),
+                ApiException(status=503, reason="Service Unavailable"),
+            ]
+            mock_exec_cls.return_value.exec.return_value = _failed_exec_result()
+
+            with caplog.at_level("WARNING"):
+                result = await pod.exec(
+                    cmd=["echo", "hello"],
+                    stdin=None,
+                    cwd=None,
+                    env={},
+                    user=None,
+                    timeout=None,
+                )
+
+        assert not result.success
+        assert result.returncode == 127
+        assert any("re-check failed" in r.message for r in caplog.records)
+
+    async def test_two_api_calls_on_failed_exec(self) -> None:
+        """Verify the post-exec check actually makes a second API call."""
+        pod = _make_pod(uid="uid-1", restart_count=0)
+
+        k8s_pods = [
+            _k8s_pod(uid="uid-1", container_name="default", restart_count=0),
+            _k8s_pod(uid="uid-1", container_name="default", restart_count=1),
+        ]
+
+        with (
+            patch("k8s_sandbox._pod.op.k8s_client") as mock_client,
+            patch(
+                "k8s_sandbox._pod.pod.ExecuteOperation"
+            ) as mock_exec_cls,
+        ):
+            mock_client.return_value.read_namespaced_pod.side_effect = k8s_pods
+            mock_exec_cls.return_value.exec.return_value = _failed_exec_result()
+
+            with pytest.raises(ContainerRestartedError):
+                await pod.exec(
+                    cmd=["echo", "hello"],
+                    stdin=None,
+                    cwd=None,
+                    env={},
+                    user=None,
+                    timeout=None,
+                )
+
+        # Two API calls: pre-exec and post-exec
+        assert mock_client.return_value.read_namespaced_pod.call_count == 2

--- a/test/k8s_sandbox/test_diagnostics.py
+++ b/test/k8s_sandbox/test_diagnostics.py
@@ -1,0 +1,134 @@
+from unittest.mock import MagicMock, patch
+
+from kubernetes.client import (  # type: ignore
+    CoreV1Event,
+    CoreV1EventList,
+    V1ContainerState,
+    V1ContainerStateTerminated,
+    V1ContainerStateWaiting,
+    V1ContainerStatus,
+    V1ObjectMeta,
+    V1ObjectReference,
+    V1Pod,
+    V1PodList,
+    V1PodStatus,
+)
+
+from k8s_sandbox._diagnostics import describe_release_pods
+
+
+def _pod(name: str, phase: str, container_statuses, labels=None) -> V1Pod:
+    return V1Pod(
+        metadata=V1ObjectMeta(name=name, labels=labels or {}),
+        status=V1PodStatus(phase=phase, container_statuses=container_statuses),
+    )
+
+
+def _patch_client(pods, events=None):
+    client = MagicMock()
+    client.list_namespaced_pod.return_value = V1PodList(items=pods)
+    client.list_namespaced_event.return_value = CoreV1EventList(items=events or [])
+    return patch("k8s_sandbox._diagnostics.k8s_client", return_value=client)
+
+
+def test_surfaces_oom_killed_reason_exit_code_and_restart_count() -> None:
+    container = V1ContainerStatus(
+        name="default",
+        image="busybox:1.36",
+        image_id="",
+        ready=False,
+        restart_count=3,
+        state=V1ContainerState(
+            waiting=V1ContainerStateWaiting(reason="CrashLoopBackOff")
+        ),
+        last_state=V1ContainerState(
+            terminated=V1ContainerStateTerminated(reason="OOMKilled", exit_code=137)
+        ),
+    )
+    pods = [_pod("rel-default", "Running", [container])]
+
+    with _patch_client(pods):
+        summary = describe_release_pods(None, "default", "rel")
+
+    assert summary is not None
+    assert "default" in summary  # container name
+    assert "OOMKilled" in summary
+    assert "137" in summary
+    assert "3" in summary  # restart count
+
+
+def test_surfaces_image_pull_backoff_reason_message_and_image() -> None:
+    container = V1ContainerStatus(
+        name="default",
+        image="nonexistent.invalid/nope:latest",
+        image_id="",
+        ready=False,
+        restart_count=0,
+        state=V1ContainerState(
+            waiting=V1ContainerStateWaiting(
+                reason="ImagePullBackOff",
+                message='Back-off pulling image "nonexistent.invalid/nope:latest"',
+            )
+        ),
+    )
+    pods = [_pod("rel-default", "Pending", [container])]
+
+    with _patch_client(pods):
+        summary = describe_release_pods(None, "default", "rel")
+
+    assert summary is not None
+    assert "ImagePullBackOff" in summary
+    assert "Back-off pulling image" in summary
+    assert "nonexistent.invalid/nope:latest" in summary
+
+
+def test_surfaces_failed_scheduling_event_when_pod_has_no_container_statuses() -> None:
+    # An unschedulable pod stays Pending with no container statuses; the actionable
+    # detail is in a FailedScheduling Warning event.
+    pods = [_pod("rel-default", "Pending", container_statuses=None)]
+    events = [
+        CoreV1Event(
+            metadata=V1ObjectMeta(name="evt-1"),
+            involved_object=V1ObjectReference(name="rel-default"),
+            reason="FailedScheduling",
+            message="0/1 nodes available: 1 Insufficient cpu",
+            type="Warning",
+        )
+    ]
+
+    with _patch_client(pods, events) as mock_client_factory:
+        summary = describe_release_pods(None, "default", "rel")
+
+    assert summary is not None
+    assert "FailedScheduling" in summary
+    assert "Insufficient cpu" in summary
+    # Warning events are filtered server-side rather than in Python.
+    mock_client_factory.return_value.list_namespaced_event.assert_called_once_with(
+        "default", field_selector="type=Warning"
+    )
+
+
+def test_returns_none_and_does_not_raise_when_api_call_fails() -> None:
+    # describe_release_pods runs from error-handling paths; it must never raise and mask
+    # the original failure.
+    with patch("k8s_sandbox._diagnostics.k8s_client", side_effect=RuntimeError("boom")):
+        summary = describe_release_pods(None, "default", "rel")
+
+    assert summary is None
+
+
+def test_returns_none_when_all_containers_healthy_and_no_events() -> None:
+    container = V1ContainerStatus(
+        name="default",
+        image="busybox:1.36",
+        image_id="",
+        ready=True,
+        restart_count=0,
+        state=V1ContainerState(running={"started_at": None}),
+    )
+    pods = [_pod("rel-default", "Running", [container])]
+
+    with _patch_client(pods):
+        summary = describe_release_pods(None, "default", "rel")
+
+    assert summary is None

--- a/test/k8s_sandbox/test_helm.py
+++ b/test/k8s_sandbox/test_helm.py
@@ -734,3 +734,47 @@ async def test_helm_labels_appear_on_release_secret(
             assert secret_labels.labels.get(key) == value
     finally:
         await release.uninstall(quiet=True)
+
+
+async def test_install_error_includes_pod_diagnostics() -> None:
+    release = Release(
+        __file__,
+        chart_path=Path("/non_existent_chart"),
+        values_source=ValuesSource.none(),
+        context_name=None,
+    )
+    result = ExecResult(
+        success=False,
+        returncode=1,
+        stdout="",
+        stderr="Error: INSTALLATION FAILED: resource Pod/default/x not ready.\n",
+    )
+    diagnostics = "container 'default': last terminated OOMKilled (exit code 137)"
+
+    with patch("k8s_sandbox._helm.describe_release_pods", return_value=diagnostics):
+        with pytest.raises(RuntimeError) as excinfo:
+            await release._raise_install_error(result)
+
+    assert "OOMKilled" in str(excinfo.value)
+    assert "137" in str(excinfo.value)
+
+
+async def test_install_error_omits_diagnostics_when_unavailable() -> None:
+    release = Release(
+        __file__,
+        chart_path=Path("/non_existent_chart"),
+        values_source=ValuesSource.none(),
+        context_name=None,
+    )
+    result = ExecResult(
+        success=False,
+        returncode=1,
+        stdout="",
+        stderr="Error: INSTALLATION FAILED: resource Pod/default/x not ready.\n",
+    )
+
+    with patch("k8s_sandbox._helm.describe_release_pods", return_value=None):
+        with pytest.raises(RuntimeError) as excinfo:
+            await release._raise_install_error(result)
+
+    assert "Helm install failed." in str(excinfo.value)


### PR DESCRIPTION
Closes #191

Rechecks for container restart after a failed exec. Narrows the race window between kubelet restarting the container and the k8s API updating restart_count. If the API hasn't caught up by then, the original
failure will still surface as-is.

Now raises `ContainerRestartedError` with pod name, restart count, and termination reason.

Always raises on restart detection even in warn mode, given the exec already failed. API errors during the re-check are logged at WARNING and do not mask the original failure.