### PR TITLE
seccomp: gVisor/runc docs caveat + compose-entrypoint test

### DIFF
--- a/docs/docs/helm/compose-to-helm.md
+++ b/docs/docs/helm/compose-to-helm.md
@@ -182,11 +182,19 @@ Notes:
 - Non-seccomp entries (e.g. `apparmor=...`, `no-new-privileges`) have no mapping here and
   are rejected rather than silently dropped, so a workload can't believe a security
   control is applied when it isn't.
+- **Runtime caveat (gVisor).** A seccomp profile only changes which syscalls the kernel
+  *allows*; it can't add syscalls the runtime doesn't implement. The chart defaults to the
+  `gvisor` runtime, whose `personality()` does not support `ADDR_NO_RANDOMIZE`. So a
+  profile that permits `personality` in order to run `setarch -R` (the portable way to
+  disable ASLR, e.g. for exploitation workloads) has no effect under gVisor — `setarch -R`
+  fails with `EINVAL` regardless of the profile. Set `runtime: runc` on the service
+  (mapped to `runtimeClassName: runc`) for those workloads.
 
 ```yaml
 services:
   my-service:
     image: ubuntu
+    runtime: runc  # gVisor (the default) can't disable ASLR; see the runtime caveat above
     security_opt:
       - seccomp=profiles/no-aslr.json
 ```

--- a/test/k8s_sandbox/compose/test_parse_docker_config.py
+++ b/test/k8s_sandbox/compose/test_parse_docker_config.py
@@ -2,9 +2,13 @@ from pathlib import Path
 from typing import Callable
 
 import pytest
+import yaml
 from inspect_ai.util import ComposeBuild, ComposeConfig
 
-from k8s_sandbox.compose._compose import parse_docker_config
+from k8s_sandbox.compose._compose import (
+    ComposeConfigValuesSource,
+    parse_docker_config,
+)
 
 TmpFileFixture = Callable[[str, str], Path]
 
@@ -79,3 +83,27 @@ def test_unsupported_file_type(tmp_file: TmpFileFixture) -> None:
 
     with pytest.raises(ValueError, match="neither a Dockerfile nor a Docker Compose"):
         parse_docker_config(str(values_file))
+
+
+def test_security_opt_reaches_converter_via_compose_entrypoint(
+    tmp_file: TmpFileFixture,
+) -> None:
+    # The ("k8s", "compose.yaml") entrypoint parses through inspect_ai's ComposeConfig
+    # before the converter runs. Guards against that model silently rejecting
+    # security_opt/memswap_limit (and so never reaching the converter).
+    compose_file = tmp_file(
+        "compose.yaml",
+        "services:\n"
+        "  default:\n"
+        "    image: ubuntu:24.04\n"
+        "    memswap_limit: 512m\n"
+        "    security_opt:\n"
+        "      - seccomp=unconfined\n",
+    )
+
+    config = parse_docker_config(str(compose_file))
+    with ComposeConfigValuesSource(config).values_file() as values_file:
+        values = yaml.safe_load(values_file.read_text())
+
+    security_context = values["services"]["default"]["securityContext"]
+    assert security_context["seccompProfile"] == {"type": "Unconfined"}


### PR DESCRIPTION
Additions for #216, targeting its branch.

## Docs — gVisor/runc caveat
The motivating use case for `security_opt` seccomp (disable ASLR via `setarch -R`, which needs `personality(ADDR_NO_RANDOMIZE)`) is a **no-op under the chart's default `gvisor` runtime** — gVisor doesn't implement that personality flag, so `setarch -R` fails with `EINVAL` regardless of the profile. Documents that such workloads need `runtime: runc` (→ `runtimeClassName: runc`), with the compose example updated to match.

## Test — cover the real compose entrypoint
Every existing converter test calls `convert_compose_to_helm_values` directly, which bypasses inspect_ai's `ComposeConfig` — the layer that `("k8s", "compose.yaml")` actually goes through (`parse_docker_config` → `ComposeConfigValuesSource`). That's exactly why the feature could be unreachable while the converter tests stayed green. The new test drives that entrypoint end-to-end and asserts the `seccompProfile` comes out, so a regression where `ComposeConfig` rejects `security_opt`/`memswap_limit` before the converter runs is caught.

