### PR TITLE
fix: omit successfully completed init containers from pod diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- On Helm install failure, the raised error now includes pod diagnostics.
 - Compose to HELM: Support the `security_opt` seccomp option (mapped to a pod `seccompProfile`) and ignore the unsupported `memswap_limit`. See [Compose to Helm](https://k8s-sandbox.aisi.org.uk/helm/compose-to-helm/) for details.
 - The package and bundled `agent-env` chart versions are now unified, both jumping to
   `0.13.0` (intervening numbers are unused).

--- a/src/k8s_sandbox/_diagnostics.py
+++ b/src/k8s_sandbox/_diagnostics.py
@@ -104,6 +104,9 @@ def _describe_container(
             detail += f": {waiting.message}"
         parts.append(f"waiting ({detail})")
     if terminated is not None:
+        # Init containers run to completion: exit 0 is success, not a symptom.
+        if is_init and terminated.exit_code == 0:
+            return None
         parts.append(
             f"terminated {terminated.reason} (exit code {terminated.exit_code})"
         )

--- a/test/k8s_sandbox/test_diagnostics.py
+++ b/test/k8s_sandbox/test_diagnostics.py
@@ -138,6 +138,85 @@ def test_surfaces_failing_init_container_cause() -> None:
     assert "restarted 2 time(s)" in summary
 
 
+def test_omits_completed_init_container_when_app_container_failing() -> None:
+    # Only the app container's failure is reported; the completed (exit 0) init
+    # container is omitted.
+    init_container = V1ContainerStatus(
+        name="setup",
+        image="busybox:1.36",
+        image_id="",
+        ready=True,
+        restart_count=0,
+        state=V1ContainerState(
+            terminated=V1ContainerStateTerminated(reason="Completed", exit_code=0)
+        ),
+    )
+    app_container = V1ContainerStatus(
+        name="default",
+        image="busybox:1.36",
+        image_id="",
+        ready=False,
+        restart_count=3,
+        state=V1ContainerState(
+            waiting=V1ContainerStateWaiting(reason="CrashLoopBackOff")
+        ),
+        last_state=V1ContainerState(
+            terminated=V1ContainerStateTerminated(reason="Error", exit_code=1)
+        ),
+    )
+    pods = [
+        _pod(
+            "rel-default",
+            "Running",
+            container_statuses=[app_container],
+            init_container_statuses=[init_container],
+        )
+    ]
+
+    with _patch_client(pods):
+        summary = describe_release_pods(None, "default", "rel")
+
+    assert summary is not None
+    assert "init container" not in summary
+    assert "container 'default'" in summary
+    assert "exit code 1" in summary
+
+
+def test_returns_none_when_init_completed_and_app_healthy() -> None:
+    # A healthy pod with a completed init container produces no diagnostics at all.
+    init_container = V1ContainerStatus(
+        name="setup",
+        image="busybox:1.36",
+        image_id="",
+        ready=True,
+        restart_count=0,
+        state=V1ContainerState(
+            terminated=V1ContainerStateTerminated(reason="Completed", exit_code=0)
+        ),
+    )
+    app_container = V1ContainerStatus(
+        name="default",
+        image="busybox:1.36",
+        image_id="",
+        ready=True,
+        restart_count=0,
+        state=V1ContainerState(running=V1ContainerStateRunning(started_at=None)),
+    )
+    pods = [
+        _pod(
+            "rel-default",
+            "Running",
+            container_statuses=[app_container],
+            init_container_statuses=[init_container],
+        )
+    ]
+
+    with _patch_client(pods):
+        summary = describe_release_pods(None, "default", "rel")
+
+    assert summary is None
+
+
 def test_surfaces_failed_scheduling_event_when_pod_has_no_container_statuses() -> None:
     # An unschedulable pod stays Pending with no container statuses; the actionable
     # detail is in a FailedScheduling Warning event.


### PR DESCRIPTION
Follow-up to #202:

On any install failure of a chart that uses init containers, the pod diagnostics added in #202 include a line like `init container 'setup': terminated Completed (exit code 0)`. That is an init container's normal resting state after it has done its job, so the line is noise at the exact moment the output needs to be signal, and for a pod whose containers are otherwise healthy it can be the only line in the summary.

`_describe_container` now skips init containers that terminated with exit code 0. Failed init containers are still surfaced, as are all app container states and Warning events. One deliberate consequence: an init container that crash-looped a few times before eventually succeeding is also omitted, since it is not the cause of the current failure and its churn still shows up in the BackOff events.

Tested with two new unit cases (a completed init container alongside a crashing app container, and the no-op case where the completed init container would have been the only output) and end to end on a minikube cluster, where the same deliberately failing pod produced the noise line before the change and only the real failure afterwards.
