### PR TITLE
compose converter: support security_opt (seccomp) and ignore memswap_limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Compose to HELM: Map `security_opt: ["seccomp=<path>"]` to a `Localhost` `seccompProfile` in the pod's `securityContext` (merged with any `user:`-derived context; non-`seccomp=` entries are rejected).
+- Compose to HELM: Ignore `memswap_limit` with an info log, since Kubernetes has no per-pod swap knob and nodes run with swap off by default.
+
 ## 2026-06-25 0.6.1
 
 - no changes - version bump only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Unreleased
 
-- Compose to HELM: Map a `security_opt` seccomp entry (`seccomp=<value>` or `seccomp:<value>`) to a `seccompProfile` in the pod's `securityContext`, merged with any `user:`-derived context. `unconfined`/`builtin` map to the `Unconfined`/`RuntimeDefault` profile types; other values are treated as `Localhost` profile paths (validated as relative, non-empty, no `..`). Non-seccomp entries (e.g. `apparmor=`) are rejected.
-- Compose to HELM: Ignore `memswap_limit` with an info log, since Kubernetes exposes no Compose-equivalent per-container swap limit.
+- Compose to HELM: Support the `security_opt` seccomp option (mapped to a pod `seccompProfile`) and ignore the unsupported `memswap_limit`. See [Compose to Helm](https://k8s-sandbox.aisi.org.uk/helm/compose-to-helm/) for details.
 
 ## 2026-06-25 0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- Compose to HELM: Map `security_opt: ["seccomp=<path>"]` to a `Localhost` `seccompProfile` in the pod's `securityContext` (merged with any `user:`-derived context; non-`seccomp=` entries are rejected).
-- Compose to HELM: Ignore `memswap_limit` with an info log, since Kubernetes has no per-pod swap knob and nodes run with swap off by default.
+- Compose to HELM: Map a `security_opt` seccomp entry (`seccomp=<value>` or `seccomp:<value>`) to a `seccompProfile` in the pod's `securityContext`, merged with any `user:`-derived context. `unconfined`/`builtin` map to the `Unconfined`/`RuntimeDefault` profile types; other values are treated as `Localhost` profile paths (validated as relative, non-empty, no `..`). Non-seccomp entries (e.g. `apparmor=`) are rejected.
+- Compose to HELM: Ignore `memswap_limit` with an info log, since Kubernetes exposes no Compose-equivalent per-container swap limit.
 
 ## 2026-06-25 0.6.1
 

--- a/docs/docs/helm/compose-to-helm.md
+++ b/docs/docs/helm/compose-to-helm.md
@@ -182,11 +182,19 @@ Notes:
 - Non-seccomp entries (e.g. `apparmor=...`, `no-new-privileges`) have no mapping here and
   are rejected rather than silently dropped, so a workload can't believe a security
   control is applied when it isn't.
+- **Runtime caveat (gVisor).** A seccomp profile only changes which syscalls the kernel
+  *allows*; it can't add syscalls the runtime doesn't implement. The chart defaults to the
+  `gvisor` runtime, whose `personality()` does not support `ADDR_NO_RANDOMIZE`. So a
+  profile that permits `personality` in order to run `setarch -R` (the portable way to
+  disable ASLR, e.g. for exploitation workloads) has no effect under gVisor — `setarch -R`
+  fails with `EINVAL` regardless of the profile. Set `runtime: runc` on the service
+  (mapped to `runtimeClassName: runc`) for those workloads.
 
 ```yaml
 services:
   my-service:
     image: ubuntu
+    runtime: runc  # gVisor (the default) can't disable ASLR; see the runtime caveat above
     security_opt:
       - seccomp=profiles/no-aslr.json
 ```

--- a/docs/docs/helm/compose-to-helm.md
+++ b/docs/docs/helm/compose-to-helm.md
@@ -161,10 +161,10 @@ A `security_opt` **seccomp** entry (`seccomp=<value>` or `seccomp:<value>`) is c
 to a `seccompProfile` in the pod's `securityContext` (merged with any context derived
 from `user`). Docker's special values map to Kubernetes profile types:
 
-| Compose value | Kubernetes `seccompProfile` |
-| --- | --- |
-| `seccomp=unconfined` | `{type: Unconfined}` |
-| `seccomp=builtin` | `{type: RuntimeDefault}` |
+| Compose value                  | Kubernetes `seccompProfile`                                 |
+| ------------------------------ | ----------------------------------------------------------- |
+| `seccomp=unconfined`           | `{type: Unconfined}`                                        |
+| `seccomp=builtin`              | `{type: RuntimeDefault}`                                    |
 | `seccomp=<relative/path.json>` | `{type: Localhost, localhostProfile: <relative/path.json>}` |
 
 Notes:
@@ -177,8 +177,8 @@ Notes:
   passed through as `localhostProfile`. **Kubernetes resolves this relative to the
   kubelet's seccomp root, so the profile file must already be pre-staged on every node
   (default `/var/lib/kubelet/seccomp/<path>`).** This is not verified at conversion time;
-  a missing profile fails only when the pod is launched. The converter logs a warning as
-  a reminder.
+  a missing profile fails only when the pod is launched. The converter logs an info-level
+  reminder.
 - Non-seccomp entries (e.g. `apparmor=...`, `no-new-privileges`) have no mapping here and
   are rejected rather than silently dropped, so a workload can't believe a security
   control is applied when it isn't.

--- a/docs/docs/helm/compose-to-helm.md
+++ b/docs/docs/helm/compose-to-helm.md
@@ -150,7 +150,7 @@ limit, nor of resources such as `hugepages-*`.
 `memswap_limit` is ignored (with an info-level log) because Kubernetes has no
 Compose-equivalent per-container swap limit. On typical clusters, swap is disabled on
 nodes, so this is a no-op. However, if your cluster enables swap (via the Kubernetes
-[NodeSwap](https://kubernetes.io/docs/concepts/architecture/nodes/#swap-memory)
+[NodeSwap](https://kubernetes.io/docs/concepts/cluster-administration/swap-memory-management/)
 feature) and your Compose file set `memswap_limit` equal to `mem_limit` to disable swap
 for the container, the converted workload may instead be able to use swap. If that
 matters, disable swap at the node or pod level.

--- a/docs/docs/helm/compose-to-helm.md
+++ b/docs/docs/helm/compose-to-helm.md
@@ -144,3 +144,49 @@ This extension exists because Docker Compose cannot express many Kubernetes
 resources. It covers CPU and memory requests/limits (via `cpus`/`mem_limit` and
 `deploy.resources`), but has no concept of a disk (`ephemeral-storage`) request or
 limit, nor of resources such as `hugepages-*`.
+
+### Swap (`memswap_limit`)
+
+`memswap_limit` is ignored (with an info-level log) because Kubernetes has no
+Compose-equivalent per-container swap limit. On typical clusters, swap is disabled on
+nodes, so this is a no-op. However, if your cluster enables swap (via the Kubernetes
+[NodeSwap](https://kubernetes.io/docs/concepts/architecture/nodes/#swap-memory)
+feature) and your Compose file set `memswap_limit` equal to `mem_limit` to disable swap
+for the container, the converted workload may instead be able to use swap. If that
+matters, disable swap at the node or pod level.
+
+## Security Options
+
+A `security_opt` **seccomp** entry (`seccomp=<value>` or `seccomp:<value>`) is converted
+to a `seccompProfile` in the pod's `securityContext` (merged with any context derived
+from `user`). Docker's special values map to Kubernetes profile types:
+
+| Compose value | Kubernetes `seccompProfile` |
+| --- | --- |
+| `seccomp=unconfined` | `{type: Unconfined}` |
+| `seccomp=builtin` | `{type: RuntimeDefault}` |
+| `seccomp=<relative/path.json>` | `{type: Localhost, localhostProfile: <relative/path.json>}` |
+
+Notes:
+
+- `builtin` is Docker's (undocumented) value for its built-in default profile.
+  `RuntimeDefault` — the container runtime's default profile — is the closest Kubernetes
+  analog, though the runtime's default may differ slightly from Docker's built-in
+  profile.
+- A profile path must be relative and descending (no absolute paths or `..`); it is
+  passed through as `localhostProfile`. **Kubernetes resolves this relative to the
+  kubelet's seccomp root, so the profile file must already be pre-staged on every node
+  (default `/var/lib/kubelet/seccomp/<path>`).** This is not verified at conversion time;
+  a missing profile fails only when the pod is launched. The converter logs a warning as
+  a reminder.
+- Non-seccomp entries (e.g. `apparmor=...`, `no-new-privileges`) have no mapping here and
+  are rejected rather than silently dropped, so a workload can't believe a security
+  control is applied when it isn't.
+
+```yaml
+services:
+  my-service:
+    image: ubuntu
+    security_opt:
+      - seccomp=profiles/no-aslr.json
+```

--- a/src/k8s_sandbox/compose/_converter.py
+++ b/src/k8s_sandbox/compose/_converter.py
@@ -254,38 +254,37 @@ class _ServiceConverter:
         _transform(
             src, "user", result, "securityContext", self._user_to_security_context
         )
-        # security_opt: map a `seccomp=<path>` entry to a Localhost seccompProfile,
-        # merged into securityContext (which `user` above may also populate). Any other
-        # security_opt entries (e.g. `apparmor=`, `no-new-privileges`) have no k8s
-        # mapping here and are rejected rather than silently dropped, so a workload
+        # security_opt: map a seccomp entry (`seccomp=<value>` or `seccomp:<value>`) to
+        # a seccompProfile in securityContext (which `user` above may also populate).
+        # Any other security_opt entries (e.g. `apparmor=`, `no-new-privileges`) have no
+        # k8s mapping here and are rejected rather than silently dropped, so a workload
         # can't believe a security control is applied when it isn't.
         if (security_opt := src.pop("security_opt", None)) is not None:
             entries = security_opt if isinstance(security_opt, list) else [security_opt]
-            seccomp = [
-                e for e in entries if isinstance(e, str) and e.startswith("seccomp=")
-            ]
-            other = [
-                e
-                for e in entries
-                if not (isinstance(e, str) and e.startswith("seccomp="))
-            ]
-            if other:
+            seccomp_profile = None
+            unsupported = []
+            for entry in entries:
+                option, value = _split_security_opt(entry)
+                if option == "seccomp":
+                    seccomp_profile = self._seccomp_to_profile(value)
+                else:
+                    unsupported.append(entry)
+            if unsupported:
                 raise ComposeConverterError(
-                    f"Unsupported 'security_opt' entries: {other}. Only "
-                    f"'seccomp=<path>' is supported. {self.context}"
+                    f"Unsupported 'security_opt' entries: {unsupported}. Only "
+                    f"'seccomp=<value>' is supported. {self.context}"
                 )
-            if seccomp:
-                sec = result.setdefault("securityContext", {})
-                sec["seccompProfile"] = {
-                    "type": "Localhost",
-                    "localhostProfile": seccomp[0][len("seccomp=") :],
-                }
-        # memswap_limit: no per-pod swap knob in k8s and nodes are swap-off by default,
-        # so `memswap_limit == mem_limit` (disable swap) is already the ambient
-        # behavior.
-        if src.pop("memswap_limit", None) is not None:
+            if seccomp_profile is not None:
+                result.setdefault("securityContext", {})["seccompProfile"] = (
+                    seccomp_profile
+                )
+        # memswap_limit: k8s exposes no Compose-equivalent per-container swap limit, so
+        # this Docker-only knob has no conversion target and is ignored (the rest of the
+        # config still converts).
+        if (memswap_limit := src.pop("memswap_limit", None)) is not None:
             logger.info(
-                f"Ignoring 'memswap_limit': k8s nodes run swap off. {self.context}"
+                f"Ignoring 'memswap_limit: {memswap_limit}': Kubernetes does not "
+                f"expose a Compose-equivalent per-container swap limit. {self.context}"
             )
         # Check for network_mode first
         network_mode = src.pop("network_mode", None)
@@ -618,6 +617,23 @@ class _ServiceConverter:
             f"str. {self.context}"
         )
 
+    def _seccomp_to_profile(self, value: str | None) -> dict[str, str]:
+        # Docker's special seccomp values map to k8s built-in profile types; anything
+        # else is treated as a custom profile path (k8s `Localhost`).
+        if value == "unconfined":
+            return {"type": "Unconfined"}
+        if value == "builtin":
+            return {"type": "RuntimeDefault"}
+        # k8s resolves `localhostProfile` relative to the kubelet's seccomp root, so it
+        # must be a non-empty, descending relative path (no absolute or `..` paths).
+        if not value or value.startswith("/") or ".." in value.split("/"):
+            raise ComposeConverterError(
+                f"Invalid seccomp profile in 'security_opt': '{value}'. Expected "
+                f"'unconfined', 'builtin', or a relative profile path (no absolute "
+                f"paths or '..'). {self.context}"
+            )
+        return {"type": "Localhost", "localhostProfile": value}
+
     def _duration_to_seconds(self, value: str) -> int:
         """Convert Docker Compose duration format (e.g., '30s', '1m') to seconds.
 
@@ -635,6 +651,19 @@ class _ServiceConverter:
         minutes = int(match.group("minutes") or 0)
         seconds = int(match.group("seconds") or 0)
         return hours * 3600 + minutes * 60 + seconds
+
+
+def _split_security_opt(entry: Any) -> tuple[str | None, str | None]:
+    # Compose accepts both `option=value` and `option:value` forms; split on whichever
+    # separator appears first. Returns (None, None) for non-string entries so the caller
+    # treats them as unsupported.
+    if not isinstance(entry, str):
+        return None, None
+    separators = [i for i, ch in enumerate(entry) if ch in "=:"]
+    if not separators:
+        return entry, None
+    idx = min(separators)
+    return entry[:idx], entry[idx + 1 :]
 
 
 def _make_volume_name_k8s_compliant(value: str) -> str:

--- a/src/k8s_sandbox/compose/_converter.py
+++ b/src/k8s_sandbox/compose/_converter.py
@@ -260,10 +260,11 @@ class _ServiceConverter:
         # k8s mapping here and are rejected rather than silently dropped, so a workload
         # can't believe a security control is applied when it isn't.
         if (security_opt := src.pop("security_opt", None)) is not None:
-            entries = security_opt if isinstance(security_opt, list) else [security_opt]
+            # The Compose schema constrains `security_opt` to an array, so a scalar is
+            # already rejected by `_validate_compose` before we get here.
             seccomp_profile = None
             unsupported = []
-            for entry in entries:
+            for entry in security_opt:
                 option, value = _split_security_opt(entry)
                 if option == "seccomp":
                     seccomp_profile = self._seccomp_to_profile(value)
@@ -272,7 +273,8 @@ class _ServiceConverter:
             if unsupported:
                 raise ComposeConverterError(
                     f"Unsupported 'security_opt' entries: {unsupported}. Only "
-                    f"'seccomp=<value>' is supported. {self.context}"
+                    f"'seccomp=<value>' (or 'seccomp:<value>') is supported. "
+                    f"{self.context}"
                 )
             if seccomp_profile is not None:
                 result.setdefault("securityContext", {})["seccompProfile"] = (
@@ -622,6 +624,9 @@ class _ServiceConverter:
         # else is treated as a custom profile path (k8s `Localhost`).
         if value == "unconfined":
             return {"type": "Unconfined"}
+        # `builtin` is Docker's (undocumented) value for its built-in default profile;
+        # k8s `RuntimeDefault` (the container runtime's default profile) is the closest
+        # analog, though the runtime's default may differ slightly from Docker's.
         if value == "builtin":
             return {"type": "RuntimeDefault"}
         # k8s resolves `localhostProfile` relative to the kubelet's seccomp root, so it
@@ -632,6 +637,16 @@ class _ServiceConverter:
                 f"'unconfined', 'builtin', or a relative profile path (no absolute "
                 f"paths or '..'). {self.context}"
             )
+        # Unlike the built-in profile types, a Localhost profile file is not shipped by
+        # the converter: it must already exist on every node. This isn't verified here,
+        # so a missing file surfaces only as a pod launch failure, not a conversion
+        # error.
+        logger.warning(
+            f"seccomp profile '{value}' maps to a k8s Localhost profile; the file must "
+            f"be pre-staged on every node under the kubelet seccomp root (default "
+            f"'/var/lib/kubelet/seccomp/{value}'). A missing profile fails at pod "
+            f"launch, not conversion. {self.context}"
+        )
         return {"type": "Localhost", "localhostProfile": value}
 
     def _duration_to_seconds(self, value: str) -> int:

--- a/src/k8s_sandbox/compose/_converter.py
+++ b/src/k8s_sandbox/compose/_converter.py
@@ -254,6 +254,39 @@ class _ServiceConverter:
         _transform(
             src, "user", result, "securityContext", self._user_to_security_context
         )
+        # security_opt: map a `seccomp=<path>` entry to a Localhost seccompProfile,
+        # merged into securityContext (which `user` above may also populate). Any other
+        # security_opt entries (e.g. `apparmor=`, `no-new-privileges`) have no k8s
+        # mapping here and are rejected rather than silently dropped, so a workload
+        # can't believe a security control is applied when it isn't.
+        if (security_opt := src.pop("security_opt", None)) is not None:
+            entries = security_opt if isinstance(security_opt, list) else [security_opt]
+            seccomp = [
+                e for e in entries if isinstance(e, str) and e.startswith("seccomp=")
+            ]
+            other = [
+                e
+                for e in entries
+                if not (isinstance(e, str) and e.startswith("seccomp="))
+            ]
+            if other:
+                raise ComposeConverterError(
+                    f"Unsupported 'security_opt' entries: {other}. Only "
+                    f"'seccomp=<path>' is supported. {self.context}"
+                )
+            if seccomp:
+                sec = result.setdefault("securityContext", {})
+                sec["seccompProfile"] = {
+                    "type": "Localhost",
+                    "localhostProfile": seccomp[0][len("seccomp=") :],
+                }
+        # memswap_limit: no per-pod swap knob in k8s and nodes are swap-off by default,
+        # so `memswap_limit == mem_limit` (disable swap) is already the ambient
+        # behavior.
+        if src.pop("memswap_limit", None) is not None:
+            logger.info(
+                f"Ignoring 'memswap_limit': k8s nodes run swap off. {self.context}"
+            )
         # Check for network_mode first
         network_mode = src.pop("network_mode", None)
         networks = src.get("networks")

--- a/src/k8s_sandbox/compose/_converter.py
+++ b/src/k8s_sandbox/compose/_converter.py
@@ -256,9 +256,6 @@ class _ServiceConverter:
         )
         # security_opt: map a seccomp entry (`seccomp=<value>` or `seccomp:<value>`) to
         # a seccompProfile in securityContext (which `user` above may also populate).
-        # Any other security_opt entries (e.g. `apparmor=`, `no-new-privileges`) have no
-        # k8s mapping here and are rejected rather than silently dropped, so a workload
-        # can't believe a security control is applied when it isn't.
         if (security_opt := src.pop("security_opt", None)) is not None:
             # The Compose schema constrains `security_opt` to an array, so a scalar is
             # already rejected by `_validate_compose` before we get here.

--- a/src/k8s_sandbox/compose/_converter.py
+++ b/src/k8s_sandbox/compose/_converter.py
@@ -638,7 +638,7 @@ class _ServiceConverter:
         # the converter: it must already exist on every node. This isn't verified here,
         # so a missing file surfaces only as a pod launch failure, not a conversion
         # error.
-        logger.warning(
+        logger.info(
             f"seccomp profile '{value}' maps to a k8s Localhost profile; the file must "
             f"be pre-staged on every node under the kubelet seccomp root (default "
             f"'/var/lib/kubelet/seccomp/{value}'). A missing profile fails at pod "

--- a/test/k8s_sandbox/compose/test_converter.py
+++ b/test/k8s_sandbox/compose/test_converter.py
@@ -802,6 +802,133 @@ services:
     assert "Invalid 'user' value" in str(exc_info.value)
 
 
+def test_converts_security_opt_seccomp(tmp_compose: TmpComposeFixture) -> None:
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    security_opt:
+      - seccomp=./profiles/no-aslr.json
+""")
+
+    result = convert_compose_to_helm_values(compose_path)
+
+    assert result["services"]["my-service"]["securityContext"]["seccompProfile"] == {
+        "type": "Localhost",
+        "localhostProfile": "./profiles/no-aslr.json",
+    }
+
+
+def test_merges_seccomp_into_user_security_context(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    # `user` and `security_opt` both populate securityContext; neither clobbers the
+    # other.
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    user: 1000:1001
+    security_opt:
+      - seccomp=./profiles/no-aslr.json
+""")
+
+    result = convert_compose_to_helm_values(compose_path)
+
+    assert result["services"]["my-service"]["securityContext"] == {
+        "runAsUser": 1000,
+        "runAsGroup": 1001,
+        "seccompProfile": {
+            "type": "Localhost",
+            "localhostProfile": "./profiles/no-aslr.json",
+        },
+    }
+
+
+def test_seccomp_output_validates_against_chart_schema(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    compose_path = tmp_compose("""
+services:
+  default:
+    image: my-image
+    security_opt:
+      - seccomp=./profiles/no-aslr.json
+""")
+
+    result = convert_compose_to_helm_values(compose_path)
+
+    schema_path = (
+        Path(k8s_sandbox.__file__).parent
+        / "resources"
+        / "helm"
+        / "agent-env"
+        / "values.schema.json"
+    )
+    schema = json.loads(schema_path.read_text())
+    # 'global' is injected by inspect at install time; add it to satisfy the schema.
+    jsonschema.validate({**result, "global": {}}, schema)
+
+
+def test_rejects_non_seccomp_security_opt(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    # Non-seccomp security_opt entries have no k8s mapping and must be rejected rather
+    # than silently dropped (so a security control isn't believed-applied when it
+    # isn't).
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    image: my-image
+    security_opt:
+      - no-new-privileges:true
+""")
+
+    with pytest.raises(ComposeConverterError) as exc_info:
+        convert_compose_to_helm_values(compose_path)
+
+    assert "Unsupported 'security_opt' entries" in str(exc_info.value)
+
+
+def test_rejects_non_seccomp_security_opt_alongside_seccomp(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    # A valid seccomp entry does not excuse an unsupported sibling entry.
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    image: my-image
+    security_opt:
+      - seccomp=./profiles/no-aslr.json
+      - apparmor=unconfined
+""")
+
+    with pytest.raises(ComposeConverterError) as exc_info:
+        convert_compose_to_helm_values(compose_path)
+
+    assert "Unsupported 'security_opt' entries" in str(exc_info.value)
+    assert "apparmor=unconfined" in str(exc_info.value)
+
+
+def test_ignores_memswap_limit(
+    caplog: pytest.LogCaptureFixture, tmp_compose: TmpComposeFixture
+) -> None:
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    image: my-image
+    mem_limit: 1G
+    memswap_limit: 1G
+""")
+
+    with caplog.at_level(logging.INFO):
+        result = convert_compose_to_helm_values(compose_path)
+
+    # memswap_limit is dropped (not carried into output) and an info log is emitted.
+    assert "memswap_limit" not in result["services"]["my-service"]
+    assert any(
+        "Ignoring 'memswap_limit'" in record.message for record in caplog.records
+    )
+
+
 def test_ignores_init_true(tmp_compose: TmpComposeFixture) -> None:
     compose_path = tmp_compose("""
 services:

--- a/test/k8s_sandbox/compose/test_converter.py
+++ b/test/k8s_sandbox/compose/test_converter.py
@@ -887,16 +887,17 @@ services:
     }
 
 
+@pytest.mark.parametrize("sep", ["=", ":"])
 def test_converts_security_opt_seccomp_unconfined(
-    tmp_compose: TmpComposeFixture,
+    sep: str, tmp_compose: TmpComposeFixture
 ) -> None:
     # Docker's `seccomp=unconfined` maps to the k8s Unconfined profile type, not a
-    # Localhost profile literally named "unconfined".
-    compose_path = tmp_compose("""
+    # Localhost profile literally named "unconfined". Both `=` and `:` are accepted.
+    compose_path = tmp_compose(f"""
 services:
   my-service:
     security_opt:
-      - seccomp=unconfined
+      - "seccomp{sep}unconfined"
 """)
 
     result = convert_compose_to_helm_values(compose_path)
@@ -906,15 +907,17 @@ services:
     }
 
 
+@pytest.mark.parametrize("sep", ["=", ":"])
 def test_converts_security_opt_seccomp_builtin(
-    tmp_compose: TmpComposeFixture,
+    sep: str, tmp_compose: TmpComposeFixture
 ) -> None:
-    # Docker's built-in default profile maps to the runtime's default on k8s.
-    compose_path = tmp_compose("""
+    # Docker's built-in default profile maps to the runtime's default on k8s. Both `=`
+    # and `:` are accepted.
+    compose_path = tmp_compose(f"""
 services:
   my-service:
     security_opt:
-      - seccomp=builtin
+      - "seccomp{sep}builtin"
 """)
 
     result = convert_compose_to_helm_values(compose_path)
@@ -987,6 +990,44 @@ services:
 
     assert "Unsupported 'security_opt' entries" in str(exc_info.value)
     assert "apparmor=unconfined" in str(exc_info.value)
+
+
+def test_rejects_scalar_security_opt(tmp_compose: TmpComposeFixture) -> None:
+    # The Compose schema requires `security_opt` to be a list, so a scalar is rejected
+    # up front by schema validation (never reaching the seccomp conversion logic).
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    image: my-image
+    security_opt: seccomp=unconfined
+""")
+
+    with pytest.raises(ComposeConverterError) as exc_info:
+        convert_compose_to_helm_values(compose_path)
+
+    assert "failed validation against the Compose schema" in str(exc_info.value)
+
+
+def test_warns_localhost_seccomp_profile_must_be_prestaged(
+    caplog: pytest.LogCaptureFixture, tmp_compose: TmpComposeFixture
+) -> None:
+    # A Localhost profile file isn't shipped by the converter; warn that it must be
+    # pre-staged on every node, since a missing file only fails at pod launch.
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    security_opt:
+      - seccomp=profiles/no-aslr.json
+""")
+
+    with caplog.at_level(logging.WARNING):
+        convert_compose_to_helm_values(compose_path)
+
+    assert any(
+        "/var/lib/kubelet/seccomp/" in record.message
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+    )
 
 
 def test_ignores_memswap_limit(

--- a/test/k8s_sandbox/compose/test_converter.py
+++ b/test/k8s_sandbox/compose/test_converter.py
@@ -868,6 +868,87 @@ services:
     jsonschema.validate({**result, "global": {}}, schema)
 
 
+def test_converts_security_opt_seccomp_colon_separator(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    # Compose accepts both `option=value` and `option:value`.
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    security_opt:
+      - "seccomp:profiles/no-aslr.json"
+""")
+
+    result = convert_compose_to_helm_values(compose_path)
+
+    assert result["services"]["my-service"]["securityContext"]["seccompProfile"] == {
+        "type": "Localhost",
+        "localhostProfile": "profiles/no-aslr.json",
+    }
+
+
+def test_converts_security_opt_seccomp_unconfined(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    # Docker's `seccomp=unconfined` maps to the k8s Unconfined profile type, not a
+    # Localhost profile literally named "unconfined".
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    security_opt:
+      - seccomp=unconfined
+""")
+
+    result = convert_compose_to_helm_values(compose_path)
+
+    assert result["services"]["my-service"]["securityContext"]["seccompProfile"] == {
+        "type": "Unconfined",
+    }
+
+
+def test_converts_security_opt_seccomp_builtin(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    # Docker's built-in default profile maps to the runtime's default on k8s.
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    security_opt:
+      - seccomp=builtin
+""")
+
+    result = convert_compose_to_helm_values(compose_path)
+
+    assert result["services"]["my-service"]["securityContext"]["seccompProfile"] == {
+        "type": "RuntimeDefault",
+    }
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "seccomp=/etc/seccomp/profile.json",  # absolute
+        "seccomp=../escape.json",  # path traversal
+        "seccomp=profiles/../../escape.json",  # traversal mid-path
+        "seccomp=",  # empty
+    ],
+)
+def test_rejects_invalid_seccomp_profile_path(
+    value: str, tmp_compose: TmpComposeFixture
+) -> None:
+    compose_path = tmp_compose(f"""
+services:
+  my-service:
+    security_opt:
+      - "{value}"
+""")
+
+    with pytest.raises(ComposeConverterError) as exc_info:
+        convert_compose_to_helm_values(compose_path)
+
+    assert "Invalid seccomp profile" in str(exc_info.value)
+
+
 def test_rejects_non_seccomp_security_opt(
     tmp_compose: TmpComposeFixture,
 ) -> None:
@@ -922,10 +1003,11 @@ services:
     with caplog.at_level(logging.INFO):
         result = convert_compose_to_helm_values(compose_path)
 
-    # memswap_limit is dropped (not carried into output) and an info log is emitted.
+    # memswap_limit is dropped (not carried into output) and an info log naming the
+    # ignored value is emitted.
     assert "memswap_limit" not in result["services"]["my-service"]
     assert any(
-        "Ignoring 'memswap_limit'" in record.message for record in caplog.records
+        "Ignoring 'memswap_limit: 1G'" in record.message for record in caplog.records
     )
 
 

--- a/test/k8s_sandbox/compose/test_converter.py
+++ b/test/k8s_sandbox/compose/test_converter.py
@@ -1008,11 +1008,11 @@ services:
     assert "failed validation against the Compose schema" in str(exc_info.value)
 
 
-def test_warns_localhost_seccomp_profile_must_be_prestaged(
+def test_logs_localhost_seccomp_profile_must_be_prestaged(
     caplog: pytest.LogCaptureFixture, tmp_compose: TmpComposeFixture
 ) -> None:
-    # A Localhost profile file isn't shipped by the converter; warn that it must be
-    # pre-staged on every node, since a missing file only fails at pod launch.
+    # A Localhost profile file isn't shipped by the converter; log a reminder that it
+    # must be pre-staged on every node, since a missing file only fails at pod launch.
     compose_path = tmp_compose("""
 services:
   my-service:
@@ -1020,13 +1020,13 @@ services:
       - seccomp=profiles/no-aslr.json
 """)
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INFO):
         convert_compose_to_helm_values(compose_path)
 
     assert any(
         "/var/lib/kubelet/seccomp/" in record.message
         for record in caplog.records
-        if record.levelno == logging.WARNING
+        if record.levelno == logging.INFO
     )
 
 

--- a/test/k8s_sandbox/compose/test_parse_docker_config.py
+++ b/test/k8s_sandbox/compose/test_parse_docker_config.py
@@ -2,9 +2,13 @@ from pathlib import Path
 from typing import Callable
 
 import pytest
+import yaml
 from inspect_ai.util import ComposeBuild, ComposeConfig
 
-from k8s_sandbox.compose._compose import parse_docker_config
+from k8s_sandbox.compose._compose import (
+    ComposeConfigValuesSource,
+    parse_docker_config,
+)
 
 TmpFileFixture = Callable[[str, str], Path]
 
@@ -79,3 +83,27 @@ def test_unsupported_file_type(tmp_file: TmpFileFixture) -> None:
 
     with pytest.raises(ValueError, match="neither a Dockerfile nor a Docker Compose"):
         parse_docker_config(str(values_file))
+
+
+def test_security_opt_reaches_converter_via_compose_entrypoint(
+    tmp_file: TmpFileFixture,
+) -> None:
+    # The ("k8s", "compose.yaml") entrypoint parses through inspect_ai's ComposeConfig
+    # before the converter runs. Guards against that model silently rejecting
+    # security_opt/memswap_limit (and so never reaching the converter).
+    compose_file = tmp_file(
+        "compose.yaml",
+        "services:\n"
+        "  default:\n"
+        "    image: ubuntu:24.04\n"
+        "    memswap_limit: 512m\n"
+        "    security_opt:\n"
+        "      - seccomp=unconfined\n",
+    )
+
+    config = parse_docker_config(str(compose_file))
+    with ComposeConfigValuesSource(config).values_file() as values_file:
+        values = yaml.safe_load(values_file.read_text())
+
+    security_context = values["services"]["default"]["securityContext"]
+    assert security_context["seccompProfile"] == {"type": "Unconfined"}

--- a/test/k8s_sandbox/compose/test_parse_docker_config.py
+++ b/test/k8s_sandbox/compose/test_parse_docker_config.py
@@ -103,6 +103,7 @@ def test_security_opt_reaches_converter_via_compose_entrypoint(
 
     config = parse_docker_config(str(compose_file))
     with ComposeConfigValuesSource(config).values_file() as values_file:
+        assert values_file is not None
         values = yaml.safe_load(values_file.read_text())
 
     security_context = values["services"]["default"]["securityContext"]


### PR DESCRIPTION
## Summary
The compose→Helm converter (`k8s_sandbox/compose/_converter.py`, `_ServiceConverter._convert_service`)
pops each supported service key and then raises `Unsupported key(s) in 'service'` for anything left
over. Two Docker Compose fields have no handler and so fail conversion, even though both have clean
k8s semantics:

- **`security_opt: ["seccomp=<path>"]`** → a `Localhost` `seccompProfile` in the pod's
  `securityContext`. This is the standard k8s mechanism for running a workload under a custom
  seccomp profile.
- **`memswap_limit`** → k8s has no per-pod swap-limit field, and nodes run with swap off by default,
  so the "disable swap" intent of `memswap_limit == mem_limit` is already the ambient behavior on
  k8s. Ignore it with an info log (matching how the converter already treats `init`/`expose`).

Both changes are **purely additive**: they add handling for keys the converter currently rejects, so
no config that converts today changes behavior.

## Motivation
Running an exploitation/security-eval workload faithfully requires **ASLR disabled in the target
container**. The portable, per-container way to do this is `setarch -R <cmd>`
(`personality(ADDR_NO_RANDOMIZE)`), inherited across fork+exec — no host/node sysctl needed. But the
default docker/k8s seccomp profiles **filter `personality(0x40000)`**, silently defeating `setarch -R`.
The fix is a scoped seccomp profile (docker default + `personality` allowed), expressed in compose as
`security_opt: ["seccomp=<path>"]`. On docker this Just Works; on k8s the ComposeConfig currently
can't be converted at all because the converter rejects `security_opt`. This PR closes that gap so the
same ComposeConfig is portable across the docker and k8s providers.

`memswap_limit` shows up alongside it (setting `memswap_limit == mem_limit` to force clean OOM-kills
instead of host swap on docker); it's handled here so the same config converts cleanly rather than
requiring provider-specific config surgery.

## Behavior
- `security_opt: ["seccomp=/path/to/profile.json"]` →
  ```yaml
  securityContext:
    seccompProfile:
      type: Localhost
      localhostProfile: /path/to/profile.json
  ```
  merged with any `securityContext` already produced from `user:`. (Note: `localhostProfile` is
  resolved by the kubelet relative to its seccomp root — the profile must be present on nodes; that's
  a deployment prerequisite, same as any Localhost seccomp profile, and out of scope for the
  converter.)
- Non-`seccomp=` `security_opt` entries (e.g. `apparmor=`, `no-new-privileges`): rejected with an
  explicit `Unsupported 'security_opt' entries: […]` error. We only map `seccomp=`; we don't silently
  swallow other options (which would let a workload believe a security control is applied when it isn't).
- `memswap_limit`: popped + info-logged, not mapped.

## Testing
- Added: a service with `security_opt: ["seccomp=<path>"]` converts and emits the expected
  `securityContext.seccompProfile`; merges with a `user:`-derived `securityContext`; the emitted
  values validate against the chart's `values.schema.json`; a non-`seccomp=` entry raises (both alone
  and alongside a valid `seccomp=` entry); `memswap_limit` is ignored (info-logged, not rejected).
- Existing converter tests unchanged/passing (additive change).

## Notes / alternatives considered
- Could route via the `x-inspect_k8s_sandbox` extension instead of the native `security_opt` field,
  but the extension currently only supports `resources`, and `security_opt` is a first-class compose
  field with an obvious k8s target, so handling it natively is cleaner and more discoverable.
- Scope kept minimal: only `seccomp=` (the portable, widely-useful case). Other `security_opt`
  values can be added later if there's demand.

## Interim usage (downstream)
Until this lands, downstream applies the same mapping via a small, feature-detected monkeypatch of
`_ServiceConverter._convert_service` (pop `security_opt`/`memswap_limit` before the leftover guard,
inject `seccompProfile` after). The patch here supersedes that.
