### PR TITLE
Lock agent-env chart version to the package version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- The package and bundled `agent-env` chart versions are now unified, both jumping to
+  `0.13.0` (intervening numbers are unused).
+
 ## 2026-06-25 0.6.1
 
 - no changes - version bump only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Read AGENTS.md.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,8 @@ this guide does not duplicate those steps.
 
 The repo-specific parts are:
 
-- Bump `version` in `pyproject.toml` and run `uv lock` to update `uv.lock`.
+- Bump `version` in `pyproject.toml` and run `uv lock` to update `uv.lock`. Set the
+  bundled `agent-env` chart version in `Chart.yaml` to match.
 - Replace the `## Unreleased` heading in `CHANGELOG.md` with `## <YYYY-MM-DD> <version>`
   (see existing entries for the format).
 - After merging, tag the release commit `vX.Y.Z` and push the tag.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inspect-k8s-sandbox"
-version = "0.6.1"
+version = "0.13.0"
 description = "A Kubernetes Sandbox Environment for Inspect"
 authors = [{name = "UK AI Security Institute"}]
 readme = "README.md"

--- a/src/k8s_sandbox/resources/helm/agent-env/Chart.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: agent-env
-version: 0.12.0
+version: 0.13.0

--- a/src/k8s_sandbox/resources/helm/agent-env/README.md
+++ b/src/k8s_sandbox/resources/helm/agent-env/README.md
@@ -1,6 +1,6 @@
 # agent-env
 
-![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square)
+![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square)
 
 ## Values
 

--- a/test/k8s_sandbox/helm_chart/test_chart_version.py
+++ b/test/k8s_sandbox/helm_chart/test_chart_version.py
@@ -1,0 +1,20 @@
+import re
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_CHART = _REPO_ROOT / "src/k8s_sandbox/resources/helm/agent-env/Chart.yaml"
+
+
+def test_chart_version_matches_package_version() -> None:
+    # The chart is bundled in the package rather than published separately, so its
+    # version must track pyproject.toml's.
+    match = re.search(r'^version = "([^"]+)"', _PYPROJECT.read_text(), re.MULTILINE)
+    assert match is not None, "no [project] version in pyproject.toml"
+    package_version = match.group(1)
+
+    chart_version = str(yaml.safe_load(_CHART.read_text())["version"])
+
+    assert chart_version == package_version

--- a/uv.lock
+++ b/uv.lock
@@ -839,7 +839,7 @@ wheels = [
 
 [[package]]
 name = "inspect-k8s-sandbox"
-version = "0.6.1"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "inspect-ai" },


### PR DESCRIPTION
The `agent-env` chart version was bumped by hand in `Chart.yaml` and had drifted — stuck at `0.12.0` across feature additions and the breaking `allowDomains` change.

The chart ships in the wheel, not a separate Helm repo, so lock its version to the package: both move to `0.13.0`, and a unit test fails if they diverge.
