### PR TITLE
Release 0.6.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+# Repo guidance for coding agents
+
+## Changelog (`CHANGELOG.md`)
+
+New work goes under the `## Unreleased` heading. Each entry is
+read by a **user of this library** — someone running `inspect eval` against the k8s
+sandbox or writing Helm/compose config. Write for them, not for a reviewer of the diff.
+
+Rules:
+
+- **Describe what the user experiences, not how it's implemented.** The mechanism
+  (worker threads, WebSocket frame sizes, `_preload_content`, deserialization paths)
+  belongs in the PR, not the changelog. The user only cares about the observable change.
+- **Cut the non-actionable.** If you're explaining *why* an obvious change is good, or
+  *how* it works internally, cut it.
+- **Keep what's actionable**: new config names, breaking-change migration steps,
+  version requirements, the symptom a bug fix removes, public API names (exception
+  types callers catch).
+- **Don't churn existing entries.** When editing, make changes that are necessary
+  (accuracy, completeness) and minimal. Don't swap synonyms or reorder for taste.
+
+Examples (all from real entries):
+
+```
+# Internal mechanism — the user can't act on "raw API JSON":
+- Parse pod reads from the raw API JSON instead of the kubernetes client's model
+  deserialization, which serialized under high concurrency and caused TimeoutErrors...
+# The user-facing effect:
+- Fix `TimeoutError`s in high-concurrency evals (many concurrent clusters).
+```
+
+[#211](https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/pull/211)
+
+```
+# Trailing justification of a self-explanatory change:
+- Include the cause's type and message in `K8sError`'s string, so callers reading
+  only str(error) can tell a transient infra error from a real failure.
+# Just the change:
+- Include the cause's type and message in `K8sError`'s string.
+```
+
+[#199](https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/pull/199)
+
+```
+# Leads with implementation:
+- Propagate the caller's context into the pod-operation worker thread so Inspect
+  sandbox config overrides are honoured.
+# Leads with the effect:
+- Honour Inspect sandbox config overrides (e.g. exec output size limits) that were
+  previously ignored on Kubernetes.
+```
+
+[#201](https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/pull/201)
+
+Detail is warranted when it's actionable. A breaking change earns its length because
+the user must reconfigure:
+
+```
+- **BREAKING CHANGE**: `allowDomains` egress is now restricted to ports 80/443, with
+  the request identity enforced (TLS SNI on 443, HTTP `Host` on 80) rather than just
+  the resolved IP. Wildcard entries require Cilium >= 1.18. New `allowDomainsPorts`
+  opens other ports to those domains (IP-pinned; see `values.yaml`).
+```
+
+[#208](https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/pull/208)
+
+A new config option keeps the "when would I use this" clause that distinguishes it from
+existing options:
+
+```
+- Add a per-service `x-inspect_k8s_sandbox.resources` compose extension (alias `x-k8s`)
+  for Kubernetes resource `requests`/`limits` (e.g. `ephemeral-storage`) that the
+  `mem_limit`/`cpus`/`deploy.resources` shortcuts cannot express.
+```
+
+[#207](https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/pull/207)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
 # Changelog
 
-## Unreleased
+## 2026-06-25 0.6.0
 
-- Support replacement rather than throwing `UnicodeDecodeError` when a command writes non-UTF-8 bytes to stdout/stderr.
-- **BREAKING CHANGE**: `allowDomains` egress is now restricted to ports 80/443 (i.e. HTTP/HTTPS) with the request identity enforced in Cilium (TLS SNI on 443, HTTP `Host` on 80), not just the resolved IP. Wildcard entries require Cilium >= 1.18 (older Cilium matches exact hostnames only). New `allowDomainsPorts` opens additional ports to those domains (IP-pinned only; see `values.yaml`).
-- Add a per-service `x-inspect_k8s_sandbox.resources` extension to the compose-to-helm converter for declaring Kubernetes resource `requests`/`limits` (e.g. request-only `ephemeral-storage`) that the `mem_limit`/`cpus`/`deploy.resources` shortcuts cannot express. Keys are merged into the resources derived from those shortcuts; conflicts are rejected rather than silently overridden.
-- Propagate the caller's context into the pod-operation worker thread to ensure that Inspect sandbox config overrides are honoured.
-- Raise typed `PodReplacedError` / `ContainerRestartedError` (instead of `RuntimeError`) when a pod operation detects the pod has been replaced or its container restarted, and refresh the cached pod identity so subsequent operations target the new pod instead of looping against a stale UID. `restarted_container_behavior="warn"` now also refreshes (previously left the cached UID stale).
-- Fix `exec(input=...)` failing with "Connection reset by peer" for large inputs (e.g. injecting a ~28 MiB binary): stdin is now written to the pod in ≤1 MiB WebSocket frames instead of a single oversized frame. `write_file` shares the same chunking helper.
-- Parse pod reads from the raw API JSON (`_preload_content=False`) instead of the kubernetes client's model deserialization, which serialized under high concurrency and stalled evals running many concurrent clusters with `TimeoutError`s.
+- Replace non-UTF-8 bytes in command output rather than throwing `UnicodeDecodeError`.
+- **BREAKING CHANGE**: `allowDomains` egress is now restricted to ports 80/443, with the request identity enforced (TLS SNI on 443, HTTP `Host` on 80) rather than just the resolved IP. Wildcard entries require Cilium >= 1.18. New `allowDomainsPorts` opens other ports to those domains (IP-pinned; see `values.yaml`).
+- Add a per-service `x-inspect_k8s_sandbox.resources` compose extension (alias `x-k8s`) for Kubernetes resource `requests`/`limits` (e.g. `ephemeral-storage`) that the `mem_limit`/`cpus`/`deploy.resources` shortcuts cannot express. Merged with those shortcuts; conflicts are rejected.
+- Add optional `serviceAccountName` to the agent-env Helm chart for IRSA-based S3 access from sandbox pods.
+- Honour Inspect sandbox config overrides (e.g. exec output size limits) that were previously ignored on Kubernetes.
+- Recover from pod replacement or container restart instead of looping against the old pod, and raise typed `PodReplacedError` / `ContainerRestartedError` (was `RuntimeError`).
+- Include the cause's type and message in `K8sError`'s string.
+- Don't misreport a user command's own stderr as a `runuser` configuration error under `exec(user=...)`.
+- Fix `exec(input=...)` and `write_file` failing with "Connection reset by peer" for large inputs (e.g. a ~28 MiB binary).
+- Fix `TimeoutError`s in high-concurrency evals (many concurrent clusters).
 
 ## 2026-05-07 0.5.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,8 +107,8 @@ Consider using the recommended [Rewrap](https://stkb.github.io/Rewrap/) extensio
 
 ## Changelog
 
-Every PR should add an entry under the `## Unreleased` heading in `CHANGELOG.md`. See
-[AGENTS.md](AGENTS.md) for how to write one.
+If appropriate, add an entry under the `## Unreleased` heading in `CHANGELOG.md` when
+submitting a PR.
 
 ## Releasing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,22 @@ your code; the check simply fails.
 Consider using the recommended [Rewrap](https://stkb.github.io/Rewrap/) extension
 (`.vscode/extensions.json`) for VS Code to wrap Markdown text at 88 characters.
 
+## Releasing
+
+Releases are published manually using uv's standard
+[build](https://docs.astral.sh/uv/guides/package/#building-your-package) and
+[publish](https://docs.astral.sh/uv/guides/package/#publishing-your-package) flow —
+this guide does not duplicate those steps.
+
+The repo-specific parts are:
+
+- Bump `version` in `pyproject.toml` and run `uv lock` to update `uv.lock`.
+- Replace the `## Unreleased` heading in `CHANGELOG.md` with `## <YYYY-MM-DD> <version>`
+  (see existing entries for the format).
+- After merging, tag the release commit `vX.Y.Z` and push the tag.
+
+See [AGENTS.md](AGENTS.md) for how to write changelog entries.
+
 ## Conventions
 
 ### Package Structure and API Visibility

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,11 @@ your code; the check simply fails.
 Consider using the recommended [Rewrap](https://stkb.github.io/Rewrap/) extension
 (`.vscode/extensions.json`) for VS Code to wrap Markdown text at 88 characters.
 
+## Changelog
+
+Every PR should add an entry under the `## Unreleased` heading in `CHANGELOG.md`. See
+[AGENTS.md](AGENTS.md) for how to write one.
+
 ## Releasing
 
 Releases are published manually using uv's standard
@@ -118,8 +123,6 @@ The repo-specific parts are:
 - Replace the `## Unreleased` heading in `CHANGELOG.md` with `## <YYYY-MM-DD> <version>`
   (see existing entries for the format).
 - After merging, tag the release commit `vX.Y.Z` and push the tag.
-
-See [AGENTS.md](AGENTS.md) for how to write changelog entries.
 
 ## Conventions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inspect-k8s-sandbox"
-version = "0.5.0"
+version = "0.6.0"
 description = "A Kubernetes Sandbox Environment for Inspect"
 authors = [{name = "UK AI Security Institute"}]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -839,7 +839,7 @@ wheels = [
 
 [[package]]
 name = "inspect-k8s-sandbox"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "inspect-ai" },


### PR DESCRIPTION
Prepares the 0.6.0 release.

## Changelog
- Bumps `version` to `0.6.0` and dates the `## Unreleased` heading (`2026-06-25 0.6.0`).
- Adds three entries that were missing for merged PRs: `serviceAccountName` (#190), `K8sError` cause in string (#199), and the `runuser`-stderr false-positive fix (#187).
- Rewrites the entries since 0.5.0 to describe the **user-facing effect** rather than the implementation (e.g. "Fix `TimeoutError`s in high-concurrency evals" instead of the raw-API-JSON mechanism).

## AGENTS.md
Adds repo guidance for coding agents, currently just the changelog conventions, with before/after examples linking to the PRs they came from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)