### PR TITLE
fix(network-policy): make sandbox default-deny-ingress actually deny

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix the built-in chart's `-sandbox-default-deny-ingress` policy, which allowed all ingress instead of denying it. Ingress to sandbox pods not allowed by another policy is now denied.
 - `inspect sandbox cleanup k8s` (with no release name) now **exits non-zero** if any release fails to uninstall, rather than reporting `Complete.` and exiting 0. Releases which fail to uninstall are named, at end-of-task cleanup too, along with their namespace and the `inspect sandbox cleanup k8s <release>` command to retry them.
 - **BREAKING CHANGE**: Sandbox pods created by the built-in Helm chart no longer mount
   Kubernetes service-account API tokens by default. Set

--- a/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
@@ -129,13 +129,19 @@ metadata:
   labels:
     {{- toYaml $.Values.labels | nindent 4 }}
 spec:
-  description: Default deny ingress. Allow other policies to be more specific.
+  description: |
+    Default deny ingress. The empty fromEntities selector matches no identities;
+    the non-empty ingress rule makes Cilium apply this policy's explicit
+    default-deny posture. Other policies provide permitted ingress.
   endpointSelector:
     matchLabels:
       io.kubernetes.pod.namespace: {{ .Release.Namespace }}
       {{- include "agentEnv.selectorLabels" $ | nindent 6 }}
+  enableDefaultDeny:
+    ingress: true
+    egress: false
   ingress:
-    - {}
+    - fromEntities: []
 {{- if .Values.networks }}
   {{- range $svcName, $svc := .Values.services }}
     {{- if $svc.networks }}

--- a/test/k8s_sandbox/helm_chart/test_helm_chart.py
+++ b/test/k8s_sandbox/helm_chart/test_helm_chart.py
@@ -30,6 +30,82 @@ def test_default_chart(chart_dir: Path) -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "set_str",
+    [
+        pytest.param(None, id="networks-disabled"),
+        pytest.param(
+            "networks.default.driver=k8s", id="default-service-without-network"
+        ),
+    ],
+)
+def test_sandbox_default_deny_ingress_matches_no_sources(
+    chart_dir: Path, set_str: str | None
+) -> None:
+    documents = _run_helm_template(chart_dir, set_str=set_str)
+
+    policies = _get_documents(documents, "CiliumNetworkPolicy")
+    default_deny_ingress = next(
+        (
+            policy
+            for policy in policies
+            if policy["metadata"]["name"].endswith("-sandbox-default-deny-ingress")
+        ),
+        None,
+    )
+
+    assert default_deny_ingress is not None
+    assert default_deny_ingress["spec"]["enableDefaultDeny"] == {
+        "ingress": True,
+        "egress": False,
+    }
+    assert default_deny_ingress["spec"]["ingress"] == [{"fromEntities": []}]
+
+
+def test_default_chart_keeps_same_sandbox_ingress_allow(chart_dir: Path) -> None:
+    documents = _run_helm_template(chart_dir)
+
+    policies = _get_documents(documents, "CiliumNetworkPolicy")
+    default_service_ingress = next(
+        policy
+        for policy in policies
+        if policy["metadata"]["name"].endswith("-svc-default-ingress")
+    )
+
+    assert default_service_ingress["spec"]["ingress"][0]["fromEndpoints"] == [
+        {
+            "matchLabels": {
+                "io.kubernetes.pod.namespace": "default",
+                "app.kubernetes.io/name": "agent-env",
+                "app.kubernetes.io/instance": "my-release",
+            }
+        }
+    ]
+
+
+def test_default_deny_composes_with_hawk_ssh_allow(
+    chart_dir: Path, test_resources_dir: Path
+) -> None:
+    documents = _run_helm_template(
+        chart_dir,
+        test_resources_dir / "additional-resources-template-block-values.yaml",
+    )
+
+    policies = _get_documents(documents, "CiliumNetworkPolicy")
+    hawk_ssh_ingress = next(
+        policy
+        for policy in policies
+        if policy["metadata"]["name"].endswith("-sandbox-default-external-ingress")
+    )
+
+    assert hawk_ssh_ingress["spec"]["ingress"] == [
+        {
+            "fromEntities": ["all"],
+            "toPorts": [{"ports": [{"port": "2222", "protocol": "TCP"}]}],
+        }
+    ]
+
+
 def test_additional_resources(chart_dir: Path, test_resources_dir: Path) -> None:
     documents = _run_helm_template(
         chart_dir, test_resources_dir / "additional-resources-values.yaml"


### PR DESCRIPTION
The `-sandbox-default-deny-ingress` CiliumNetworkPolicy renders `ingress:` followed by `- {}`. An IngressRule with no selectors matches every source, so that empty rule is allow-all: the policy named for denying ingress permits it instead. Any chart consumer relying on it for pod isolation does not have it.

## The fix

```yaml
  enableDefaultDeny:
    ingress: true
    egress: false
  ingress:
    - fromEntities: []
```

Both parts are load-bearing, and neither is obvious from the field names.

`ingress: []` on its own does not work. Cilium's `Rule` docs state that an omitted or empty top-level `ingress` means the rule does not apply at ingress, and from 1.17 a rule whose `ingress`, `ingressDeny`, `egress` and `egressDeny` are all empty is rejected by the agent. An empty list makes the policy inert rather than strict.

`fromEntities: []` is what selects nothing. Cilium special-cases empty non-nil slices in `SetAggregatedSelectors` and `GetSourceEndpointSelectorsWithRequirements` (`pkg/policy/api/ingress.go`), returning nil selectors, with the comment "explicitly check for empty non-nil slices, it should not result in any identity being selected". That is distinct from an absent field, which yields no L3 constraint, and is why a `toPorts`-only rule allows every source. So the empty list contributes no allow while keeping the stanza non-empty for the validator, and `enableDefaultDeny.ingress` states the intended posture explicitly rather than relying on it being inferred.

## Behaviour preserved

The per-service `-svc-<name>-ingress` policies still render and still allow same-sandbox traffic. Egress policies (`allowDomains`, `allowCIDR`, `allowEntities`) are untouched. Consumers that inject their own ingress allows through `additionalResources` continue to work, since those compose as a union with this policy's deny posture.

## Tests

Render tests added to `test/k8s_sandbox/helm_chart/test_helm_chart.py`, which shells out to `helm template`. They cover the default chart and a `networks`-enabled chart where a service has no `networks` of its own and therefore gets no per-service ingress policy: that second case is where nothing else would establish the deny posture.

`test/k8s_sandbox/test_network_policy.py` was not used, as it is marked `req_k8s` at module level and a render assertion there would be skipped in non-cluster runs.

`uv run pytest test/k8s_sandbox/helm_chart/` passes 34; `uv run mypy .` is clean across 83 files.