### PR TITLE
Fix/210 bypass pod deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Propagate the caller's context into the pod-operation worker thread to ensure that Inspect sandbox config overrides are honoured.
 - Raise typed `PodReplacedError` / `ContainerRestartedError` (instead of `RuntimeError`) when a pod operation detects the pod has been replaced or its container restarted, and refresh the cached pod identity so subsequent operations target the new pod instead of looping against a stale UID. `restarted_container_behavior="warn"` now also refreshes (previously left the cached UID stale).
 - Fix `exec(input=...)` failing with "Connection reset by peer" for large inputs (e.g. injecting a ~28 MiB binary): stdin is now written to the pod in ≤1 MiB WebSocket frames instead of a single oversized frame. `write_file` shares the same chunking helper.
+- Improve scaling to many concurrent clusters: pod reads (the frequent `check_for_pod_restart` and the per-install pod listing) now parse the raw API JSON via `_preload_content=False` instead of the kubernetes client's model deserialization, which serialized under high concurrency and caused `TimeoutError`s ([#210](https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/issues/210), [kubernetes-client/python#2284](https://github.com/kubernetes-client/python/issues/2284)). The parsed fields are centralised in a new `PodSnapshot` view.
 
 ## 2026-05-07 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Propagate the caller's context into the pod-operation worker thread to ensure that Inspect sandbox config overrides are honoured.
 - Raise typed `PodReplacedError` / `ContainerRestartedError` (instead of `RuntimeError`) when a pod operation detects the pod has been replaced or its container restarted, and refresh the cached pod identity so subsequent operations target the new pod instead of looping against a stale UID. `restarted_container_behavior="warn"` now also refreshes (previously left the cached UID stale).
 - Fix `exec(input=...)` failing with "Connection reset by peer" for large inputs (e.g. injecting a ~28 MiB binary): stdin is now written to the pod in ≤1 MiB WebSocket frames instead of a single oversized frame. `write_file` shares the same chunking helper.
-- Improve scaling to many concurrent clusters: pod reads (the frequent `check_for_pod_restart` and the per-install pod listing) now parse the raw API JSON via `_preload_content=False` instead of the kubernetes client's model deserialization, which serialized under high concurrency and caused `TimeoutError`s ([#210](https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/issues/210), [kubernetes-client/python#2284](https://github.com/kubernetes-client/python/issues/2284)). The parsed fields are centralised in a new `PodSnapshot` view.
+- Parse pod reads from the raw API JSON (`_preload_content=False`) instead of the kubernetes client's model deserialization, which serialized under high concurrency and stalled evals running many concurrent clusters with `TimeoutError`s.
 
 ## 2026-05-07 0.5.0
 

--- a/src/k8s_sandbox/_helm.py
+++ b/src/k8s_sandbox/_helm.py
@@ -22,6 +22,7 @@ from k8s_sandbox._logger import (
     log_trace,
 )
 from k8s_sandbox._pod import Pod
+from k8s_sandbox._pod.snapshot import list_pods
 
 DEFAULT_CHART = Path(__file__).parent / "resources" / "helm" / "agent-env"
 DEFAULT_TIMEOUT = 600  # 10 minutes
@@ -236,7 +237,8 @@ class Release:
         try:
             pods = await loop.run_in_executor(
                 None,
-                lambda: client.list_namespaced_pod(
+                lambda: list_pods(
+                    client,
                     self._namespace,
                     label_selector=f"app.kubernetes.io/instance={self.release_name}",
                 ),
@@ -245,37 +247,22 @@ class Release:
             _raise_runtime_error(
                 "Failed to list pods.", release=self.release_name, from_exception=e
             )
-        if not pods.items:
+        if not pods:
             _raise_runtime_error("No pods found.", release=self.release_name)
         sandboxes = dict()
-        for pod in pods.items:
-            assert pod.metadata is not None
-            assert pod.metadata.labels is not None
-            assert pod.spec is not None
-            assert pod.status is not None
-            assert pod.status.container_statuses is not None
-            service_name = pod.metadata.labels.get("inspect/service")
+        for pod in pods:
+            service_name = pod.labels.get("inspect/service")
             # Depending on the Helm chart, some Pods may not have a service label.
             # These should not be considered to be a sandbox pod (as per our docs).
             if service_name is not None:
-                default_container_name = pod.spec.containers[0].name
-                default_container_restart_count = next(
-                    (
-                        container_status.restart_count
-                        for container_status in pod.status.container_statuses
-                        if container_status.name == default_container_name
-                    ),
-                    0,
-                )
-                assert pod.metadata.name is not None
-                assert pod.metadata.uid is not None
+                default_container_name = pod.container_names[0]
                 sandboxes[service_name] = Pod(
-                    pod.metadata.name,
+                    pod.name,
                     self._namespace,
                     self._context_name,
                     default_container_name,
-                    pod.metadata.uid,
-                    default_container_restart_count,
+                    pod.uid,
+                    pod.restart_count_for(default_container_name),
                     self.restarted_container_behavior,
                 )
         return sandboxes

--- a/src/k8s_sandbox/_pod/op.py
+++ b/src/k8s_sandbox/_pod/op.py
@@ -10,6 +10,7 @@ from kubernetes.stream.ws_client import RESIZE_CHANNEL, WSClient  # type: ignore
 
 from k8s_sandbox._kubernetes_api import k8s_client
 from k8s_sandbox._pod.error import ContainerRestartedError, PodReplacedError
+from k8s_sandbox._pod.snapshot import read_pod
 
 # The duration to wait for an initial response from the k8s API server.
 # The initial response is received before the command is necessarily complete, so
@@ -150,62 +151,34 @@ def check_for_pod_restart(pod: PodInfo) -> None:
             (treated as a permanent misconfiguration).
     """
     api = k8s_client(pod.context_name)
-    k8s_pod = api.read_namespaced_pod(name=pod.name, namespace=pod.namespace)
-    assert k8s_pod.metadata is not None
-    assert k8s_pod.metadata.uid is not None
-    assert k8s_pod.status is not None
-    if k8s_pod.metadata.uid != pod.uid:
+    snapshot = read_pod(api, name=pod.name, namespace=pod.namespace)
+    if snapshot.uid != pod.uid:
         # Capture the new pod's restart count for the default container so the
         # caller can refresh its full cached identity atomically.
-        new_restart_count = _restart_count_for(
-            k8s_pod.status.container_statuses, pod.default_container_name
-        )
         raise PodReplacedError(
             pod_name=pod.name,
             old_uid=pod.uid,
-            new_uid=k8s_pod.metadata.uid,
-            new_restart_count=new_restart_count,
+            new_uid=snapshot.uid,
+            new_restart_count=snapshot.restart_count_for(pod.default_container_name),
         )
-    if k8s_pod.status.container_statuses is None:
+    if snapshot.container_statuses is None:
         # Kubelet hasn't published container statuses yet (briefly possible
         # right after pod scheduling). Nothing to compare against — skip the
-        # restart-count check rather than asserting.
+        # restart-count check.
         return
-    status = next(
-        (
-            container_status
-            for container_status in k8s_pod.status.container_statuses
-            if container_status.name == pod.default_container_name
-        ),
-        None,
-    )
+    status = snapshot.status_for(pod.default_container_name)
     if status is None:
         raise RuntimeError(
-            f"Pod '{k8s_pod.metadata.name}' does not have a container named "
+            f"Pod '{snapshot.name}' does not have a container named "
             f"'{pod.default_container_name}'"
         )
     if status.restart_count > pod.initial_restart_count:
-        last_state = status.last_state
-        terminated = last_state.terminated if last_state else None
-        last_reason = (
-            terminated.reason if terminated and terminated.reason else "unknown"
-        )
         raise ContainerRestartedError(
             pod_name=pod.name,
             container_name=status.name,
             restart_count=status.restart_count,
-            last_reason=last_reason,
+            last_reason=status.last_terminated_reason or "unknown",
         )
-
-
-def _restart_count_for(container_statuses, container_name: str) -> int:
-    if not container_statuses:
-        return 0
-    status = next(
-        (cs for cs in container_statuses if cs.name == container_name),
-        None,
-    )
-    return status.restart_count if status is not None else 0
 
 
 def _send_keepalive(ws_client: WSClient, stop: threading.Event) -> None:

--- a/src/k8s_sandbox/_pod/snapshot.py
+++ b/src/k8s_sandbox/_pod/snapshot.py
@@ -1,0 +1,127 @@
+"""Fast, low-overhead reads of Kubernetes Pod state.
+
+The kubernetes Python client deserializes every API response into its generated
+model classes (``V1Pod`` et al.) via ``ApiClient.__deserialize``. That code path
+is slow and effectively single-threaded, so it becomes a serialization
+bottleneck under high concurrency. In particular the frequently-called pod
+restart check (``check_for_pod_restart``) starts timing out and grinds large,
+many-cluster evals to a halt.
+See https://github.com/kubernetes-client/python/issues/2284.
+
+We sidestep the model layer by requesting the raw response
+(``_preload_content=False``) and parsing only the handful of fields we actually
+use out of the JSON ourselves. ``PodSnapshot`` is that minimal, immutable view.
+
+Note: the kubernetes client still raises ``ApiException`` for non-2xx responses
+even with ``_preload_content=False`` (the status check runs before the response
+is returned), so error handling at call sites is unchanged. The raw JSON uses
+camelCase keys (``containerStatuses``, ``restartCount``, ...), unlike the
+snake_case attributes on the generated model classes.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, cast
+
+from kubernetes import client  # type: ignore
+from urllib3 import HTTPResponse
+
+
+@dataclass(frozen=True)
+class ContainerStatus:
+    """A minimal view of a single container's status."""
+
+    name: str
+    restart_count: int
+    last_terminated_reason: str | None
+
+
+@dataclass(frozen=True)
+class PodSnapshot:
+    """A minimal, immutable view of a Kubernetes Pod.
+
+    Only the fields used by this library are parsed. ``container_statuses`` is
+    ``None`` when the kubelet has not yet published any (briefly possible right
+    after scheduling), as distinct from an empty tuple.
+    """
+
+    name: str
+    uid: str
+    labels: dict[str, str]
+    container_names: tuple[str, ...]
+    """Container names from the pod spec, in declared order."""
+    container_statuses: tuple[ContainerStatus, ...] | None
+
+    def status_for(self, container_name: str) -> ContainerStatus | None:
+        if self.container_statuses is None:
+            return None
+        return next(
+            (cs for cs in self.container_statuses if cs.name == container_name),
+            None,
+        )
+
+    def restart_count_for(self, container_name: str) -> int:
+        status = self.status_for(container_name)
+        return status.restart_count if status is not None else 0
+
+
+def read_pod(api: client.CoreV1Api, name: str, namespace: str) -> PodSnapshot:
+    """Read a single pod, bypassing the kubernetes client's model deserialization."""
+    # _preload_content is passed through to the generated client's **kwargs at
+    # runtime but is absent from the typed stubs, hence the call-arg ignore.
+    response = cast(
+        HTTPResponse,
+        api.read_namespaced_pod(  # type: ignore[call-arg]
+            name=name, namespace=namespace, _preload_content=False
+        ),
+    )
+    return _parse_pod(json.loads(response.data))
+
+
+def list_pods(
+    api: client.CoreV1Api, namespace: str, *, label_selector: str
+) -> list[PodSnapshot]:
+    """List pods, bypassing the kubernetes client's model deserialization."""
+    # See read_pod for why _preload_content needs a call-arg ignore.
+    response = cast(
+        HTTPResponse,
+        api.list_namespaced_pod(  # type: ignore[call-arg]
+            namespace, label_selector=label_selector, _preload_content=False
+        ),
+    )
+    body = json.loads(response.data)
+    return [_parse_pod(item) for item in body.get("items", [])]
+
+
+def _parse_pod(pod: dict[str, Any]) -> PodSnapshot:
+    metadata = pod.get("metadata") or {}
+    spec = pod.get("spec") or {}
+    status = pod.get("status") or {}
+    name = metadata.get("name")
+    uid = metadata.get("uid")
+    if name is None or uid is None:
+        raise ValueError(f"Pod is missing metadata.name or metadata.uid: {metadata}")
+    raw_statuses = status.get("containerStatuses")
+    container_statuses = (
+        tuple(_parse_container_status(cs) for cs in raw_statuses)
+        if raw_statuses is not None
+        else None
+    )
+    return PodSnapshot(
+        name=name,
+        uid=uid,
+        labels=metadata.get("labels") or {},
+        container_names=tuple(c["name"] for c in spec.get("containers") or []),
+        container_statuses=container_statuses,
+    )
+
+
+def _parse_container_status(cs: dict[str, Any]) -> ContainerStatus:
+    terminated = (cs.get("lastState") or {}).get("terminated") or {}
+    return ContainerStatus(
+        name=cs["name"],
+        restart_count=cs.get("restartCount", 0),
+        last_terminated_reason=terminated.get("reason"),
+    )

--- a/test/k8s_sandbox/pod/test_check_for_pod_restart.py
+++ b/test/k8s_sandbox/pod/test_check_for_pod_restart.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -7,16 +8,28 @@ from k8s_sandbox._pod.op import PodInfo, check_for_pod_restart
 from k8s_sandbox._pod.pod import Pod
 
 
+def _raw_pod_response(body: dict) -> MagicMock:
+    """Mimic the raw urllib3 response returned by ``_preload_content=False``."""
+    response = MagicMock()
+    response.data = json.dumps(body).encode()
+    return response
+
+
 def _k8s_pod(uid: str, container_name: str, restart_count: int) -> MagicMock:
-    pod = MagicMock()
-    pod.metadata.uid = uid
-    pod.metadata.name = "agent-env-abc-default-0"
-    status = MagicMock()
-    status.name = container_name
-    status.restart_count = restart_count
-    status.last_state.terminated.reason = "OOMKilled"
-    pod.status.container_statuses = [status]
-    return pod
+    return _raw_pod_response(
+        {
+            "metadata": {"uid": uid, "name": "agent-env-abc-default-0"},
+            "status": {
+                "containerStatuses": [
+                    {
+                        "name": container_name,
+                        "restartCount": restart_count,
+                        "lastState": {"terminated": {"reason": "OOMKilled"}},
+                    }
+                ]
+            },
+        }
+    )
 
 
 def _pod_info(uid: str = "uid-1", restart_count: int = 0) -> PodInfo:
@@ -42,11 +55,10 @@ def test_no_change_does_not_raise():
 
 def test_missing_container_statuses_skips_restart_check():
     # Briefly possible right after pod scheduling: same UID but kubelet
-    # hasn't published container_statuses yet. Must not assert.
-    pod = MagicMock()
-    pod.metadata.uid = "uid-1"
-    pod.metadata.name = "agent-env-abc-default-0"
-    pod.status.container_statuses = None
+    # hasn't published container_statuses yet. Must not raise.
+    pod = _raw_pod_response(
+        {"metadata": {"uid": "uid-1", "name": "agent-env-abc-default-0"}, "status": {}}
+    )
     with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
         mock_client.return_value.read_namespaced_pod.return_value = pod
         check_for_pod_restart(_pod_info(uid="uid-1"))

--- a/test/k8s_sandbox/pod/test_snapshot.py
+++ b/test/k8s_sandbox/pod/test_snapshot.py
@@ -1,0 +1,147 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from k8s_sandbox._pod.snapshot import (
+    ContainerStatus,
+    PodSnapshot,
+    _parse_pod,
+    list_pods,
+    read_pod,
+)
+
+
+def _raw_response(body: dict) -> MagicMock:
+    response = MagicMock()
+    response.data = json.dumps(body).encode()
+    return response
+
+
+def _pod_body(
+    *,
+    name: str = "agent-env-abc-default-0",
+    uid: str = "uid-1",
+    labels: dict | None = None,
+    containers: list[str] | None = None,
+    container_statuses: list[dict] | None = None,
+) -> dict:
+    body: dict = {"metadata": {"name": name, "uid": uid}, "spec": {}, "status": {}}
+    if labels is not None:
+        body["metadata"]["labels"] = labels
+    if containers is not None:
+        body["spec"]["containers"] = [{"name": n} for n in containers]
+    if container_statuses is not None:
+        body["status"]["containerStatuses"] = container_statuses
+    return body
+
+
+def test_parse_pod_extracts_key_fields():
+    # Arrange
+    body = _pod_body(
+        labels={"inspect/service": "default"},
+        containers=["default", "sidecar"],
+        container_statuses=[
+            {
+                "name": "default",
+                "restartCount": 2,
+                "lastState": {"terminated": {"reason": "OOMKilled"}},
+            }
+        ],
+    )
+
+    # Act
+    snapshot = _parse_pod(body)
+
+    # Assert
+    assert snapshot == PodSnapshot(
+        name="agent-env-abc-default-0",
+        uid="uid-1",
+        labels={"inspect/service": "default"},
+        container_names=("default", "sidecar"),
+        container_statuses=(
+            ContainerStatus(
+                name="default", restart_count=2, last_terminated_reason="OOMKilled"
+            ),
+        ),
+    )
+
+
+def test_parse_pod_distinguishes_missing_statuses_from_empty():
+    # Kubelet hasn't published container statuses yet -> None, not ().
+    no_statuses = _parse_pod(_pod_body())
+    empty_statuses = _parse_pod(_pod_body(container_statuses=[]))
+
+    assert no_statuses.container_statuses is None
+    assert empty_statuses.container_statuses == ()
+
+
+def test_parse_pod_defaults_missing_optional_fields():
+    snapshot = _parse_pod(_pod_body())
+
+    assert snapshot.labels == {}
+    assert snapshot.container_names == ()
+
+
+def test_parse_pod_raises_when_identity_missing():
+    with pytest.raises(ValueError, match="metadata.name or metadata.uid"):
+        _parse_pod({"metadata": {"name": "no-uid"}})
+
+
+@pytest.mark.parametrize(
+    ("container_name", "expected"),
+    [("default", 3), ("sidecar", 0), ("absent", 0)],
+)
+def test_restart_count_for(container_name: str, expected: int):
+    snapshot = _parse_pod(
+        _pod_body(
+            container_statuses=[{"name": "default", "restartCount": 3}],
+        )
+    )
+
+    assert snapshot.restart_count_for(container_name) == expected
+
+
+def test_restart_count_for_is_zero_when_statuses_unpublished():
+    snapshot = _parse_pod(_pod_body())
+
+    assert snapshot.restart_count_for("default") == 0
+
+
+def test_read_pod_requests_raw_json_and_parses():
+    # Arrange
+    api = MagicMock()
+    api.read_namespaced_pod.return_value = _raw_response(_pod_body(uid="uid-42"))
+
+    # Act
+    snapshot = read_pod(api, name="pod", namespace="ns")
+
+    # Assert
+    api.read_namespaced_pod.assert_called_once_with(
+        name="pod", namespace="ns", _preload_content=False
+    )
+    assert snapshot.uid == "uid-42"
+
+
+def test_list_pods_parses_all_items():
+    # Arrange
+    api = MagicMock()
+    api.list_namespaced_pod.return_value = _raw_response(
+        {"items": [_pod_body(uid="a"), _pod_body(uid="b")]}
+    )
+
+    # Act
+    snapshots = list_pods(api, "ns", label_selector="app=x")
+
+    # Assert
+    api.list_namespaced_pod.assert_called_once_with(
+        "ns", label_selector="app=x", _preload_content=False
+    )
+    assert [s.uid for s in snapshots] == ["a", "b"]
+
+
+def test_list_pods_handles_empty_items():
+    api = MagicMock()
+    api.list_namespaced_pod.return_value = _raw_response({})
+
+    assert list_pods(api, "ns", label_selector="app=x") == []


### PR DESCRIPTION
The kubernetes Python client deserializes every API response into its generated model classes via ApiClient.__deserialize. That path is slow and effectively single-threaded, so it becomes a serialization bottleneck under high concurrency: the frequently-called check_for_pod_restart starts timing out and grinds many-cluster evals to a halt
(see https://github.com/kubernetes-client/python/issues/2284).

Add a central k8s_sandbox._pod.snapshot module that reads pods with _preload_content=False and parses only the handful of fields we use out of the raw JSON into an immutable PodSnapshot.

Fixes https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/issues/210

Will be running an eval using this fork tonight, can report back on if seemed to work.