### PR TITLE
Tests: consume inspect's portable self_check pytest suite

### DIFF
--- a/test/k8s_sandbox/test_inspect_self_check.py
+++ b/test/k8s_sandbox/test_inspect_self_check.py
@@ -2,13 +2,30 @@ from typing import AsyncGenerator
 
 import pytest
 import pytest_asyncio
-from inspect_ai.util import SandboxEnvironment
-from inspect_ai.util._sandbox.self_check import self_check
+from inspect_ai.util._sandbox.self_check import *  # noqa: F401, F403
 
 from k8s_sandbox._sandbox_environment import K8sSandboxEnvironment
 from test.k8s_sandbox.utils import install_sandbox_environments
 
 pytestmark = pytest.mark.req_k8s
+
+# Known failures per sandbox, applied as strict xfails in the sandbox_env fixture
+# (keyed on the running check's function name). Strict means a check that starts
+# passing here is surfaced rather than silently ignored.
+_ROOT_XFAILS = {
+    # Running as a nonexistent user raises (by design) instead of returning a
+    # failed ExecResult, which is what the check expects.
+    "test_exec_as_nonexistent_user": "k8s raises for a nonexistent user",
+    # Root can read/write regardless of the permission bits.
+    "test_read_file_not_allowed": "root can read after chmod -r",
+    "test_write_text_file_without_permissions": "root can write after chmod -w",
+    "test_write_binary_file_without_permissions": "root can write after chmod -w",
+}
+_NON_ROOT_XFAILS = {
+    "test_exec_as_nonexistent_user": "k8s raises for a nonexistent user",
+    # In k8s the container must run as root to exec as a different user.
+    "test_exec_as_user": "container must run as root to exec as a different user",
+}
 
 
 @pytest_asyncio.fixture(scope="module")
@@ -17,53 +34,15 @@ async def sandboxes() -> AsyncGenerator[dict[str, K8sSandboxEnvironment], None]:
         yield envs
 
 
-@pytest_asyncio.fixture(scope="module")
-async def root(sandboxes: dict[str, K8sSandboxEnvironment]) -> K8sSandboxEnvironment:
-    return sandboxes["default"]
-
-
-@pytest_asyncio.fixture(scope="module")
-async def non_root(
-    sandboxes: dict[str, K8sSandboxEnvironment],
+@pytest_asyncio.fixture(
+    params=[("default", _ROOT_XFAILS), ("nonroot", _NON_ROOT_XFAILS)],
+    ids=["root", "non-root"],
+)
+async def sandbox_env(
+    request: pytest.FixtureRequest, sandboxes: dict[str, K8sSandboxEnvironment]
 ) -> K8sSandboxEnvironment:
-    return sandboxes["nonroot"]
-
-
-async def test_self_check_k8s_default_root(root: SandboxEnvironment) -> None:
-    known_failures = [
-        # Running as a nonexistent user results in an exception being raised (by design)
-        # whereas the test expects an ExecResult to be returned without an exception.
-        "test_exec_as_nonexistent_user",
-        # Root can read from files after `chmod -r`.
-        "test_read_file_not_allowed",
-        # Root can write to files after `chmod -w`.
-        "test_write_text_file_without_permissions",
-        "test_write_binary_file_without_permissions",
-    ]
-
-    return await _run_self_check(root, known_failures)
-
-
-async def test_self_check_k8s_non_root(non_root: SandboxEnvironment) -> None:
-    known_failures = [
-        # Running as a nonexistent user results in an exception being raised (by design)
-        # whereas the test expects an ExecResult to be returned without an exception.
-        "test_exec_as_nonexistent_user",
-        # In K8s, the container must be running as root to exec as a different user.
-        "test_exec_as_user",
-    ]
-
-    return await _run_self_check(non_root, known_failures)
-
-
-async def _run_self_check(
-    sandbox_env: SandboxEnvironment, known_failures: list[str] = []
-) -> None:
-    """Self-check is the name of Inspect's test suite which runs against sandboxes."""
-    self_check_results = await self_check(sandbox_env)
-    failures = []
-    for test_name, result in self_check_results.items():
-        if result is not True and test_name not in known_failures:
-            failures.append(f"Test {test_name} failed: {result}")
-    if failures:
-        assert False, "\n".join(failures)
+    key, xfails = request.param
+    reason = xfails.get(request.node.originalname)
+    if reason is not None:
+        request.node.add_marker(pytest.mark.xfail(reason=reason, strict=True))
+    return sandboxes[key]

--- a/test/k8s_sandbox/test_inspect_self_check.py
+++ b/test/k8s_sandbox/test_inspect_self_check.py
@@ -20,11 +20,13 @@ _ROOT_XFAILS = {
     "test_read_file_not_allowed": "root can read after chmod -r",
     "test_write_text_file_without_permissions": "root can write after chmod -w",
     "test_write_binary_file_without_permissions": "root can write after chmod -w",
+    "test_exec_input_large": "large stdin is silently dropped, see #244",
 }
 _NON_ROOT_XFAILS = {
     "test_exec_as_nonexistent_user": "k8s raises for a nonexistent user",
     # In k8s the container must run as root to exec as a different user.
     "test_exec_as_user": "container must run as root to exec as a different user",
+    "test_exec_input_large": "large stdin is silently dropped, see #244",
 }
 
 

--- a/test/k8s_sandbox/test_inspect_self_check.py
+++ b/test/k8s_sandbox/test_inspect_self_check.py
@@ -20,13 +20,16 @@ _ROOT_XFAILS = {
     "test_read_file_not_allowed": "root can read after chmod -r",
     "test_write_text_file_without_permissions": "root can write after chmod -w",
     "test_write_binary_file_without_permissions": "root can write after chmod -w",
-    "test_exec_input_large": "large stdin is silently dropped, see #244",
 }
 _NON_ROOT_XFAILS = {
     "test_exec_as_nonexistent_user": "k8s raises for a nonexistent user",
     # In k8s the container must run as root to exec as a different user.
     "test_exec_as_user": "container must run as root to exec as a different user",
-    "test_exec_input_large": "large stdin is silently dropped, see #244",
+}
+# Non-strict: the drop is environment-dependent (fails on one minikube at
+# ~40-44 MiB, passes on another at 50 MiB), so an XPASS is not a signal.
+_NONSTRICT_XFAILS = {
+    "test_exec_input_large": "large stdin can be silently dropped, see #244",
 }
 
 
@@ -47,4 +50,9 @@ async def sandbox_env(
     reason = xfails.get(request.node.originalname)
     if reason is not None:
         request.node.add_marker(pytest.mark.xfail(reason=reason, strict=True))
+    nonstrict_reason = _NONSTRICT_XFAILS.get(request.node.originalname)
+    if nonstrict_reason is not None:
+        request.node.add_marker(
+            pytest.mark.xfail(reason=nonstrict_reason, strict=False)
+        )
     return sandboxes[key]


### PR DESCRIPTION
## What

Adapts `test/k8s_sandbox/test_inspect_self_check.py` to the new sandbox conformance suite in `inspect_ai`, which replaces the `self_check()` runner with importable pytest checks driven by a `sandbox_env` fixture.

**Depends on UKGovernmentBEIS/inspect_ai#4265.**

## Verification
Run against local minikube (containerd + gVisor + Cilium) with the inspect_ai#4265 branch installed: **80 passed, 8 xfailed**. Six xfails match the prior `known_failures`; two are new:
- root + non-root: `test_exec_input_large` — a check added upstream after this PR was opened. It exposed that exec() can silently drop large stdin (#244). This xfail is **non-strict**: the drop is environment-dependent (fails on my minikube, XPASSed on CI's), so an XPASS is not a signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
