### PR TITLE
Add per-service `x-inspect_k8s_sandbox.resources` extension to the compose converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add a per-service `x-inspect_k8s_sandbox.resources` extension to the compose-to-helm converter for declaring Kubernetes resource `requests`/`limits` (e.g. request-only `ephemeral-storage`) that the `mem_limit`/`cpus`/`deploy.resources` shortcuts cannot express. Keys are merged into the resources derived from those shortcuts; conflicts are rejected rather than silently overridden.
 - Propagate the caller's context into the pod-operation worker thread to ensure that Inspect sandbox config overrides are honoured.
 - Raise typed `PodReplacedError` / `ContainerRestartedError` (instead of `RuntimeError`) when a pod operation detects the pod has been replaced or its container restarted, and refresh the cached pod identity so subsequent operations target the new pod instead of looping against a stale UID. `restarted_container_behavior="warn"` now also refreshes (previously left the cached UID stale).
 - Fix `exec(input=...)` failing with "Connection reset by peer" for large inputs (e.g. injecting a ~28 MiB binary): stdin is now written to the pod in ≤1 MiB WebSocket frames instead of a single oversized frame. `write_file` shares the same chunking helper.

--- a/docs/docs/helm/compose-to-helm.md
+++ b/docs/docs/helm/compose-to-helm.md
@@ -102,3 +102,45 @@ services:
     image: ubuntu
     network_mode: none
 ```
+
+## Resource Requests and Limits
+
+Use the per-service `x-inspect_k8s_sandbox` extension to set Kubernetes resource
+requests and limits that the Docker Compose shortcuts (`mem_limit`, `cpus` and
+`deploy.resources`) cannot express. The `resources` block is merged into the
+`requests`/`limits` that the converter derives from those shortcuts.
+
+The motivating case is a _request-only_ resource such as `ephemeral-storage` — a
+scheduling floor with no eviction cap:
+
+```yaml
+services:
+  default:
+    image: ubuntu
+    mem_limit: 32g
+    cpus: 4.0
+    x-inspect_k8s_sandbox:
+      resources:
+        requests:
+          ephemeral-storage: 80Gi
+```
+
+This produces the following Helm values for the service:
+
+```yaml
+services:
+  default:
+    resources:
+      limits: {memory: 32Gi, cpu: 4.0}
+      requests: {memory: 32Gi, cpu: 4.0, ephemeral-storage: 80Gi}
+```
+
+Resource names and values are passed through verbatim, so any Kubernetes resource
+(e.g. `hugepages-2Mi`) can be set under either `requests` or `limits`. Setting a
+key that a Compose shortcut already populated (e.g. `requests.memory` alongside
+`mem_limit`) is rejected rather than silently overridden.
+
+This extension exists because Docker Compose cannot express many Kubernetes
+resources. It covers CPU and memory requests/limits (via `cpus`/`mem_limit` and
+`deploy.resources`), but has no concept of a disk (`ephemeral-storage`) request or
+limit, nor of resources such as `hugepages-*`.

--- a/src/k8s_sandbox/compose/_converter.py
+++ b/src/k8s_sandbox/compose/_converter.py
@@ -292,6 +292,11 @@ class _ServiceConverter:
                 f"must be available for pulling from a container registry. "
                 f"{self.context}"
             )
+        # Apply the per-service 'x-inspect_k8s_sandbox' extension after 'resources'
+        # has been built from mem_limit/cpus/deploy (so the merge target exists) but
+        # before the leftover-key guard (so it isn't flagged as unsupported).
+        if (extensions := src.pop("x-inspect_k8s_sandbox", None)) is not None:
+            self._apply_service_extensions(extensions, result)
         if src:
             raise ComposeConverterError(
                 f"Unsupported key(s) in 'service': {set(src)}. {self.context}"
@@ -473,6 +478,68 @@ class _ServiceConverter:
         if "limits" in resources and "requests" not in resources:
             # Copy to avoid references which can result in anchors and aliases in YAML.
             resources["requests"] = resources["limits"].copy()
+
+    def _apply_service_extensions(
+        self, extensions: Any, result: dict[str, Any]
+    ) -> None:
+        """Apply the per-service 'x-inspect_k8s_sandbox' extension.
+
+        This is an escape hatch for expressing Kubernetes resources that the Docker
+        Compose shortcuts (mem_limit/cpus/deploy.resources) cannot, most notably
+        request-only resources such as 'ephemeral-storage'. Currently only a
+        'resources' block is supported.
+        """
+        if not isinstance(extensions, dict):
+            raise ComposeConverterError(
+                f"Invalid 'x-inspect_k8s_sandbox' type: {type(extensions)}. Expected "
+                f"dict. {self.context}"
+            )
+        if (resources := extensions.pop("resources", None)) is not None:
+            self._merge_extension_resources(resources, result)
+        if extensions:
+            raise ComposeConverterError(
+                f"Unsupported key(s) in service 'x-inspect_k8s_sandbox': "
+                f"{set(extensions)}. Only 'resources' is supported. {self.context}"
+            )
+
+    def _merge_extension_resources(self, src: Any, result: dict[str, Any]) -> None:
+        """Deep-merge an extension 'resources' block into the built resources.
+
+        Keys are merged into the existing 'requests'/'limits' dicts the converter
+        built from mem_limit/cpus/deploy. Conflicts (a key already set by those
+        shortcuts) are rejected rather than silently overridden. Resource names and
+        values are passed through generically so any Kubernetes resource can be set.
+        """
+        if not isinstance(src, dict):
+            raise ComposeConverterError(
+                f"Invalid 'x-inspect_k8s_sandbox.resources' type: {type(src)}. "
+                f"Expected dict. {self.context}"
+            )
+        resources = result.setdefault("resources", {})
+        for section in ("requests", "limits"):
+            if (values := src.pop(section, None)) is None:
+                continue
+            if not isinstance(values, dict):
+                raise ComposeConverterError(
+                    f"Invalid 'x-inspect_k8s_sandbox.resources.{section}' type: "
+                    f"{type(values)}. Expected dict. {self.context}"
+                )
+            target = resources.setdefault(section, {})
+            for key, value in values.items():
+                if key in target:
+                    raise ComposeConverterError(
+                        f"Conflicting '{section}.{key}' in "
+                        f"'x-inspect_k8s_sandbox.resources': already set to "
+                        f"'{target[key]}' (likely via mem_limit/cpus/deploy). "
+                        f"{self.context}"
+                    )
+                target[key] = value
+        if src:
+            raise ComposeConverterError(
+                f"Unsupported key(s) in 'x-inspect_k8s_sandbox.resources': "
+                f"{set(src)}. Only 'requests' and 'limits' are supported. "
+                f"{self.context}"
+            )
 
     def _user_to_security_context(self, user: str | int) -> dict[str, Any]:
         def parse_int(value: str) -> int:

--- a/src/k8s_sandbox/compose/_converter.py
+++ b/src/k8s_sandbox/compose/_converter.py
@@ -14,6 +14,11 @@ COMPOSE_SCHEMA_PATH = (
     Path(__file__).parent.parent / "resources" / "compose" / "compose-spec.json"
 )
 
+# The canonical inspect_k8s_sandbox extension key is verbose; 'x-k8s' is a supported
+# shorthand alias. Both are accepted wherever the extension is read (top-level and
+# per-service). Listed canonical-first only for stable error messages.
+_EXTENSION_KEYS = ("x-inspect_k8s_sandbox", "x-k8s")
+
 
 class ComposeConverterError(Exception):
     """Raised when an error occurs converting a Docker Compose file to Helm values."""
@@ -52,9 +57,9 @@ def convert_compose_to_helm_values(compose_file: Path) -> dict[str, Any]:
         result["volumes"] = _convert_volumes(volumes, compose_file)
     if networks := compose.pop("networks", None):
         result["networks"] = _convert_networks(networks, compose_file)
-    # The 'x-inspect_k8s_sandbox' key is used to add additional configuration to
-    # Docker Compose files for use in Helm values.
-    if extensions := compose.pop("x-inspect_k8s_sandbox", None):
+    # The 'x-inspect_k8s_sandbox' key (or its 'x-k8s' shorthand) is used to add
+    # additional configuration to Docker Compose files for use in Helm values.
+    if extensions := _pop_extension(compose, f"Compose file: '{compose_file}'."):
         result.update(_convert_extensions(extensions, compose_file))
     # Ignore the version key.
     compose.pop("version", None)
@@ -154,6 +159,22 @@ def _convert_networks(src: dict[str, Any], compose_file: Path) -> dict[str, Any]
             )
         result[network_name] = {}
     return result
+
+
+def _pop_extension(src: dict[str, Any], context: str) -> Any:
+    """Pop the inspect_k8s_sandbox extension value from src.
+
+    Both the canonical 'x-inspect_k8s_sandbox' key and the shorter 'x-k8s' alias are
+    accepted. Returns the extension value, or None if neither key is present. Raises
+    if both keys are present, since which one would win is ambiguous.
+    """
+    present = [key for key in _EXTENSION_KEYS if key in src]
+    if len(present) > 1:
+        raise ComposeConverterError(
+            f"Specify only one of {present}; 'x-k8s' is an alias for "
+            f"'x-inspect_k8s_sandbox'. {context}"
+        )
+    return src.pop(present[0]) if present else None
 
 
 def _convert_extensions(
@@ -292,10 +313,12 @@ class _ServiceConverter:
                 f"must be available for pulling from a container registry. "
                 f"{self.context}"
             )
-        # Apply the per-service 'x-inspect_k8s_sandbox' extension after 'resources'
-        # has been built from mem_limit/cpus/deploy (so the merge target exists) but
-        # before the leftover-key guard (so it isn't flagged as unsupported).
-        if (extensions := src.pop("x-inspect_k8s_sandbox", None)) is not None:
+        # Apply the per-service extension ('x-inspect_k8s_sandbox' or its 'x-k8s'
+        # shorthand) after 'resources' has been built from mem_limit/cpus/deploy (so
+        # the merge target exists) but before the leftover-key guard (so it isn't
+        # flagged as unsupported).
+        extensions = _pop_extension(src, self.context)
+        if extensions is not None:
             self._apply_service_extensions(extensions, result)
         if src:
             raise ComposeConverterError(

--- a/test/k8s_sandbox/compose/test_converter.py
+++ b/test/k8s_sandbox/compose/test_converter.py
@@ -1118,6 +1118,91 @@ x-inspect_k8s_sandbox:
     assert "Unsupported key(s) in 'x-inspect_k8s_sandbox'" in str(exc_info.value)
 
 
+### x-k8s extension alias
+
+
+def test_converts_allow_domains_via_x_k8s_alias(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    # 'x-k8s' is a shorthand alias for the verbose 'x-inspect_k8s_sandbox' key.
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    image: my-image
+x-k8s:
+  allow_domains:
+    - example.com
+""")
+
+    result = convert_compose_to_helm_values(compose_path)
+
+    assert result["allowDomains"] == ["example.com"]
+
+
+def test_converts_service_extension_via_x_k8s_alias(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    image: my-image
+    x-k8s:
+      resources:
+        requests:
+          ephemeral-storage: 80Gi
+""")
+
+    result = convert_compose_to_helm_values(compose_path)
+
+    assert result["services"]["my-service"]["resources"] == {
+        "requests": {"ephemeral-storage": "80Gi"},
+    }
+
+
+def test_rejects_both_extension_keys_at_top_level(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    image: my-image
+x-inspect_k8s_sandbox:
+  allow_domains:
+    - example.com
+x-k8s:
+  allow_entities:
+    - world
+""")
+
+    with pytest.raises(ComposeConverterError) as exc_info:
+        convert_compose_to_helm_values(compose_path)
+
+    assert "Specify only one of" in str(exc_info.value)
+
+
+def test_rejects_both_extension_keys_on_service(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    image: my-image
+    x-inspect_k8s_sandbox:
+      resources:
+        requests:
+          ephemeral-storage: 80Gi
+    x-k8s:
+      resources:
+        limits:
+          ephemeral-storage: 80Gi
+""")
+
+    with pytest.raises(ComposeConverterError) as exc_info:
+        convert_compose_to_helm_values(compose_path)
+
+    assert "Specify only one of" in str(exc_info.value)
+
+
 ### Network elements
 
 

--- a/test/k8s_sandbox/compose/test_converter.py
+++ b/test/k8s_sandbox/compose/test_converter.py
@@ -1,10 +1,13 @@
+import json
 import logging
 from pathlib import Path
 from typing import Any, Callable
 
+import jsonschema
 import pytest
 import yaml
 
+import k8s_sandbox
 from k8s_sandbox.compose._converter import (
     ComposeConverterError,
     convert_compose_to_helm_values,
@@ -582,6 +585,168 @@ services:
         convert_compose_to_helm_values(compose_path)
 
     assert "Unsupported key(s) in 'resources'" in str(exc_info.value)
+
+
+### Service-level x-inspect_k8s_sandbox extension
+
+
+def test_service_extension_request_only_ephemeral_storage(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    image: my-image
+    x-inspect_k8s_sandbox:
+      resources:
+        requests:
+          ephemeral-storage: 80Gi
+""")
+
+    result = convert_compose_to_helm_values(compose_path)
+
+    # With no mem/cpu shortcuts there is no limits block; request-only is preserved.
+    assert result["services"]["my-service"]["resources"] == {
+        "requests": {"ephemeral-storage": "80Gi"},
+    }
+
+
+def test_service_extension_merges_into_existing_resources(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    image: my-image
+    mem_limit: 32g
+    cpus: 4.0
+    x-inspect_k8s_sandbox:
+      resources:
+        requests:
+          ephemeral-storage: 80Gi
+""")
+
+    result = convert_compose_to_helm_values(compose_path)
+
+    # ephemeral-storage is merged into the Guaranteed-QoS requests block; memory/cpu
+    # remain in both requests and limits; ephemeral-storage is NOT added to limits.
+    assert result["services"]["my-service"]["resources"] == {
+        "limits": {"memory": "32Gi", "cpu": 4.0},
+        "requests": {"memory": "32Gi", "cpu": 4.0, "ephemeral-storage": "80Gi"},
+    }
+
+
+def test_service_extension_accepts_arbitrary_resource_names(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    # The extension is a generic Kubernetes-resource escape hatch, not hardcoded to
+    # ephemeral-storage.
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    image: my-image
+    x-inspect_k8s_sandbox:
+      resources:
+        limits:
+          hugepages-2Mi: 128Mi
+""")
+
+    result = convert_compose_to_helm_values(compose_path)
+
+    assert result["services"]["my-service"]["resources"] == {
+        "limits": {"hugepages-2Mi": "128Mi"},
+    }
+
+
+def test_rejects_unsupported_service_extension_key(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    image: my-image
+    x-inspect_k8s_sandbox:
+      foo: 1
+""")
+
+    with pytest.raises(ComposeConverterError) as exc_info:
+        convert_compose_to_helm_values(compose_path)
+
+    assert "Unsupported key(s) in service 'x-inspect_k8s_sandbox'" in str(
+        exc_info.value
+    )
+
+
+def test_rejects_unsupported_service_extension_resources_key(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    # Only 'requests' and 'limits' are supported (Docker's 'reservations' is not).
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    image: my-image
+    x-inspect_k8s_sandbox:
+      resources:
+        reservations:
+          ephemeral-storage: 80Gi
+""")
+
+    with pytest.raises(ComposeConverterError) as exc_info:
+        convert_compose_to_helm_values(compose_path)
+
+    assert "Unsupported key(s) in 'x-inspect_k8s_sandbox.resources'" in str(
+        exc_info.value
+    )
+
+
+def test_rejects_service_extension_resource_conflict(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    # mem_limit populates requests.memory, so the extension may not also set it.
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    image: my-image
+    mem_limit: 32g
+    x-inspect_k8s_sandbox:
+      resources:
+        requests:
+          memory: 16Gi
+""")
+
+    with pytest.raises(ComposeConverterError) as exc_info:
+        convert_compose_to_helm_values(compose_path)
+
+    assert "Conflicting 'requests.memory'" in str(exc_info.value)
+
+
+def test_service_extension_output_validates_against_chart_schema(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    compose_path = tmp_compose("""
+services:
+  default:
+    image: my-image
+    mem_limit: 32g
+    cpus: 4.0
+    x-inspect_k8s_sandbox:
+      resources:
+        requests:
+          ephemeral-storage: 80Gi
+""")
+
+    result = convert_compose_to_helm_values(compose_path)
+
+    schema_path = (
+        Path(k8s_sandbox.__file__).parent
+        / "resources"
+        / "helm"
+        / "agent-env"
+        / "values.schema.json"
+    )
+    schema = json.loads(schema_path.read_text())
+    # 'global' is injected by inspect at install time; add it to satisfy the schema.
+    jsonschema.validate({**result, "global": {}}, schema)
 
 
 def test_converts_user_to_security_context(tmp_compose: TmpComposeFixture) -> None:


### PR DESCRIPTION
## Summary

Adds a per-service `x-inspect_k8s_sandbox` extension to the compose-to-helm
converter so a Docker Compose service can declare Kubernetes resource
`requests`/`limits` that the existing Compose shortcuts cannot express — most
notably a **request-only** resource such as `ephemeral-storage` (a scheduling
floor with no eviction cap).

```yaml
services:
  default:
    image: example.com/foo@sha256:...
    mem_limit: 32g
    cpus: 4.0
    network_mode: none
    x-inspect_k8s_sandbox:
      resources:
        requests:
          ephemeral-storage: 80Gi
```

converts to:

```yaml
services:
  default:
    resources:
      limits:   {memory: 32Gi, cpu: 4.0}
      requests: {memory: 32Gi, cpu: 4.0, ephemeral-storage: 80Gi}
```

## Motivation

`ephemeral-storage` is a first-class Kubernetes resource, and a request with no
matching limit ("schedule me where there's ≥80Gi free disk, but don't cap/evict
me") is a legitimate pattern. None of the converter's existing surfaces can
express it:

- A bare service-level `x-ephemeral-storage` is rejected by the converter's
  leftover-key guard.
- `deploy.resources.reservations.ephemeral-storage` fails compose-spec schema
  validation — `deploy.resources.{limits,reservations}` is a closed list
  (`cpus`/`memory`/`pids`/`generic_resources`/`devices`,
  `additionalProperties: false`).
- The root `x-inspect_k8s_sandbox` handler is a closed allowlist
  (`allow_domains`/`allow_entities`), and services had no extension handler at
  all.

Docker Compose has no equivalent to map from: it covers CPU and memory
requests/limits but has no disk (`ephemeral-storage`) request/reservation concept,
and the closest analog — `storage_opt.size` — is a storage-driver-dependent limit
on the container's writable layer, which is neither a request nor the same scope as
Kubernetes ephemeral storage. The extension is therefore the supported surface for
these resources.

## What changed

- **`src/k8s_sandbox/compose/_converter.py`** — `_ServiceConverter._convert_service`
  now consumes a per-service `x-inspect_k8s_sandbox` extension (after the
  `resources` block is built from `mem_limit`/`cpus`/`deploy`, before the
  leftover-key guard). Two new helpers, `_apply_service_extensions` and
  `_merge_extension_resources`, deep-merge the extension's `resources` block into
  the existing `requests`/`limits`. Resource names and values are passed through
  generically (not hardcoded to `ephemeral-storage`), so `hugepages-2Mi` etc. work
  too.

- **`test/k8s_sandbox/compose/test_converter.py`** — 7 new tests: request-only
  (no mem/cpu), merge alongside `mem_limit`/`cpus`, arbitrary resource names,
  unsupported extension key, unsupported `resources` sub-key, conflict detection,
  and a round-trip validation against the chart's `values.schema.json`.

- **`docs/docs/helm/compose-to-helm.md`** — new "Resource Requests and Limits"
  section documenting the extension and why Compose has no equivalent.

- **`CHANGELOG.md`** — Unreleased entry.

No schema changes are required: the compose-spec `service` definition already
allows `^x-` keys, and the chart's `values.schema.json` types
`services.*.resources` as an opaque object (rendered via `toYaml`), so the merged
keys validate and template unchanged.

## Design decisions

- **Raise on conflict.** If the extension sets a `requests`/`limits` key already
  populated by a Compose shortcut (e.g. `requests.memory` alongside `mem_limit`),
  the converter raises `ComposeConverterError` rather than silently overriding —
  consistent with the converter's strict reject-on-ambiguity style.
- **Scoped, not flat or wide.** The surface mirrors the Kubernetes `resources`
  structure exactly (self-documenting, generalizes to any resource) but stays
  bounded to `resources` — it is not a flat single-purpose key (which would hide
  the request-vs-limit semantics) nor an arbitrary Helm-values pass-through (which
  would duplicate fields the converter already derives and erode the
  "compose file vs. Helm values file" boundary).
- **No request→limit mirroring for extension keys.** The existing
  `_set_requests_to_limits_if_unset` only copies limits→requests, so a
  request-only `ephemeral-storage` is intentionally not mirrored into `limits`.

## Testing

- `pytest test/k8s_sandbox/compose/ -m "not req_k8s"` — 102 passed (incl. 7 new).
- `mypy` and `ruff check`/`ruff format` clean on the changed files.
- End-to-end conversion snippet and `values.schema.json` round-trip both verified.

No Kubernetes cluster is required; all converter tests are non-`req_k8s`.

## Out of scope

Downstream consumers (e.g. setting the prefixed `x-inspect_k8s_sandbox` key on an
inspect_ai `ComposeService` to drop manual values-file patching) are separate
follow-ups in their own repos.
