### PR TITLE
fix: recheck for container restart after failed exec

### DIFF
--- a/docs/docs/design/limitations.md
+++ b/docs/docs/design/limitations.md
@@ -41,9 +41,10 @@ chart](../helm//built-in-chart.md#resource-requests-and-limits).
 
 You can reduce the impact of a container restarting by using persistent volumes.
 
-The framework will issue a warning if a container restarts during an eval. If you set
-the `restarted_container_behaviour` parameter to `raise`, the eval will fail the sample
-if it detects a container restart.
+The framework will issue a warning if a container restarts during an eval. If a
+subsequent `exec()` fails after a detected restart, the restart is raised as the cause
+regardless of mode. If you set the `restarted_container_behaviour` parameter to `raise`,
+the eval will fail the sample immediately on detection, even if `exec()` has not failed.
 
 ??? question "Why not use Jobs over StatefulSets?"
 

--- a/src/k8s_sandbox/_pod/pod.py
+++ b/src/k8s_sandbox/_pod/pod.py
@@ -161,8 +161,7 @@ class Pod:
             raise
         except Exception:
             logger.warning(
-                "Post-exec restart re-check failed; "
-                "returning original exec result",
+                "Post-exec restart re-check failed; returning original exec result",
                 exc_info=True,
             )
 

--- a/src/k8s_sandbox/_pod/pod.py
+++ b/src/k8s_sandbox/_pod/pod.py
@@ -151,13 +151,12 @@ class Pod:
         if not result.success:
             if warned_restart is not None:
                 raise warned_restart
-            await self._recheck_for_restart_after_failed_exec()
+            await self._diagnose_restart_after_failed_exec()
         return result
 
-    async def _recheck_for_restart_after_failed_exec(self) -> None:
-        """Re-check for restart after a failed exec to close the race window."""
+    async def _diagnose_restart_after_failed_exec(self) -> None:
         try:
-            await self._run_async(self._recheck_for_restart_sync)
+            restart = await self.check_for_pod_restart()
         except (PodReplacedError, ContainerRestartedError):
             raise
         except Exception:
@@ -165,23 +164,9 @@ class Pod:
                 "Post-exec restart re-check failed; returning original exec result",
                 exc_info=True,
             )
-
-    def _recheck_for_restart_sync(self) -> None:
-        try:
-            check_for_pod_restart(self._info)
-        except PodReplacedError as e:
-            self._info = dataclasses.replace(
-                self._info,
-                uid=e.new_uid,
-                initial_restart_count=e.new_restart_count,
-            )
-            raise
-        except ContainerRestartedError as e:
-            self._info = dataclasses.replace(
-                self._info,
-                initial_restart_count=e.restart_count,
-            )
-            raise
+            return
+        if restart is not None:
+            raise restart
 
     async def write_file(self, data: bytes, dst: Path) -> None:
         """

--- a/src/k8s_sandbox/_pod/pod.py
+++ b/src/k8s_sandbox/_pod/pod.py
@@ -49,7 +49,9 @@ class Pod:
         """
         return self._info
 
-    async def check_for_pod_restart(self) -> None:
+    async def check_for_pod_restart(
+        self,
+    ) -> PodReplacedError | ContainerRestartedError | None:
         """Check whether the pod has been replaced or its container has restarted.
 
         On detection, refreshes the cached identity (``uid`` and/or
@@ -57,17 +59,17 @@ class Pod:
         without re-raising the same condition. Whether the detection raises is
         governed by ``restarted_container_behavior``:
 
-        - ``"warn"``: log a warning and return normally.
+        - ``"warn"``: log a warning and return the detected error.
         - ``"raise"``: raise ``PodReplacedError`` or ``ContainerRestartedError``.
         """
-        await self._run_async(self._check_for_pod_restart_sync)
+        return await self._run_async(self._check_for_pod_restart_sync)
 
-    def _check_for_pod_restart_sync(self) -> None:
+    def _check_for_pod_restart_sync(
+        self,
+    ) -> PodReplacedError | ContainerRestartedError | None:
         try:
             check_for_pod_restart(self._info)
         except PodReplacedError as e:
-            # Refresh cached identity atomically (frozen dataclass replacement
-            # is an attribute assignment, which is atomic in CPython).
             self._info = dataclasses.replace(
                 self._info,
                 uid=e.new_uid,
@@ -75,7 +77,7 @@ class Pod:
             )
             if self._info.restarted_container_behavior == "warn":
                 logger.warning(str(e))
-                return
+                return e
             raise
         except ContainerRestartedError as e:
             self._info = dataclasses.replace(
@@ -84,8 +86,9 @@ class Pod:
             )
             if self._info.restarted_container_behavior == "warn":
                 logger.warning(str(e))
-                return
+                return e
             raise
+        return None
 
     async def exec(
         self,
@@ -140,33 +143,21 @@ class Pod:
             elapsed. This is enforced by the `timeout` command on the pod. This will not
             terminate background processes started by cmd.
         """
-        restart_count_before = self._info.initial_restart_count
-        uid_before = self._info.uid
-        await self.check_for_pod_restart()
+        warned_restart = await self.check_for_pod_restart()
         executor = ExecuteOperation(self._info)
         result = await self._run_async(
             lambda: executor.exec(cmd, stdin, cwd, env, user, timeout)
         )
         if not result.success:
-            await self._recheck_for_restart_after_failed_exec(
-                restart_count_before, uid_before
-            )
+            if warned_restart is not None:
+                raise warned_restart
+            await self._recheck_for_restart_after_failed_exec()
         return result
 
-    async def _recheck_for_restart_after_failed_exec(
-        self,
-        restart_count_before: int,
-        uid_before: str,
-    ) -> None:
-        """Re-check for restart after a failed exec.
-
-        Uses the pre-exec snapshot as baseline so restarts detected-and-warned
-        by the pre-exec check are still visible here.
-        """
+    async def _recheck_for_restart_after_failed_exec(self) -> None:
+        """Re-check for restart after a failed exec to close the race window."""
         try:
-            await self._run_async(
-                lambda: self._recheck_for_restart_sync(restart_count_before, uid_before)
-            )
+            await self._run_async(self._recheck_for_restart_sync)
         except (PodReplacedError, ContainerRestartedError):
             raise
         except Exception:
@@ -175,18 +166,9 @@ class Pod:
                 exc_info=True,
             )
 
-    def _recheck_for_restart_sync(
-        self, restart_count_before: int, uid_before: str
-    ) -> None:
-        # Use the pre-exec snapshot so we can see restarts that the
-        # pre-exec warn-mode check already consumed.
-        snapshot = dataclasses.replace(
-            self._info,
-            initial_restart_count=restart_count_before,
-            uid=uid_before,
-        )
+    def _recheck_for_restart_sync(self) -> None:
         try:
-            check_for_pod_restart(snapshot)
+            check_for_pod_restart(self._info)
         except PodReplacedError as e:
             self._info = dataclasses.replace(
                 self._info,

--- a/src/k8s_sandbox/_pod/pod.py
+++ b/src/k8s_sandbox/_pod/pod.py
@@ -140,23 +140,33 @@ class Pod:
             elapsed. This is enforced by the `timeout` command on the pod. This will not
             terminate background processes started by cmd.
         """
+        restart_count_before = self._info.initial_restart_count
+        uid_before = self._info.uid
         await self.check_for_pod_restart()
         executor = ExecuteOperation(self._info)
         result = await self._run_async(
             lambda: executor.exec(cmd, stdin, cwd, env, user, timeout)
         )
         if not result.success:
-            await self._recheck_for_restart_after_failed_exec()
+            await self._recheck_for_restart_after_failed_exec(
+                restart_count_before, uid_before
+            )
         return result
 
-    async def _recheck_for_restart_after_failed_exec(self) -> None:
-        """Re-check for restart after a failed exec to close the race window.
+    async def _recheck_for_restart_after_failed_exec(
+        self,
+        restart_count_before: int,
+        uid_before: str,
+    ) -> None:
+        """Re-check for restart after a failed exec.
 
-        Always raises on detection regardless of restarted_container_behavior
-        — the exec already failed, so the restart is operationally relevant.
+        Uses the pre-exec snapshot as baseline so restarts detected-and-warned
+        by the pre-exec check are still visible here.
         """
         try:
-            await self._run_async(self._recheck_for_restart_sync)
+            await self._run_async(
+                lambda: self._recheck_for_restart_sync(restart_count_before, uid_before)
+            )
         except (PodReplacedError, ContainerRestartedError):
             raise
         except Exception:
@@ -165,9 +175,18 @@ class Pod:
                 exc_info=True,
             )
 
-    def _recheck_for_restart_sync(self) -> None:
+    def _recheck_for_restart_sync(
+        self, restart_count_before: int, uid_before: str
+    ) -> None:
+        # Use the pre-exec snapshot so we can see restarts that the
+        # pre-exec warn-mode check already consumed.
+        snapshot = dataclasses.replace(
+            self._info,
+            initial_restart_count=restart_count_before,
+            uid=uid_before,
+        )
         try:
-            check_for_pod_restart(self._info)
+            check_for_pod_restart(snapshot)
         except PodReplacedError as e:
             self._info = dataclasses.replace(
                 self._info,

--- a/src/k8s_sandbox/_pod/pod.py
+++ b/src/k8s_sandbox/_pod/pod.py
@@ -145,7 +145,43 @@ class Pod:
         result = await self._run_async(
             lambda: executor.exec(cmd, stdin, cwd, env, user, timeout)
         )
+        if not result.success:
+            await self._recheck_for_restart_after_failed_exec()
         return result
+
+    async def _recheck_for_restart_after_failed_exec(self) -> None:
+        """Re-check for restart after a failed exec to close the race window.
+
+        Always raises on detection regardless of restarted_container_behavior
+        — the exec already failed, so the restart is operationally relevant.
+        """
+        try:
+            await self._run_async(self._recheck_for_restart_sync)
+        except (PodReplacedError, ContainerRestartedError):
+            raise
+        except Exception:
+            logger.warning(
+                "Post-exec restart re-check failed; "
+                "returning original exec result",
+                exc_info=True,
+            )
+
+    def _recheck_for_restart_sync(self) -> None:
+        try:
+            check_for_pod_restart(self._info)
+        except PodReplacedError as e:
+            self._info = dataclasses.replace(
+                self._info,
+                uid=e.new_uid,
+                initial_restart_count=e.new_restart_count,
+            )
+            raise
+        except ContainerRestartedError as e:
+            self._info = dataclasses.replace(
+                self._info,
+                initial_restart_count=e.restart_count,
+            )
+            raise
 
     async def write_file(self, data: bytes, dst: Path) -> None:
         """

--- a/test/k8s_sandbox/pod/test_post_exec_restart_check.py
+++ b/test/k8s_sandbox/pod/test_post_exec_restart_check.py
@@ -138,6 +138,35 @@ async def test_warn_mode_still_raises_after_failed_exec():
             )
 
 
+async def test_warn_mode_api_fast_still_raises_after_failed_exec():
+    # API already knows about the restart before exec runs.
+    # Pre-exec warn-mode check logs and updates the counter.
+    # Post-exec check must still detect it using the pre-exec snapshot.
+    pod = _make_pod(restarted_container_behavior="warn")
+
+    k8s_pod = _k8s_pod(uid="uid-OLD", container_name="default", restart_count=1)
+
+    with (
+        patch("k8s_sandbox._pod.op.k8s_client") as mock_client,
+        patch("k8s_sandbox._pod.pod.ExecuteOperation") as mock_exec_cls,
+    ):
+        mock_client.return_value.read_namespaced_pod.return_value = k8s_pod
+        mock_exec_cls.return_value.exec.return_value = _failed_exec_result()
+
+        with pytest.raises(ContainerRestartedError) as exc_info:
+            await pod.exec(
+                cmd=["echo", "hello"],
+                stdin=None,
+                cwd=None,
+                env={},
+                user=None,
+                timeout=None,
+            )
+
+    assert exc_info.value.restart_count == 1
+    assert pod.info.initial_restart_count == 1
+
+
 async def test_recheck_api_failure_does_not_mask_exec_result(
     caplog: pytest.LogCaptureFixture,
 ):

--- a/test/k8s_sandbox/pod/test_post_exec_restart_check.py
+++ b/test/k8s_sandbox/pod/test_post_exec_restart_check.py
@@ -110,38 +110,9 @@ async def test_failed_exec_no_restart_returns_exec_result():
     assert result.returncode == 127
 
 
-async def test_warn_mode_still_raises_after_failed_exec():
-    # Warn policy means "restart detected but operation hasn't failed yet, just warn."
-    # After a failed exec the restart is the cause — always raise.
-    pod = _make_pod(restarted_container_behavior="warn")
-
-    k8s_pods = [
-        _k8s_pod(uid="uid-OLD", container_name="default", restart_count=0),
-        _k8s_pod(uid="uid-OLD", container_name="default", restart_count=1),
-    ]
-
-    with (
-        patch("k8s_sandbox._pod.op.k8s_client") as mock_client,
-        patch("k8s_sandbox._pod.pod.ExecuteOperation") as mock_exec_cls,
-    ):
-        mock_client.return_value.read_namespaced_pod.side_effect = k8s_pods
-        mock_exec_cls.return_value.exec.return_value = _failed_exec_result()
-
-        with pytest.raises(ContainerRestartedError):
-            await pod.exec(
-                cmd=["echo", "hello"],
-                stdin=None,
-                cwd=None,
-                env={},
-                user=None,
-                timeout=None,
-            )
-
-
 async def test_warn_mode_api_fast_still_raises_after_failed_exec():
-    # API already knows about the restart before exec runs.
-    # Pre-exec warn-mode check logs and updates the counter.
-    # Post-exec check must still detect it using the pre-exec snapshot.
+    # Pre-exec check detects the restart but warns instead of raising.
+    # exec() keeps the returned error and re-raises it when exec fails.
     pod = _make_pod(restarted_container_behavior="warn")
 
     k8s_pod = _k8s_pod(uid="uid-OLD", container_name="default", restart_count=1)

--- a/test/k8s_sandbox/pod/test_post_exec_restart_check.py
+++ b/test/k8s_sandbox/pod/test_post_exec_restart_check.py
@@ -1,0 +1,168 @@
+from unittest.mock import patch
+
+import pytest
+from inspect_ai.util import ExecResult
+from kubernetes.client.exceptions import ApiException
+
+from k8s_sandbox._pod.error import ContainerRestartedError, PodReplacedError
+
+# Reuse the mock helpers from the existing restart tests.
+from test.k8s_sandbox.pod.test_check_for_pod_restart import _k8s_pod, _make_pod
+
+
+def _failed_exec_result() -> ExecResult[str]:
+    return ExecResult(
+        success=False,
+        returncode=127,
+        stdout="",
+        stderr=(
+            "timeout: failed to run command "
+            "'/var/tmp/.da7be258e003d428/inspect-sandbox-tools': "
+            "No such file or directory"
+        ),
+    )
+
+
+async def test_race_window_restart_detected_on_recheck():
+    pod = _make_pod()
+
+    # Pre-exec check sees stale state; post-exec check sees the restart
+    k8s_pods = [
+        _k8s_pod(uid="uid-OLD", container_name="default", restart_count=0),
+        _k8s_pod(uid="uid-OLD", container_name="default", restart_count=1),
+    ]
+
+    with (
+        patch("k8s_sandbox._pod.op.k8s_client") as mock_client,
+        patch("k8s_sandbox._pod.pod.ExecuteOperation") as mock_exec_cls,
+    ):
+        mock_client.return_value.read_namespaced_pod.side_effect = k8s_pods
+        mock_exec_cls.return_value.exec.return_value = _failed_exec_result()
+
+        with pytest.raises(ContainerRestartedError) as exc_info:
+            await pod.exec(
+                cmd=["echo", "hello"],
+                stdin=None,
+                cwd=None,
+                env={},
+                user=None,
+                timeout=None,
+            )
+
+    assert exc_info.value.restart_count == 1
+    assert exc_info.value.last_reason == "OOMKilled"
+    assert pod.info.initial_restart_count == 1
+
+
+async def test_race_window_pod_replaced_on_recheck():
+    pod = _make_pod()
+
+    k8s_pods = [
+        _k8s_pod(uid="uid-OLD", container_name="default", restart_count=0),
+        _k8s_pod(uid="uid-NEW", container_name="default", restart_count=0),
+    ]
+
+    with (
+        patch("k8s_sandbox._pod.op.k8s_client") as mock_client,
+        patch("k8s_sandbox._pod.pod.ExecuteOperation") as mock_exec_cls,
+    ):
+        mock_client.return_value.read_namespaced_pod.side_effect = k8s_pods
+        mock_exec_cls.return_value.exec.return_value = _failed_exec_result()
+
+        with pytest.raises(PodReplacedError) as exc_info:
+            await pod.exec(
+                cmd=["echo", "hello"],
+                stdin=None,
+                cwd=None,
+                env={},
+                user=None,
+                timeout=None,
+            )
+
+    assert exc_info.value.old_uid == "uid-OLD"
+    assert exc_info.value.new_uid == "uid-NEW"
+    assert pod.info.uid == "uid-NEW"
+
+
+async def test_failed_exec_no_restart_returns_exec_result():
+    pod = _make_pod()
+
+    # Both checks see the same state — no restart happened
+    k8s_pod = _k8s_pod(uid="uid-OLD", container_name="default", restart_count=0)
+
+    with (
+        patch("k8s_sandbox._pod.op.k8s_client") as mock_client,
+        patch("k8s_sandbox._pod.pod.ExecuteOperation") as mock_exec_cls,
+    ):
+        mock_client.return_value.read_namespaced_pod.return_value = k8s_pod
+        mock_exec_cls.return_value.exec.return_value = _failed_exec_result()
+
+        result = await pod.exec(
+            cmd=["echo", "hello"],
+            stdin=None,
+            cwd=None,
+            env={},
+            user=None,
+            timeout=None,
+        )
+
+    assert not result.success
+    assert result.returncode == 127
+
+
+async def test_warn_mode_still_raises_after_failed_exec():
+    # Warn policy means "restart detected but operation hasn't failed yet, just warn."
+    # After a failed exec the restart is the cause — always raise.
+    pod = _make_pod(restarted_container_behavior="warn")
+
+    k8s_pods = [
+        _k8s_pod(uid="uid-OLD", container_name="default", restart_count=0),
+        _k8s_pod(uid="uid-OLD", container_name="default", restart_count=1),
+    ]
+
+    with (
+        patch("k8s_sandbox._pod.op.k8s_client") as mock_client,
+        patch("k8s_sandbox._pod.pod.ExecuteOperation") as mock_exec_cls,
+    ):
+        mock_client.return_value.read_namespaced_pod.side_effect = k8s_pods
+        mock_exec_cls.return_value.exec.return_value = _failed_exec_result()
+
+        with pytest.raises(ContainerRestartedError):
+            await pod.exec(
+                cmd=["echo", "hello"],
+                stdin=None,
+                cwd=None,
+                env={},
+                user=None,
+                timeout=None,
+            )
+
+
+async def test_recheck_api_failure_does_not_mask_exec_result(
+    caplog: pytest.LogCaptureFixture,
+):
+    pod = _make_pod()
+
+    with (
+        patch("k8s_sandbox._pod.op.k8s_client") as mock_client,
+        patch("k8s_sandbox._pod.pod.ExecuteOperation") as mock_exec_cls,
+    ):
+        mock_client.return_value.read_namespaced_pod.side_effect = [
+            _k8s_pod(uid="uid-OLD", container_name="default", restart_count=0),
+            ApiException(status=503, reason="Service Unavailable"),
+        ]
+        mock_exec_cls.return_value.exec.return_value = _failed_exec_result()
+
+        with caplog.at_level("WARNING"):
+            result = await pod.exec(
+                cmd=["echo", "hello"],
+                stdin=None,
+                cwd=None,
+                env={},
+                user=None,
+                timeout=None,
+            )
+
+    assert not result.success
+    assert result.returncode == 127
+    assert any("re-check failed" in r.message for r in caplog.records)


### PR DESCRIPTION
Closes #191

Adds a post-exec check in `Pod.exec()` for container restarts when exec fails.

If `exec()` fails, and the pre-check found that the container had restarted, we re-raise the initial error.
If `exec()` doesn't initially fail, but exec fails, and the post-check finds the container has restarted, we raise `ContainerRestartedError`/`PodReplacedError` that was detected.

API errors during the post-check are logged at WARNING and don't mask the failure.