### PR TITLE
fix: replace non-utf-8 outputs in exec

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,13 @@
 {
-    "editor.rulers": [
-        88
-    ],
-    "python.testing.pytestEnabled": true,
-    "files.insertFinalNewline": true,
-    "files.trimTrailingWhitespace": true,
-    "[python]": {
-        "editor.defaultFormatter": "charliermarsh.ruff"
-    },
-    "rewrap.wrappingColumn": 88
+  "editor.rulers": [
+    88
+  ],
+  "python.testing.pytestEnabled": true,
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff"
+  },
+  "rewrap.wrappingColumn": 88,
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,12 @@
 {
-  "editor.rulers": [
-    88
-  ],
-  "python.testing.pytestEnabled": true,
-  "files.insertFinalNewline": true,
-  "files.trimTrailingWhitespace": true,
-  "[python]": {
-    "editor.defaultFormatter": "charliermarsh.ruff"
-  },
-  "rewrap.wrappingColumn": 88,
-  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
+    "editor.rulers": [
+        88
+    ],
+    "python.testing.pytestEnabled": true,
+    "files.insertFinalNewline": true,
+    "files.trimTrailingWhitespace": true,
+    "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff"
+    },
+    "rewrap.wrappingColumn": 88
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix `exec()` raising `UnicodeDecodeError` when a command writes non-UTF-8 bytes to stdout/stderr. Invalid bytes are now replaced with the unicode replacement character (matching Inspect's other sandboxes) instead of aborting the call.
+- Support replacement rather than throwing `UnicodeDecodeError` when a command writes non-UTF-8 bytes to stdout/stderr.
 - Propagate the caller's context into the pod-operation worker thread to ensure that Inspect sandbox config overrides are honoured.
 - Raise typed `PodReplacedError` / `ContainerRestartedError` (instead of `RuntimeError`) when a pod operation detects the pod has been replaced or its container restarted, and refresh the cached pod identity so subsequent operations target the new pod instead of looping against a stale UID. `restarted_container_behavior="warn"` now also refreshes (previously left the cached UID stale).
 - Fix `exec(input=...)` failing with "Connection reset by peer" for large inputs (e.g. injecting a ~28 MiB binary): stdin is now written to the pod in ≤1 MiB WebSocket frames instead of a single oversized frame. `write_file` shares the same chunking helper.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix `exec()` raising `UnicodeDecodeError` when a command writes non-UTF-8 bytes to stdout/stderr. Invalid bytes are now replaced with the unicode replacement character (matching Inspect's other sandboxes) instead of aborting the call.
 - Propagate the caller's context into the pod-operation worker thread to ensure that Inspect sandbox config overrides are honoured.
 - Raise typed `PodReplacedError` / `ContainerRestartedError` (instead of `RuntimeError`) when a pod operation detects the pod has been replaced or its container restarted, and refresh the cached pod identity so subsequent operations target the new pod instead of looping against a stale UID. `restarted_container_behavior="warn"` now also refreshes (previously left the cached UID stale).
 - Fix `exec(input=...)` failing with "Connection reset by peer" for large inputs (e.g. injecting a ~28 MiB binary): stdin is now written to the pod in ≤1 MiB WebSocket frames instead of a single oversized frame. `write_file` shares the same chunking helper.

--- a/src/k8s_sandbox/_pod/buffer.py
+++ b/src/k8s_sandbox/_pod/buffer.py
@@ -4,9 +4,9 @@ class LimitedBuffer:
 
     Once the buffer is full, `truncated` is set and further appends are ignored.
 
-    The buffer can be converted to a string (utf-8). Invalid utf-8 bytes are replaced
-    with the unicode replacement character; an incomplete trailing character left by
-    truncation is dropped.
+    The buffer can be converted to a string (utf-8). Invalid utf-8 bytes — including an
+    incomplete trailing character left by truncation — are replaced with the unicode
+    replacement character.
     """
 
     def __init__(self, limit: int) -> None:
@@ -23,11 +23,4 @@ class LimitedBuffer:
         self._buffer.extend(data[:remaining_space])
 
     def __str__(self) -> str:
-        try:
-            return self._buffer.decode("utf-8", errors="strict")
-        except UnicodeDecodeError as e:
-            # Drop an incomplete character left at the very end by truncation; replace
-            # any other invalid bytes (e.g. binary subprocess output) rather than raise.
-            if self.truncated and e.end == len(self._buffer):
-                return self._buffer[: e.start].decode("utf-8", errors="strict")
-            return self._buffer.decode("utf-8", errors="replace")
+        return self._buffer.decode("utf-8", errors="replace")

--- a/src/k8s_sandbox/_pod/buffer.py
+++ b/src/k8s_sandbox/_pod/buffer.py
@@ -4,8 +4,9 @@ class LimitedBuffer:
 
     Once the buffer is full, `truncated` is set and further appends are ignored.
 
-    The buffer can be converted to a string (utf-8). Will raise a UnicodeDecodeError if
-    the buffer contains invalid utf-8 data (except it it was as a result of truncation).
+    The buffer can be converted to a string (utf-8). Invalid utf-8 bytes are replaced
+    with the unicode replacement character; an incomplete trailing character left by
+    truncation is dropped.
     """
 
     def __init__(self, limit: int) -> None:
@@ -22,11 +23,11 @@ class LimitedBuffer:
         self._buffer.extend(data[:remaining_space])
 
     def __str__(self) -> str:
-        # If we're truncated the data, there may be an incomplete character right at the
-        # end of the buffer.
         try:
             return self._buffer.decode("utf-8", errors="strict")
         except UnicodeDecodeError as e:
+            # Drop an incomplete character left at the very end by truncation; replace
+            # any other invalid bytes (e.g. binary subprocess output) rather than raise.
             if self.truncated and e.end == len(self._buffer):
                 return self._buffer[: e.start].decode("utf-8", errors="strict")
-            raise
+            return self._buffer.decode("utf-8", errors="replace")

--- a/src/k8s_sandbox/_pod/execute.py
+++ b/src/k8s_sandbox/_pod/execute.py
@@ -193,17 +193,16 @@ class ExecuteOperation(PodOperation):
             )
 
     def _filter_sentinel_and_returncode(self, frame: bytes) -> tuple[bytes, int | None]:
-        # We don't support returning binary data from an exec() command and are expected
-        # to raise a UnicodeDecodeError if we encounter one, so errors="strict".
-        # Assumption: individual frames are valid utf-8 (i.e. characters are not split
-        # across frames).
-        decoded = frame.decode("utf-8", errors="strict")
-        split_frame = re.split(COMPLETED_SENTINEL_PATTERN, decoded)
-        if len(split_frame) == 1:
+        # The sentinel is ASCII, so decode-with-replace detects it without raising on
+        # binary subprocess output. Only raw bytes pass through, so the replacement
+        # chars can't reach the caller. Assumption: sentinel isn't split across frames.
+        probe = frame.decode("utf-8", errors="replace")
+        match = COMPLETED_SENTINEL_PATTERN.search(probe)
+        if match is None:
             return frame, None
-        # Remove the sentinel value from the stdout frame.
-        filtered = split_frame[0] + split_frame[2]
-        return filtered.encode("utf-8"), int(split_frame[1])
+        # The matched sentinel is ASCII, so its bytes appear verbatim in the raw frame.
+        sentinel_bytes = match.group(0).encode("ascii")
+        return frame.replace(sentinel_bytes, b"", 1), int(match.group(1))
 
     def _verify_output_limit(
         self, stdout: LimitedBuffer, stderr: LimitedBuffer

--- a/src/k8s_sandbox/_pod/execute.py
+++ b/src/k8s_sandbox/_pod/execute.py
@@ -193,16 +193,15 @@ class ExecuteOperation(PodOperation):
             )
 
     def _filter_sentinel_and_returncode(self, frame: bytes) -> tuple[bytes, int | None]:
-        # The sentinel is ASCII, so decode-with-replace detects it without raising on
-        # binary subprocess output. Only raw bytes pass through, so the replacement
-        # chars can't reach the caller. Assumption: sentinel isn't split across frames.
-        probe = frame.decode("utf-8", errors="replace")
-        match = COMPLETED_SENTINEL_PATTERN.search(probe)
-        if match is None:
+        # latin-1 maps each byte 1:1 to a codepoint, so it decodes arbitrary binary
+        # without raising and re-encodes losslessly. We use it only to locate and strip
+        # the ASCII sentinel; the surrounding bytes round-trip unchanged.
+        # Assumption: the sentinel is not split across frames.
+        decoded = frame.decode("latin-1")
+        split_frame = re.split(COMPLETED_SENTINEL_PATTERN, decoded)
+        if len(split_frame) == 1:
             return frame, None
-        # The matched sentinel is ASCII, so its bytes appear verbatim in the raw frame.
-        sentinel_bytes = match.group(0).encode("ascii")
-        return frame.replace(sentinel_bytes, b"", 1), int(match.group(1))
+        return (split_frame[0] + split_frame[2]).encode("latin-1"), int(split_frame[1])
 
     def _verify_output_limit(
         self, stdout: LimitedBuffer, stderr: LimitedBuffer

--- a/test/k8s_sandbox/pod/test_execute.py
+++ b/test/k8s_sandbox/pod/test_execute.py
@@ -174,7 +174,7 @@ class TestNonUtf8Output:
         result = executor._handle_shell_output(ws, user=None, timeout=None)
 
         assert result.returncode == 0
-        assert result.stdout == "before � after"
+        assert result.stdout == "before \ufffd after"
 
     def test_binary_byte_on_stderr(self) -> None:
         ws = _make_ws_client(
@@ -186,7 +186,7 @@ class TestNonUtf8Output:
         result = executor._handle_shell_output(ws, user=None, timeout=None)
 
         assert result.returncode == 0
-        assert result.stderr == "warn � done\n"
+        assert result.stderr == "warn \ufffd done\n"
 
     def test_binary_byte_in_earlier_frame_than_sentinel(self) -> None:
         ws = _make_ws_client(
@@ -197,7 +197,7 @@ class TestNonUtf8Output:
         result = executor._handle_shell_output(ws, user=None, timeout=None)
 
         assert result.returncode == 0
-        assert result.stdout == "raw � bytesmore"
+        assert result.stdout == "raw \ufffd bytesmore"
 
 
 class TestRunuserErrors:

--- a/test/k8s_sandbox/pod/test_execute.py
+++ b/test/k8s_sandbox/pod/test_execute.py
@@ -162,6 +162,44 @@ class TestBrokenPipeWithoutSentinel:
             executor._handle_shell_output(ws, user=None, timeout=None)
 
 
+class TestNonUtf8Output:
+    """A command emitting non-UTF-8 bytes must not abort exec() (issue #206)."""
+
+    def test_binary_byte_with_sentinel_in_same_frame(self) -> None:
+        ws = _make_ws_client(
+            stdout_frames=[b"before \xbb after<completed-sentinel-value-0>"],
+        )
+
+        executor = ExecuteOperation(MagicMock())
+        result = executor._handle_shell_output(ws, user=None, timeout=None)
+
+        assert result.returncode == 0
+        assert result.stdout == "before � after"
+
+    def test_binary_byte_on_stderr(self) -> None:
+        ws = _make_ws_client(
+            stdout_frames=[b"<completed-sentinel-value-0>"],
+            stderr_frames=[b"warn \xbb done\n"],
+        )
+
+        executor = ExecuteOperation(MagicMock())
+        result = executor._handle_shell_output(ws, user=None, timeout=None)
+
+        assert result.returncode == 0
+        assert result.stderr == "warn � done\n"
+
+    def test_binary_byte_in_earlier_frame_than_sentinel(self) -> None:
+        ws = _make_ws_client(
+            stdout_frames=[b"raw \xbb bytes", b"more<completed-sentinel-value-0>"],
+        )
+
+        executor = ExecuteOperation(MagicMock())
+        result = executor._handle_shell_output(ws, user=None, timeout=None)
+
+        assert result.returncode == 0
+        assert result.stdout == "raw � bytesmore"
+
+
 class TestRunuserErrors:
     def test_user_command_runuser_error_with_sentinel_returns_result(self) -> None:
         ws = _make_ws_client(

--- a/test/k8s_sandbox/pod/test_execute.py
+++ b/test/k8s_sandbox/pod/test_execute.py
@@ -163,7 +163,7 @@ class TestBrokenPipeWithoutSentinel:
 
 
 class TestNonUtf8Output:
-    """A command emitting non-UTF-8 bytes must not abort exec() (issue #206)."""
+    """A command emitting non-UTF-8 bytes must not abort exec()."""
 
     def test_binary_byte_with_sentinel_in_same_frame(self) -> None:
         ws = _make_ws_client(

--- a/test/k8s_sandbox/test_limited_stream_buffer.py
+++ b/test/k8s_sandbox/test_limited_stream_buffer.py
@@ -69,9 +69,8 @@ def test_truncates_unicode_without_raising_decode_error():
     sut.append("abcd😀".encode("utf-8"))
     actual = str(sut)
 
-    # The 4-byte character is simply discarded.
-    assert actual == "abcd"
-    assert _count_bytes(actual) == 4
+    # The incomplete trailing character becomes a single replacement character.
+    assert actual == "abcd�"
     assert sut.truncated
 
 

--- a/test/k8s_sandbox/test_limited_stream_buffer.py
+++ b/test/k8s_sandbox/test_limited_stream_buffer.py
@@ -70,7 +70,7 @@ def test_truncates_unicode_without_raising_decode_error():
     actual = str(sut)
 
     # The incomplete trailing character becomes a single replacement character.
-    assert actual == "abcd�"
+    assert actual == "abcd\ufffd"
     assert sut.truncated
 
 
@@ -79,7 +79,7 @@ def test_replaces_interior_invalid_utf8(invalid_utf8: bytes):
 
     sut.append(b"abcde" + invalid_utf8 + b"fghij")
 
-    assert str(sut) == "abcde�fghij"
+    assert str(sut) == "abcde\ufffdfghij"
     assert not sut.truncated
 
 
@@ -88,7 +88,7 @@ def test_replaces_invalid_utf8_at_end_if_not_truncated(invalid_utf8: bytes):
 
     sut.append(b"abcde" + invalid_utf8)
 
-    assert str(sut) == "abcde�"
+    assert str(sut) == "abcde\ufffd"
     assert not sut.truncated
 
 

--- a/test/k8s_sandbox/test_limited_stream_buffer.py
+++ b/test/k8s_sandbox/test_limited_stream_buffer.py
@@ -75,22 +75,22 @@ def test_truncates_unicode_without_raising_decode_error():
     assert sut.truncated
 
 
-def test_raises_unicode_decode_error(invalid_utf8: bytes):
+def test_replaces_interior_invalid_utf8(invalid_utf8: bytes):
     sut = LimitedBuffer(1024)
 
     sut.append(b"abcde" + invalid_utf8 + b"fghij")
 
-    with pytest.raises(UnicodeDecodeError):
-        str(sut)
+    assert str(sut) == "abcde�fghij"
+    assert not sut.truncated
 
 
-def test_raises_unicode_decode_error_at_end_if_not_truncated(invalid_utf8: bytes):
+def test_replaces_invalid_utf8_at_end_if_not_truncated(invalid_utf8: bytes):
     sut = LimitedBuffer(1024)
 
     sut.append(b"abcde" + invalid_utf8)
 
-    with pytest.raises(UnicodeDecodeError):
-        str(sut)
+    assert str(sut) == "abcde�"
+    assert not sut.truncated
 
 
 def _count_bytes(string: str) -> int:

--- a/test/k8s_sandbox/test_sandbox.py
+++ b/test/k8s_sandbox/test_sandbox.py
@@ -360,7 +360,7 @@ async def test_exec_non_utf8_output_is_replaced(sandbox: K8sSandboxEnvironment) 
     result = await sandbox.exec(["bash", "-c", r"printf 'before \xbb after'"])
 
     assert result.success
-    assert result.stdout == "before � after"
+    assert result.stdout == "before \ufffd after"
 
 
 async def test_exec_background_returns(sandbox: K8sSandboxEnvironment) -> None:

--- a/test/k8s_sandbox/test_sandbox.py
+++ b/test/k8s_sandbox/test_sandbox.py
@@ -357,8 +357,6 @@ async def test_exec_timeout_terminates_foreground_commands(
 
 
 async def test_exec_non_utf8_output_is_replaced(sandbox: K8sSandboxEnvironment) -> None:
-    # A stray non-utf-8 byte on stdout must not abort exec() (issue #206); the
-    # invalid byte is replaced rather than raising a UnicodeDecodeError.
     result = await sandbox.exec(["bash", "-c", r"printf 'before \xbb after'"])
 
     assert result.success

--- a/test/k8s_sandbox/test_sandbox.py
+++ b/test/k8s_sandbox/test_sandbox.py
@@ -356,9 +356,13 @@ async def test_exec_timeout_terminates_foreground_commands(
     assert file_exists_result.success
 
 
-async def test_exec_unicode_decode_error(sandbox: K8sSandboxEnvironment) -> None:
-    with pytest.raises(UnicodeDecodeError):
-        await sandbox.exec(["head", "-c", "1024", "/bin/ls"])
+async def test_exec_non_utf8_output_is_replaced(sandbox: K8sSandboxEnvironment) -> None:
+    # A stray non-utf-8 byte on stdout must not abort exec() (issue #206); the
+    # invalid byte is replaced rather than raising a UnicodeDecodeError.
+    result = await sandbox.exec(["bash", "-c", r"printf 'before \xbb after'"])
+
+    assert result.success
+    assert result.stdout == "before � after"
 
 
 async def test_exec_background_returns(sandbox: K8sSandboxEnvironment) -> None:


### PR DESCRIPTION
This PR updates the `exec` function to handle binary characters with replacement to their utf-8 equivalent, rather than raising. This is consistent with the current behaviour of local and docker sandboxes, and reflects the update documented in [this Slack thread](https://inspectcommunity.slack.com/archives/C0855KJ6BMW/p1782122706621579)