### PR TITLE
feat(sandbox): route egress config through inspect_ai NetworkAccess

### DIFF
--- a/src/k8s_sandbox/_network_access.py
+++ b/src/k8s_sandbox/_network_access.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Generator, Literal
+
+import yaml
+from inspect_ai.util import DomainPort, NetworkAccess
+
+from k8s_sandbox._helm import ValuesSource
+
+_EGRESS_KEYS = ("allowDomains", "allowDomainsPorts", "allowCIDR", "allowEntities")
+
+
+def _normalize_protocol(value: Any) -> Literal["TCP", "UDP", "ANY"]:
+    """Canonicalize a Helm protocol value to DomainPort's uppercase form."""
+    text = value if value is not None else "ANY"
+    if not isinstance(text, str):
+        raise ValueError(
+            f"allowDomainsPorts protocol must be a string or absent, got {value!r}."
+        )
+
+    match text.upper():
+        case "TCP":
+            return "TCP"
+        case "UDP":
+            return "UDP"
+        case "ANY":
+            return "ANY"
+        case _:
+            raise ValueError(
+                f"allowDomainsPorts protocol {value!r} is not one of TCP, UDP, ANY."
+            )
+
+
+def network_access_to_helm_values(na: NetworkAccess) -> dict[str, Any]:
+    """Serialize NetworkAccess to the Helm values the chart consumes."""
+    values: dict[str, Any] = {}
+
+    if na.allow_domains:
+        values["allowDomains"] = list(na.allow_domains)
+
+    if na.allow_domains_ports:
+        ports: list[dict[str, Any]] = []
+        for domain_port in na.allow_domains_ports:
+            port: dict[str, Any] = {"port": domain_port.port}
+            if domain_port.protocol != "ANY":
+                port["protocol"] = domain_port.protocol
+            if domain_port.domain is not None:
+                port["domain"] = domain_port.domain
+            ports.append(port)
+        values["allowDomainsPorts"] = ports
+
+    if na.allow_cidr:
+        values["allowCIDR"] = list(na.allow_cidr)
+
+    if na.allow_entities:
+        values["allowEntities"] = list(na.allow_entities)
+
+    return values
+
+
+def helm_values_to_network_access(values: dict[str, Any]) -> NetworkAccess:
+    """Normalize Helm egress values into NetworkAccess."""
+    return NetworkAccess(
+        allow_domains=list(values.get("allowDomains", [])),
+        allow_domains_ports=[
+            DomainPort(
+                port=port["port"],
+                protocol=_normalize_protocol(port.get("protocol")),
+                domain=port.get("domain"),
+            )
+            for port in values.get("allowDomainsPorts", [])
+        ],
+        allow_cidr=list(values.get("allowCIDR", [])),
+        allow_entities=list(values.get("allowEntities", [])),
+    )
+
+
+class NetworkAccessValuesSource(ValuesSource):
+    """Normalize Helm values egress keys via NetworkAccess.
+
+    Only the four egress keys are round-tripped through NetworkAccess (validating them
+    and canonicalizing to the omitted-key/uppercase form the chart renders); every
+    other key is passed through untouched. Used only for the built-in chart — a custom
+    chart's values are opaque and must not be rewritten.
+    """
+
+    def __init__(self, file: Path) -> None:
+        self._file = file
+
+    @contextmanager
+    def values_file(self) -> Generator[Path, None, None]:
+        values = yaml.safe_load(self._file.read_text()) or {}
+        na = helm_values_to_network_access(values)
+        normalized = network_access_to_helm_values(na)
+        for key in _EGRESS_KEYS:
+            values.pop(key, None)
+        values.update(normalized)
+        with tempfile.NamedTemporaryFile("w") as f:
+            f.write(yaml.dump(values, sort_keys=False))
+            f.flush()
+            yield Path(f.name)

--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -45,6 +45,7 @@ from k8s_sandbox._manager import (
     uninstall_all_unmanaged_releases,
     uninstall_unmanaged_release,
 )
+from k8s_sandbox._network_access import NetworkAccessValuesSource
 from k8s_sandbox._pod import Pod
 from k8s_sandbox._pod.error import (
     ExecutableNotFoundError,
@@ -567,6 +568,11 @@ def _create_values_source(config: _ResolvedConfig) -> ValuesSource:
                 "supported when using the built-in Helm chart."
             )
         return ComposeValuesSource(config.values)
+    # Built-in chart + a plain Helm values file: normalize the egress keys through
+    # NetworkAccess so the values= path enforces the same policy vocabulary as compose.
+    # Custom charts (config.chart set) are opaque and pass through untouched.
+    if config.values is not None and config.chart is None:
+        return NetworkAccessValuesSource(config.values)
     return StaticValuesSource(config.values)
 
 

--- a/src/k8s_sandbox/compose/_converter.py
+++ b/src/k8s_sandbox/compose/_converter.py
@@ -7,6 +7,9 @@ from typing import Any, Callable
 
 import jsonschema
 import yaml
+from inspect_ai.util import NetworkAccess
+
+from k8s_sandbox._network_access import network_access_to_helm_values
 
 logger = logging.getLogger(__name__)
 
@@ -57,10 +60,22 @@ def convert_compose_to_helm_values(compose_file: Path) -> dict[str, Any]:
         result["volumes"] = _convert_volumes(volumes, compose_file)
     if networks := compose.pop("networks", None):
         result["networks"] = _convert_networks(networks, compose_file)
-    # The 'x-inspect_k8s_sandbox' key (or its 'x-k8s' shorthand) is used to add
-    # additional configuration to Docker Compose files for use in Helm values.
-    if extensions := _pop_extension(compose, f"Compose file: '{compose_file}'."):
-        result.update(_convert_extensions(extensions, compose_file))
+    # The shared, cross-provider 'x-inspect-network' extension carries the full egress
+    # vocabulary. The k8s-native 'x-inspect_k8s_sandbox' key (or its 'x-k8s' alias) is
+    # still accepted for allow_domains/allow_entities. Both normalize through
+    # NetworkAccess; specifying both is ambiguous and rejected.
+    shared_network = compose.pop("x-inspect-network", None)
+    legacy_extension = _pop_extension(compose, f"Compose file: '{compose_file}'.")
+    if shared_network is not None and legacy_extension is not None:
+        raise ComposeConverterError(
+            f"Specify only one of 'x-inspect-network' or '{_EXTENSION_KEYS[0]}' "
+            f"(alias '{_EXTENSION_KEYS[1]}'); 'x-inspect-network' is the "
+            f"cross-provider egress extension. Compose file: '{compose_file}'."
+        )
+    if shared_network is not None:
+        result.update(_convert_shared_network_extension(shared_network, compose_file))
+    elif legacy_extension is not None:
+        result.update(_convert_extensions(legacy_extension, compose_file))
     # Ignore the version key.
     compose.pop("version", None)
     if compose:
@@ -177,32 +192,46 @@ def _pop_extension(src: dict[str, Any], context: str) -> Any:
     return src.pop(present[0]) if present else None
 
 
+def _convert_shared_network_extension(
+    shared: Any, compose_file: Path
+) -> dict[str, Any]:
+    """Validate a top-level 'x-inspect-network' block and serialize to Helm values."""
+    try:
+        na = NetworkAccess.model_validate(shared)
+    except Exception as e:  # pydantic ValidationError
+        raise ComposeConverterError(
+            f"Invalid 'x-inspect-network' policy: {e}. Compose file: '{compose_file}'."
+        ) from e
+    return network_access_to_helm_values(na)
+
+
 def _convert_extensions(
     extensions: dict[str, Any], compose_file: Path
 ) -> dict[str, Any]:
-    result: dict[str, Any] = dict()
-    if allow_domains := extensions.pop("allow_domains", None):
-        if not isinstance(allow_domains, list):
-            raise ComposeConverterError(
-                f"Invalid 'allow_domains' type: {type(allow_domains)}. "
-                f"Expected list. "
-                f"Compose file: '{compose_file}'."
-            )
-        result["allowDomains"] = allow_domains
-    if allow_entities := extensions.pop("allow_entities", None):
-        if not isinstance(allow_entities, list):
-            raise ComposeConverterError(
-                f"Invalid 'allow_entities' type: {type(allow_entities)}. "
-                f"Expected list. "
-                f"Compose file: '{compose_file}'."
-            )
-        result["allowEntities"] = allow_entities
+    # Legacy k8s-native surface: allow_domains + allow_entities, normalized through
+    # NetworkAccess so output matches the shared surface (empty lists omitted).
+    allow_domains = extensions.pop("allow_domains", None)
+    if allow_domains is not None and not isinstance(allow_domains, list):
+        raise ComposeConverterError(
+            f"Invalid 'allow_domains' type: {type(allow_domains)}. Expected list. "
+            f"Compose file: '{compose_file}'."
+        )
+    allow_entities = extensions.pop("allow_entities", None)
+    if allow_entities is not None and not isinstance(allow_entities, list):
+        raise ComposeConverterError(
+            f"Invalid 'allow_entities' type: {type(allow_entities)}. Expected list. "
+            f"Compose file: '{compose_file}'."
+        )
     if extensions:
         raise ComposeConverterError(
             f"Unsupported key(s) in 'x-inspect_k8s_sandbox': {set(extensions)}. "
             f"Compose file: '{compose_file}'."
         )
-    return result
+    na = NetworkAccess(
+        allow_domains=allow_domains or [],
+        allow_entities=allow_entities or [],
+    )
+    return network_access_to_helm_values(na)
 
 
 class _ServiceConverter:

--- a/test/k8s_sandbox/compose/test_converter.py
+++ b/test/k8s_sandbox/compose/test_converter.py
@@ -1629,3 +1629,50 @@ services:
     # Single service should keep its original name
     assert "my-service" in result["services"]
     assert "default" not in result["services"]
+
+
+def test_converts_shared_x_inspect_network_full_vocab(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    image: my-image
+x-inspect-network:
+  allow_domains:
+    - example.com
+  allow_cidr:
+    - 1.1.1.1/32
+  allow_domains_ports:
+    - port: 22
+      domain: example.com
+""")
+
+    result = convert_compose_to_helm_values(compose_path)
+
+    assert result["allowDomains"] == ["example.com"]
+    assert result["allowCIDR"] == ["1.1.1.1/32"]
+    assert result["allowDomainsPorts"] == [{"port": 22, "domain": "example.com"}]
+
+
+def test_rejects_shared_and_legacy_extension_conflict(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    # x-inspect-network is the cross-provider egress key; combining it with the legacy
+    # k8s-native key is ambiguous and must be rejected.
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    image: my-image
+x-inspect-network:
+  allow_domains:
+    - example.com
+x-inspect_k8s_sandbox:
+  allow_entities:
+    - world
+""")
+
+    with pytest.raises(ComposeConverterError) as exc_info:
+        convert_compose_to_helm_values(compose_path)
+
+    assert "Specify only one of" in str(exc_info.value)

--- a/test/k8s_sandbox/test_network_access_conformance.py
+++ b/test/k8s_sandbox/test_network_access_conformance.py
@@ -1,0 +1,181 @@
+from pathlib import Path
+
+import pytest
+import yaml
+from inspect_ai.util import DomainPort, NetworkAccess
+
+from k8s_sandbox._helm import DEFAULT_CHART, StaticValuesSource
+from k8s_sandbox._network_access import (
+    NetworkAccessValuesSource,
+    helm_values_to_network_access,
+    network_access_to_helm_values,
+)
+from k8s_sandbox._sandbox_environment import _create_values_source, _ResolvedConfig
+
+
+def test_to_helm_values_omits_empty_lists() -> None:
+    assert network_access_to_helm_values(NetworkAccess(allow_domains=["pypi.org"])) == {
+        "allowDomains": ["pypi.org"]
+    }
+
+
+def test_to_helm_values_full() -> None:
+    na = NetworkAccess(
+        allow_domains=["pypi.org", "*.debian.org"],
+        allow_domains_ports=[DomainPort(port=22, domain="pypi.org")],
+        allow_cidr=["1.1.1.1/32"],
+        allow_entities=["world"],
+    )
+
+    assert network_access_to_helm_values(na) == {
+        "allowDomains": ["pypi.org", "*.debian.org"],
+        "allowDomainsPorts": [{"port": 22, "domain": "pypi.org"}],
+        "allowCIDR": ["1.1.1.1/32"],
+        "allowEntities": ["world"],
+    }
+
+
+def test_round_trip_values_to_na_to_values() -> None:
+    values = {
+        "allowDomains": ["pypi.org", "github.com"],
+        "allowDomainsPorts": [{"port": 8008}, {"port": 22, "domain": "github.com"}],
+        "allowCIDR": ["10.0.0.0/8"],
+        "allowEntities": ["world"],
+    }
+
+    na = helm_values_to_network_access(values)
+
+    assert network_access_to_helm_values(na) == values
+
+
+def test_lowercase_protocol_normalizes_to_uppercase() -> None:
+    values = {
+        "allowDomains": ["pypi.org"],
+        "allowDomainsPorts": [{"port": 22}, {"port": 443, "protocol": "udp"}],
+    }
+
+    na = helm_values_to_network_access(values)
+
+    assert na.allow_domains_ports[1].protocol == "UDP"
+    assert network_access_to_helm_values(na)["allowDomainsPorts"] == [
+        {"port": 22},
+        {"port": 443, "protocol": "UDP"},
+    ]
+
+
+def test_rejects_unknown_protocol() -> None:
+    with pytest.raises(ValueError, match="not one of TCP, UDP, ANY"):
+        helm_values_to_network_access(
+            {
+                "allowDomains": ["pypi.org"],
+                "allowDomainsPorts": [{"port": 22, "protocol": "sctp"}],
+            }
+        )
+
+
+def _resolved(values: Path | None, chart: Path | None = None) -> _ResolvedConfig:
+    return _ResolvedConfig(
+        chart=chart,
+        values=values,
+        context=None,
+        default_user=None,
+        restarted_container_behavior="warn",
+        max_pod_ops=None,
+    )
+
+
+def test_values_source_normalizes_egress_and_preserves_other_keys(tmp_path):
+    src_file = tmp_path / "values.yaml"
+    src_file.write_text(
+        yaml.safe_dump(
+            {
+                "services": {"default": {"image": "python:3.12-bookworm"}},
+                "allowDomains": ["pypi.org"],
+                "allowDomainsPorts": [{"port": 22}, {"port": 443, "protocol": "udp"}],
+            }
+        )
+    )
+
+    with NetworkAccessValuesSource(src_file).values_file() as out:
+        rendered = yaml.safe_load(Path(out).read_text())
+
+    # Non-egress keys pass through untouched; egress keys are canonicalized (no
+    # domain: null; protocol emitted only when non-default and uppercased).
+    assert rendered["services"] == {"default": {"image": "python:3.12-bookworm"}}
+    assert rendered["allowDomains"] == ["pypi.org"]
+    assert rendered["allowDomainsPorts"] == [
+        {"port": 22},
+        {"port": 443, "protocol": "UDP"},
+    ]
+
+
+def test_create_values_source_wraps_builtin_chart_values(tmp_path):
+    values = tmp_path / "values.yaml"
+    values.write_text("allowDomains:\n  - pypi.org\n")
+
+    source = _create_values_source(_resolved(values, chart=None))
+
+    assert isinstance(source, NetworkAccessValuesSource)
+
+
+def test_create_values_source_leaves_custom_chart_untouched(tmp_path):
+    values = tmp_path / "values.yaml"
+    values.write_text("allowDomains:\n  - pypi.org\n")
+    chart = tmp_path / "chart"
+    chart.mkdir()
+
+    source = _create_values_source(_resolved(values, chart=chart))
+
+    assert isinstance(source, StaticValuesSource)
+    assert not isinstance(source, NetworkAccessValuesSource)
+
+
+def test_create_values_source_none_values_is_static(tmp_path):
+    source = _create_values_source(_resolved(None, chart=None))
+
+    assert isinstance(source, StaticValuesSource)
+
+
+@pytest.mark.parametrize(
+    "values_file",
+    [
+        # Existing fixtures, one per egress field (and a couple of combinations).
+        "helm_chart/resources/allow-domains-values.yaml",  # allowDomains (+ SNI/Host)
+        # allowDomainsPorts (udp)
+        "helm_chart/resources/allow-domains-ports-values.yaml",
+        # scoped domain port
+        "helm_chart/resources/allow-domains-ports-scoped-values.yaml",
+        # allowDomains ["*"]
+        "helm_chart/resources/allow-domains-wildcard-all-values.yaml",
+        "resources/netpol-values.yaml",  # allowDomains + allowCIDR
+        "resources/netpol-world-values.yaml",  # allowEntities
+    ],
+)
+def test_na_roundtrip_renders_identical_cnp(values_file: str, tmp_path: Path) -> None:
+    from test.k8s_sandbox.helm_chart.test_helm_chart import (
+        _get_documents,
+        _run_helm_template,
+    )
+
+    baseline_values = Path(__file__).parent / values_file
+    direct = _run_helm_template(DEFAULT_CHART, baseline_values)
+
+    values = yaml.safe_load(baseline_values.read_text())
+    na = helm_values_to_network_access(values)
+    for key in ("allowDomains", "allowDomainsPorts", "allowCIDR", "allowEntities"):
+        values.pop(key, None)
+    values.update(network_access_to_helm_values(na))
+    rewritten = tmp_path / "values.yaml"
+    rewritten.write_text(yaml.safe_dump(values))
+    through_na = _run_helm_template(DEFAULT_CHART, rewritten)
+
+    def egress_cnp(docs: list) -> dict:
+        return next(
+            d
+            for d in _get_documents(docs, "CiliumNetworkPolicy")
+            if d["metadata"]["name"].endswith("-sandbox-egress")
+        )
+
+    # Compare the FULL egress CiliumNetworkPolicy document (metadata + spec), not just
+    # spec.egress, so any drift in the rendered policy is caught.
+    assert egress_cnp(direct) == egress_cnp(through_na)


### PR DESCRIPTION
Routes the k8s sandbox provider's egress configuration through inspect_ai's provider-agnostic `NetworkAccess` model, so a single policy is portable across the Docker, Modal, and k8s providers.

## What changed

- Adapter from `NetworkAccess` to the built-in Helm chart's `allowDomains` / `allowEntities` / `allowCIDR` / `allowDomainsPorts` values.
- Routes the compose converter and the `values=` file path through the model.

## Verification

- Render-equivalence: the generated `CiliumNetworkPolicy` is byte-identical to the prior output across the full-CNP cases, so this is a non-behavioral refactor for existing configs.
- Deterministic conformance and helm-chart unit tests pass.
- On a live Cilium cluster the deny and allow-CIDR paths enforce correctly. The allow-FQDN path exercises Cilium's DNS proxy and is datapath-dependent on the cluster.

Depends on the inspect_ai `NetworkAccess` model (UKGovernmentBEIS/inspect_ai#4545).
