### PR TITLE
fix: report Helm releases that fail to uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- A Helm release which fails to uninstall during cleanup is now reported by name, with the `inspect sandbox cleanup k8s <release>` command to remove it. Previously the failure was silent and the release was left installed in the cluster.
 - On Helm install failure, the raised error now includes pod diagnostics.
 - Compose to HELM: Support the `security_opt` seccomp option (mapped to a pod `seccompProfile`) and ignore the unsupported `memswap_limit`. See [Compose to Helm](https://k8s-sandbox.aisi.org.uk/helm/compose-to-helm/) for details.
 - The package and bundled `agent-env` chart versions are now unified, both jumping to

--- a/src/k8s_sandbox/_manager.py
+++ b/src/k8s_sandbox/_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from contextvars import ContextVar
 
 from rich import box, print
@@ -11,6 +12,8 @@ from rich.table import Table
 from k8s_sandbox._helm import Release, get_all_release_names
 from k8s_sandbox._helm import uninstall as helm_uninstall
 from k8s_sandbox._kubernetes_api import get_current_context_name, get_default_namespace
+
+logger = logging.getLogger(__name__)
 
 
 class HelmReleaseManager:
@@ -72,11 +75,25 @@ class HelmReleaseManager:
             self._print_cleanup_instructions()
             return
         _print_do_not_interrupt()
-        tasks = [release.uninstall(quiet=False) for release in self._installed_releases]
+        releases = list(self._installed_releases)
+        tasks = [release.uninstall(quiet=False) for release in releases]
         # Clear the list before awaiting the tasks to prevent other calls to this method
         # from interfering.
         self._installed_releases.clear()
-        await asyncio.gather(*tasks, return_exceptions=True)
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        # An uninstall which raises here is not retried and the release has already
+        # been dropped from tracking, so it would otherwise be left installed with no
+        # record of it anywhere. Name it and say how to remove it.
+        for release, result in zip(releases, results):
+            if isinstance(result, BaseException):
+                logger.error(
+                    "Failed to uninstall Helm release '%s'. It is still installed in "
+                    "the cluster and will not be retried. Remove it with: "
+                    "inspect sandbox cleanup k8s %s",
+                    release.release_name,
+                    release.release_name,
+                    exc_info=result,
+                )
 
     def _print_cleanup_instructions(self) -> None:
         table = Table(

--- a/test/k8s_sandbox/test_manager.py
+++ b/test/k8s_sandbox/test_manager.py
@@ -1,0 +1,63 @@
+import logging
+from typing import cast
+
+from pytest import LogCaptureFixture
+
+from k8s_sandbox._helm import Release
+from k8s_sandbox._manager import HelmReleaseManager
+
+
+class _FakeRelease:
+    """Stands in for a Release so uninstall_all can be driven without a cluster."""
+
+    def __init__(self, release_name: str, error: Exception | None = None) -> None:
+        self.release_name = release_name
+        self._error = error
+        self.uninstall_attempted = False
+
+    async def install(self) -> None:
+        return None
+
+    async def uninstall(self, quiet: bool) -> None:
+        self.uninstall_attempted = True
+        if self._error is not None:
+            raise self._error
+
+
+async def _install(manager: HelmReleaseManager, release: _FakeRelease) -> None:
+    await manager.install(cast(Release, release))
+
+
+async def test_uninstall_all_reports_a_failed_uninstall(
+    caplog: LogCaptureFixture,
+) -> None:
+    manager = HelmReleaseManager()
+    healthy = _FakeRelease("aaaaaaaa")
+    failing = _FakeRelease("bbbbbbbb", RuntimeError("Helm uninstall failed."))
+    await _install(manager, healthy)
+    await _install(manager, failing)
+
+    with caplog.at_level(logging.ERROR):
+        await manager.uninstall_all(print_only=False)
+
+    # Both were attempted: one failure must not prevent the others being uninstalled.
+    assert healthy.uninstall_attempted
+    assert failing.uninstall_attempted
+    # The failure is named, along with how to remove the release that is still there.
+    assert "bbbbbbbb" in caplog.text
+    assert "inspect sandbox cleanup k8s bbbbbbbb" in caplog.text
+    # The release which uninstalled cleanly is not reported as a failure.
+    assert "aaaaaaaa" not in caplog.text
+
+
+async def test_uninstall_all_silent_when_every_uninstall_succeeds(
+    caplog: LogCaptureFixture,
+) -> None:
+    manager = HelmReleaseManager()
+    await _install(manager, _FakeRelease("aaaaaaaa"))
+    await _install(manager, _FakeRelease("bbbbbbbb"))
+
+    with caplog.at_level(logging.ERROR):
+        await manager.uninstall_all(print_only=False)
+
+    assert caplog.text == ""


### PR DESCRIPTION
## Problem

`HelmReleaseManager.uninstall_all` gathers the uninstalls with `return_exceptions=True` and never inspects the results, having already cleared `_installed_releases` before awaiting:

```python
tasks = [release.uninstall(quiet=False) for release in self._installed_releases]
# Clear the list before awaiting the tasks to prevent other calls to this method
# from interfering.
self._installed_releases.clear()
await asyncio.gather(*tasks, return_exceptions=True)
```

`helm uninstall` failures do raise (`_helm.uninstall` calls `_raise_runtime_error` when the subprocess fails), so a failed uninstall is swallowed *and* the release has already been dropped from tracking. Nothing retries it, nothing reports it, and `_print_cleanup_instructions` can no longer list it. The release stays installed in the cluster with no record anywhere that it existed.

This is most likely to bite at task cleanup, because `sample_cleanup` returns early for interrupted samples and defers those releases to `uninstall_all`:

```python
# If we were interrupted, wait until the end of the task to cleanup (this
# enables us to show output for the cleanup operation).
if interrupted:
    return
```

So the releases most likely to reach `uninstall_all` are exactly the ones with no other cleanup path.

We hit the consequences of a leaked sandbox on a shared cluster. The pod stays alive, and because sandbox pods can carry `karpenter.sh/do-not-disrupt`, the node cannot be reclaimed. In our case that blocked an unrelated infrastructure change for hours. Our leak had a separate root cause, so this PR is not a fix for that incident; it is the reason we went looking at this function, and the silent-failure path is a real defect on its own.

## Change

Log each failed uninstall with the release name and the `inspect sandbox cleanup k8s <release>` command that removes it.

Behaviour is otherwise unchanged. One failure still does not prevent the other releases being uninstalled, and the list is still cleared before awaiting so concurrent calls cannot interfere. I deliberately did not re-add failed releases to `_installed_releases`, since that would race with the concurrent-call case the existing comment guards against.

## Tests

`test/k8s_sandbox/test_manager.py`, no cluster required.

Verified non-circular: with the source change reverted and the test kept, `test_uninstall_all_reports_a_failed_uninstall` fails on `assert 'bbbbbbbb' in ''`. The empty log is the silent swallow itself.

```
uv run pytest -q -m "not req_k8s"     388 passed, 246 deselected
uv run ruff check . / format --check  All checks passed
uv run mypy .                         Success: no issues found in 84 source files
```

Not run: the `req_k8s` suite, as I do not have a cluster available for this branch.

Written by Claude, acting on behalf of Sami Jawhar.
