### PR TITLE
fix(exec): guard against None frames from the exec websocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix intermittent `exec()` failures with `'NoneType' object has no attribute 'decode'` under high concurrency.
 - `inspect sandbox cleanup k8s` (with no release name) now **exits non-zero** if any release fails to uninstall, rather than reporting `Complete.` and exiting 0. Releases which fail to uninstall are named, at end-of-task cleanup too, along with their namespace and the `inspect sandbox cleanup k8s <release>` command to retry them.
 - **BREAKING CHANGE**: Sandbox pods created by the built-in Helm chart no longer mount
   Kubernetes service-account API tokens by default. Set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Raise an error when a conflicting `max_pod_ops` setting would otherwise be ignored.
 - Fix a service's `args` (compose `command:`) reaching the container as a single
   space-joined string instead of a list.
+- Prevent missing exec websocket output frames from interrupting command execution.
 
 ## 2026-08-12 0.13.0
 

--- a/src/k8s_sandbox/_pod/execute.py
+++ b/src/k8s_sandbox/_pod/execute.py
@@ -127,19 +127,22 @@ class ExecuteOperation(PodOperation):
                     ws_client.update(timeout=None)
                     # Note: `peek_*()` and `read_*()` may call `update(timeout=0)`.
                     if ws_client.peek_stderr():
-                        stderr.append(ws_client.read_stderr())
+                        stderr_frame = ws_client.read_stderr()
+                        if stderr_frame is not None:
+                            stderr.append(stderr_frame)
                     # Handle stdout _after_ stderr to guarantee that, if buffered, the
                     # sentinel is actioned before the blocking `ws_client.update(None)`.
                     if ws_client.peek_stdout():
                         frame = ws_client.read_stdout()
                         # Assumption: The sentinel value is written to
                         # stdout in a single frame, not split across frames.
-                        filtered, returncode = self._filter_sentinel_and_returncode(
-                            frame
-                        )
-                        stdout.append(filtered)
-                        if returncode is not None:
-                            ws_client.close()
+                        if frame is not None:
+                            filtered, returncode = self._filter_sentinel_and_returncode(
+                                frame
+                            )
+                            stdout.append(filtered)
+                            if returncode is not None:
+                                ws_client.close()
                     self._verify_output_limit(stdout, stderr)
                 except (BrokenPipeError, ConnectionResetError) as e:
                     if returncode is not None:

--- a/src/k8s_sandbox/_pod/execute.py
+++ b/src/k8s_sandbox/_pod/execute.py
@@ -135,7 +135,7 @@ class ExecuteOperation(PodOperation):
                     # "'NoneType' object has no attribute 'decode'".
                     if ws_client.peek_stderr():
                         stderr_frame = ws_client.read_stderr()
-                        if stderr_frame:
+                        if stderr_frame is not None:
                             stderr.append(stderr_frame)
                     # Handle stdout _after_ stderr to guarantee that, if buffered, the
                     # sentinel is actioned before the blocking `ws_client.update(None)`.
@@ -143,7 +143,7 @@ class ExecuteOperation(PodOperation):
                         frame = ws_client.read_stdout()
                         # Assumption: The sentinel value is written to
                         # stdout in a single frame, not split across frames.
-                        if frame:
+                        if frame is not None:
                             filtered, returncode = self._filter_sentinel_and_returncode(
                                 frame
                             )

--- a/src/k8s_sandbox/_pod/execute.py
+++ b/src/k8s_sandbox/_pod/execute.py
@@ -126,20 +126,30 @@ class ExecuteOperation(PodOperation):
                     # indefinitely until there is data to read.
                     ws_client.update(timeout=None)
                     # Note: `peek_*()` and `read_*()` may call `update(timeout=0)`.
+                    # `read_*()` can return None even directly after `peek_*()`
+                    # returned truthy: both may call `update()` (see note above),
+                    # so an intervening update can drain the channel between the
+                    # peek and the read. Guard rather than decode None -- doing so
+                    # raised AttributeError inside the exec path, which surfaced
+                    # as an opaque "Error executing command in Pod" with cause
+                    # "'NoneType' object has no attribute 'decode'".
                     if ws_client.peek_stderr():
-                        stderr.append(ws_client.read_stderr())
+                        stderr_frame = ws_client.read_stderr()
+                        if stderr_frame:
+                            stderr.append(stderr_frame)
                     # Handle stdout _after_ stderr to guarantee that, if buffered, the
                     # sentinel is actioned before the blocking `ws_client.update(None)`.
                     if ws_client.peek_stdout():
                         frame = ws_client.read_stdout()
                         # Assumption: The sentinel value is written to
                         # stdout in a single frame, not split across frames.
-                        filtered, returncode = self._filter_sentinel_and_returncode(
-                            frame
-                        )
-                        stdout.append(filtered)
-                        if returncode is not None:
-                            ws_client.close()
+                        if frame:
+                            filtered, returncode = self._filter_sentinel_and_returncode(
+                                frame
+                            )
+                            stdout.append(filtered)
+                            if returncode is not None:
+                                ws_client.close()
                     self._verify_output_limit(stdout, stderr)
                 except (BrokenPipeError, ConnectionResetError) as e:
                     if returncode is not None:

--- a/test/k8s_sandbox/test_exec_none_frame.py
+++ b/test/k8s_sandbox/test_exec_none_frame.py
@@ -1,0 +1,129 @@
+"""Regression test: a None frame from the exec websocket must not crash.
+
+`peek_*()` and `read_*()` on the WSClient may both call `update()`, so an
+intervening update can drain a channel between a truthy peek and the read. The
+read then returns None. Decoding it raised AttributeError inside the exec path,
+surfacing to callers as an opaque
+
+    Error executing command in Pod. {"cause": "'NoneType' object has no
+    attribute 'decode'"}
+
+Measured across ten concurrent eval arms over ~6h: 37-122 such events per 1000
+model calls, worst arm 1493 / 12222 calls.
+
+These drive the REAL read loop (`_handle_shell_output`) with a stub client that
+reproduces the race, rather than asserting on the source text of the guard.
+"""
+
+import json
+from typing import Any
+
+import pytest
+
+from k8s_sandbox._pod.execute import COMPLETED_SENTINEL, ExecuteOperation
+
+
+class _RaceyWSClient:
+    """Reproduces None-after-truthy-peek on whichever channel is selected.
+
+    Frame script per channel: each entry is either bytes (returned) or None
+    (the race -- peek said data was available, the read finds none).
+    """
+
+    def __init__(
+        self,
+        stdout_frames: list[bytes | None],
+        stderr_frames: list[bytes | None] | None = None,
+    ) -> None:
+        self._stdout = list(stdout_frames)
+        self._stderr = list(stderr_frames or [])
+        self._open = True
+        self.returncode = 0
+
+    def is_open(self) -> bool:
+        return self._open and bool(self._stdout or self._stderr)
+
+    def update(self, timeout: Any = None) -> None:  # noqa: ANN401
+        return None
+
+    def peek_stdout(self, timeout: Any = None) -> bool:  # noqa: ANN401
+        return bool(self._stdout)
+
+    def read_stdout(self, timeout: Any = None) -> bytes | None:  # noqa: ANN401
+        return self._stdout.pop(0) if self._stdout else None
+
+    def peek_stderr(self, timeout: Any = None) -> bool:  # noqa: ANN401
+        return bool(self._stderr)
+
+    def read_stderr(self, timeout: Any = None) -> bytes | None:  # noqa: ANN401
+        return self._stderr.pop(0) if self._stderr else None
+
+    def close(self) -> None:
+        self._open = False
+
+    def read_channel(self, channel: int, timeout: Any = None) -> str:  # noqa: ANN401
+        """k8s ERROR_CHANNEL (status channel) used to derive the exit code."""
+        if self.returncode == 0:
+            return json.dumps({"metadata": {}, "status": "Success"})
+        return json.dumps(
+            {
+                "metadata": {},
+                "status": "Failure",
+                "message": "command terminated with non-zero exit code",
+                "details": {
+                    "causes": [{"reason": "ExitCode", "message": str(self.returncode)}]
+                },
+            }
+        )
+
+
+def _run(client: _RaceyWSClient) -> Any:  # noqa: ANN401
+    op = object.__new__(ExecuteOperation)
+    return ExecuteOperation._handle_shell_output(op, client, None, None)  # type: ignore[arg-type]
+
+
+def _sentinel_frame(returncode: int = 0) -> bytes:
+    """The real in-band completion marker the loop parses out of stdout."""
+    return f"<{COMPLETED_SENTINEL}-{returncode}>".encode()
+
+
+def test_none_stdout_frame_does_not_raise_attributeerror() -> None:
+    """The exact production race: peek truthy, read returns None."""
+    client = _RaceyWSClient(
+        stdout_frames=[b"hello ", None, b"world", _sentinel_frame(0)]
+    )
+
+    try:
+        result = _run(client)
+    except AttributeError as e:  # pragma: no cover - this is the bug
+        pytest.fail(
+            f"None stdout frame reached the decoder: {e}. This is the "
+            "'NoneType' object has no attribute 'decode' production failure."
+        )
+
+    assert "hello" in result.stdout
+    assert "world" in result.stdout, "output either side of the None must survive"
+
+
+def test_none_stderr_frame_does_not_poison_the_buffer() -> None:
+    # stdout yields empty filler so the loop keeps iterating while stderr
+    # drains; the sentinel must come LAST because it closes the client.
+    client = _RaceyWSClient(
+        stdout_frames=[b"", b"", b"", _sentinel_frame(0)],
+        stderr_frames=[b"warn ", None, b"more"],
+    )
+
+    result = _run(client)
+
+    assert "warn" in result.stderr
+    assert "more" in result.stderr, "output after the None frame must survive"
+
+
+def test_all_none_stdout_frames_still_terminate() -> None:
+    """A channel that only ever yields None must not spin or crash."""
+    client = _RaceyWSClient(stdout_frames=[None, None, _sentinel_frame(3)])
+    client.returncode = 3
+
+    result = _run(client)
+
+    assert result.returncode == 3

--- a/test/k8s_sandbox/test_exec_none_frame.py
+++ b/test/k8s_sandbox/test_exec_none_frame.py
@@ -92,6 +92,7 @@ def test_none_stdout_frame_does_not_raise_attributeerror() -> None:
     client = _RaceyWSClient(
         stdout_frames=[b"hello ", None, b"world", _sentinel_frame(0)]
     )
+
     try:
         result = _run(client)
     except AttributeError as e:  # pragma: no cover - this is the bug
@@ -99,6 +100,7 @@ def test_none_stdout_frame_does_not_raise_attributeerror() -> None:
             f"None stdout frame reached the decoder: {e}. This is the "
             "'NoneType' object has no attribute 'decode' production failure."
         )
+
     assert "hello" in result.stdout
     assert "world" in result.stdout, "output either side of the None must survive"
 
@@ -110,7 +112,9 @@ def test_none_stderr_frame_does_not_poison_the_buffer() -> None:
         stdout_frames=[b"", b"", b"", _sentinel_frame(0)],
         stderr_frames=[b"warn ", None, b"more"],
     )
+
     result = _run(client)
+
     assert "warn" in result.stderr
     assert "more" in result.stderr, "output after the None frame must survive"
 
@@ -119,5 +123,7 @@ def test_all_none_stdout_frames_still_terminate() -> None:
     """A channel that only ever yields None must not spin or crash."""
     client = _RaceyWSClient(stdout_frames=[None, None, _sentinel_frame(3)])
     client.returncode = 3
+
     result = _run(client)
+
     assert result.returncode == 3

--- a/test/k8s_sandbox/test_exec_none_frame.py
+++ b/test/k8s_sandbox/test_exec_none_frame.py
@@ -1,64 +1,123 @@
 """Regression test: a None frame from the exec websocket must not crash.
 
-`peek_*()` and `read_*()` on the k8s WSClient may both call `update()`, so an
+`peek_*()` and `read_*()` on the WSClient may both call `update()`, so an
 intervening update can drain a channel between a truthy peek and the read. The
 read then returns None. Decoding it raised AttributeError inside the exec path,
-surfacing as an opaque "Error executing command in Pod" with cause
-"'NoneType' object has no attribute 'decode'".
+surfacing to callers as an opaque
 
-Measured in production: 37-122 such events per 1k model calls across all ten
-eval arms (worst arm 1493 events / 12222 calls over ~6h), so this is a
-high-frequency cluster-wide fault rather than an edge case.
+    Error executing command in Pod. {"cause": "'NoneType' object has no
+    attribute 'decode'"}
+
+Measured across ten concurrent eval arms over ~6h: 37-122 such events per 1000
+model calls, worst arm 1493 / 12222 calls.
+
+These drive the REAL read loop (`_handle_shell_output`) with a stub client that
+reproduces the race, rather than asserting on the source text of the guard.
 """
 
-import inspect
-from pathlib import Path
+import json
+from typing import Any
 
-import k8s_sandbox._pod.execute as execute_mod
+import pytest
 
-
-def _read_loop_source() -> str:
-    src = Path(inspect.getfile(execute_mod)).read_text(encoding="utf-8")
-    start = src.index("while ws_client.is_open():")
-    end = src.index("self._verify_output_limit(stdout, stderr)", start)
-    return src[start:end]
+from k8s_sandbox._pod.execute import COMPLETED_SENTINEL, ExecuteOperation
 
 
-def test_stdout_frame_is_guarded_before_decode() -> None:
-    """A None stdout frame must never reach the decoding helper."""
-    loop = _read_loop_source()
-    read_at = loop.index("frame = ws_client.read_stdout()")
-    guard_at = loop.index("if frame:", read_at)
-    filter_at = loop.index("_filter_sentinel_and_returncode", read_at)
-    assert read_at < guard_at < filter_at, (
-        "read_stdout() may return None; it must be guarded before being passed "
-        "to _filter_sentinel_and_returncode, which decodes it"
-    )
+class _RaceyWSClient:
+    """Reproduces None-after-truthy-peek on whichever channel is selected.
 
-
-def test_stderr_frame_is_guarded_before_append() -> None:
-    """A None stderr frame must never be appended into the buffer."""
-    loop = _read_loop_source()
-    assert "stderr.append(ws_client.read_stderr())" not in loop, (
-        "read_stderr() may return None; appending it unguarded pushes None into "
-        "the buffer, which fails later at buffer.decode()"
-    )
-    read_at = loop.index("ws_client.read_stderr()")
-    guard_at = loop.index("if stderr_frame:", read_at)
-    append_at = loop.index("stderr.append(stderr_frame)", read_at)
-    assert read_at < guard_at < append_at
-
-
-def test_filter_sentinel_still_rejects_none_loudly() -> None:
-    """The guard is the fix; the helper should not silently accept None.
-
-    Keeping this strict means a NEW unguarded call site fails fast and visibly
-    instead of reintroducing the same opaque cause string.
+    Frame script per channel: each entry is either bytes (returned) or None
+    (the race -- peek said data was available, the read finds none).
     """
-    import pytest
 
-    from k8s_sandbox._pod.execute import ExecuteOperation
+    def __init__(
+        self,
+        stdout_frames: list[bytes | None],
+        stderr_frames: list[bytes | None] | None = None,
+    ) -> None:
+        self._stdout = list(stdout_frames)
+        self._stderr = list(stderr_frames or [])
+        self._open = True
+        self.returncode = 0
 
+    def is_open(self) -> bool:
+        return self._open and bool(self._stdout or self._stderr)
+
+    def update(self, timeout: Any = None) -> None:  # noqa: ANN401
+        return None
+
+    def peek_stdout(self, timeout: Any = None) -> bool:  # noqa: ANN401
+        return bool(self._stdout)
+
+    def read_stdout(self, timeout: Any = None) -> bytes | None:  # noqa: ANN401
+        return self._stdout.pop(0) if self._stdout else None
+
+    def peek_stderr(self, timeout: Any = None) -> bool:  # noqa: ANN401
+        return bool(self._stderr)
+
+    def read_stderr(self, timeout: Any = None) -> bytes | None:  # noqa: ANN401
+        return self._stderr.pop(0) if self._stderr else None
+
+    def close(self) -> None:
+        self._open = False
+
+    def read_channel(self, channel: int, timeout: Any = None) -> str:  # noqa: ANN401
+        """k8s ERROR_CHANNEL (status channel) used to derive the exit code."""
+        if self.returncode == 0:
+            return json.dumps({"metadata": {}, "status": "Success"})
+        return json.dumps(
+            {
+                "metadata": {},
+                "status": "Failure",
+                "message": "command terminated with non-zero exit code",
+                "details": {
+                    "causes": [{"reason": "ExitCode", "message": str(self.returncode)}]
+                },
+            }
+        )
+
+
+def _run(client: _RaceyWSClient) -> Any:  # noqa: ANN401
     op = object.__new__(ExecuteOperation)
-    with pytest.raises(AttributeError):
-        ExecuteOperation._filter_sentinel_and_returncode(op, None)  # type: ignore[arg-type]
+    return ExecuteOperation._handle_shell_output(op, client, None, None)  # type: ignore[arg-type]
+
+
+def _sentinel_frame(returncode: int = 0) -> bytes:
+    """The real in-band completion marker the loop parses out of stdout."""
+    return f"<{COMPLETED_SENTINEL}-{returncode}>".encode()
+
+
+def test_none_stdout_frame_does_not_raise_attributeerror() -> None:
+    """The exact production race: peek truthy, read returns None."""
+    client = _RaceyWSClient(
+        stdout_frames=[b"hello ", None, b"world", _sentinel_frame(0)]
+    )
+    try:
+        result = _run(client)
+    except AttributeError as e:  # pragma: no cover - this is the bug
+        pytest.fail(
+            f"None stdout frame reached the decoder: {e}. This is the "
+            "'NoneType' object has no attribute 'decode' production failure."
+        )
+    assert "hello" in result.stdout
+    assert "world" in result.stdout, "output either side of the None must survive"
+
+
+def test_none_stderr_frame_does_not_poison_the_buffer() -> None:
+    # stdout yields empty filler so the loop keeps iterating while stderr
+    # drains; the sentinel must come LAST because it closes the client.
+    client = _RaceyWSClient(
+        stdout_frames=[b"", b"", b"", _sentinel_frame(0)],
+        stderr_frames=[b"warn ", None, b"more"],
+    )
+    result = _run(client)
+    assert "warn" in result.stderr
+    assert "more" in result.stderr, "output after the None frame must survive"
+
+
+def test_all_none_stdout_frames_still_terminate() -> None:
+    """A channel that only ever yields None must not spin or crash."""
+    client = _RaceyWSClient(stdout_frames=[None, None, _sentinel_frame(3)])
+    client.returncode = 3
+    result = _run(client)
+    assert result.returncode == 3

--- a/test/k8s_sandbox/test_exec_none_frame.py
+++ b/test/k8s_sandbox/test_exec_none_frame.py
@@ -1,0 +1,64 @@
+"""Regression test: a None frame from the exec websocket must not crash.
+
+`peek_*()` and `read_*()` on the k8s WSClient may both call `update()`, so an
+intervening update can drain a channel between a truthy peek and the read. The
+read then returns None. Decoding it raised AttributeError inside the exec path,
+surfacing as an opaque "Error executing command in Pod" with cause
+"'NoneType' object has no attribute 'decode'".
+
+Measured in production: 37-122 such events per 1k model calls across all ten
+eval arms (worst arm 1493 events / 12222 calls over ~6h), so this is a
+high-frequency cluster-wide fault rather than an edge case.
+"""
+
+import inspect
+from pathlib import Path
+
+import k8s_sandbox._pod.execute as execute_mod
+
+
+def _read_loop_source() -> str:
+    src = Path(inspect.getfile(execute_mod)).read_text(encoding="utf-8")
+    start = src.index("while ws_client.is_open():")
+    end = src.index("self._verify_output_limit(stdout, stderr)", start)
+    return src[start:end]
+
+
+def test_stdout_frame_is_guarded_before_decode() -> None:
+    """A None stdout frame must never reach the decoding helper."""
+    loop = _read_loop_source()
+    read_at = loop.index("frame = ws_client.read_stdout()")
+    guard_at = loop.index("if frame:", read_at)
+    filter_at = loop.index("_filter_sentinel_and_returncode", read_at)
+    assert read_at < guard_at < filter_at, (
+        "read_stdout() may return None; it must be guarded before being passed "
+        "to _filter_sentinel_and_returncode, which decodes it"
+    )
+
+
+def test_stderr_frame_is_guarded_before_append() -> None:
+    """A None stderr frame must never be appended into the buffer."""
+    loop = _read_loop_source()
+    assert "stderr.append(ws_client.read_stderr())" not in loop, (
+        "read_stderr() may return None; appending it unguarded pushes None into "
+        "the buffer, which fails later at buffer.decode()"
+    )
+    read_at = loop.index("ws_client.read_stderr()")
+    guard_at = loop.index("if stderr_frame:", read_at)
+    append_at = loop.index("stderr.append(stderr_frame)", read_at)
+    assert read_at < guard_at < append_at
+
+
+def test_filter_sentinel_still_rejects_none_loudly() -> None:
+    """The guard is the fix; the helper should not silently accept None.
+
+    Keeping this strict means a NEW unguarded call site fails fast and visibly
+    instead of reintroducing the same opaque cause string.
+    """
+    import pytest
+
+    from k8s_sandbox._pod.execute import ExecuteOperation
+
+    op = object.__new__(ExecuteOperation)
+    with pytest.raises(AttributeError):
+        ExecuteOperation._filter_sentinel_and_returncode(op, None)  # type: ignore[arg-type]

--- a/test/k8s_sandbox/test_exec_none_frame.py
+++ b/test/k8s_sandbox/test_exec_none_frame.py
@@ -1,18 +1,7 @@
-"""Regression test: a None frame from the exec websocket must not crash.
+"""Exercise exec output handling when a websocket-like client returns None.
 
-`peek_*()` and `read_*()` on the WSClient may both call `update()`, so an
-intervening update can drain a channel between a truthy peek and the read. The
-read then returns None. Decoding it raised AttributeError inside the exec path,
-surfacing to callers as an opaque
-
-    Error executing command in Pod. {"cause": "'NoneType' object has no
-    attribute 'decode'"}
-
-Measured across ten concurrent eval arms over ~6h: 37-122 such events per 1000
-model calls, worst arm 1493 / 12222 calls.
-
-These drive the REAL read loop (`_handle_shell_output`) with a stub client that
-reproduces the race, rather than asserting on the source text of the guard.
+The stub presents a truthy peek followed by None from read. This documents the
+behavioral precondition exercised by these tests.
 """
 
 import json
@@ -24,10 +13,9 @@ from k8s_sandbox._pod.execute import COMPLETED_SENTINEL, ExecuteOperation
 
 
 class _RaceyWSClient:
-    """Reproduces None-after-truthy-peek on whichever channel is selected.
+    """Stub whose scripted reads can return None after truthy peeks.
 
-    Frame script per channel: each entry is either bytes (returned) or None
-    (the race -- peek said data was available, the read finds none).
+    Frame script per channel: each entry is either bytes or None.
     """
 
     def __init__(
@@ -88,7 +76,7 @@ def _sentinel_frame(returncode: int = 0) -> bytes:
 
 
 def test_none_stdout_frame_does_not_raise_attributeerror() -> None:
-    """The exact production race: peek truthy, read returns None."""
+    """A None stdout read does not raise AttributeError."""
     client = _RaceyWSClient(
         stdout_frames=[b"hello ", None, b"world", _sentinel_frame(0)]
     )
@@ -96,10 +84,7 @@ def test_none_stdout_frame_does_not_raise_attributeerror() -> None:
     try:
         result = _run(client)
     except AttributeError as e:  # pragma: no cover - this is the bug
-        pytest.fail(
-            f"None stdout frame reached the decoder: {e}. This is the "
-            "'NoneType' object has no attribute 'decode' production failure."
-        )
+        pytest.fail(f"None stdout frame reached the decoder: {e}.")
 
     assert "hello" in result.stdout
     assert "world" in result.stdout, "output either side of the None must survive"
@@ -120,7 +105,7 @@ def test_none_stderr_frame_does_not_poison_the_buffer() -> None:
 
 
 def test_all_none_stdout_frames_still_terminate() -> None:
-    """A channel that only ever yields None must not spin or crash."""
+    """A channel that only yields None terminates without spinning or crashing."""
     client = _RaceyWSClient(stdout_frames=[None, None, _sentinel_frame(3)])
     client.returncode = 3
 


### PR DESCRIPTION
## Problem

The exec output loop currently ignores `None` values returned by its websocket read methods before appending or decoding them.

## Rationale

The declared dependency is `kubernetes>=35.0.0` (`pyproject.toml:10`), with no upper bound. The current lock resolves `kubernetes==35.0.0`.

For that installed version, a truthy `peek_*()` does **not** establish that a following `read_*()` can return `None`:

- `kubernetes/stream/ws_client.py:72-78`: `peek_channel()` calls `update()`, then returns `self._channels[channel]` when present and `""` otherwise.
- `kubernetes/stream/ws_client.py:80-88`: `read_channel()` reads an existing channel value, or calls `peek_channel()` when the channel is absent, deletes the channel when present, and returns the result.
- `kubernetes/stream/ws_client.py:201-218`: `update()` stores a non-empty frame payload in `_channels` or appends it to an existing payload. It does not store `None`.
- `kubernetes/stream/ws_client.py:122-140`: `peek_stdout()`/`read_stdout()` and `peek_stderr()`/`read_stderr()` delegate directly to those channel methods.

With concurrent readers of one `WSClient`, another reader can remove a channel after a truthy peek. The later `read_channel()` then calls `peek_channel()` and returns `""` if no new frame arrives. The unprotected membership and lookup sequence can also raise `KeyError` if a competing reader deletes a channel between them. Neither interleaving returns `None`.

`ExecuteOperation.exec()` creates a websocket and calls `_handle_shell_output()` once for that client (`src/k8s_sandbox/_pod/execute.py:32-36`); concurrent evaluations have separate `WSClient` instances and separate `_channels` dictionaries. The retained guards therefore do not have a demonstrated `None`-frame path in `kubernetes==35.0.0`. Because the requirement is unbounded above, this source inspection does not establish the behavior of a future version. Whether to retain the guards despite the absent current-client reproduction requires a maintainer decision.

## Change

Retain the stdout and stderr `None` guards, and add an Unreleased changelog entry for their intended behavior. This PR does not claim that the supported `kubernetes==35.0.0` `WSClient` produces `None` after a truthy peek.

## Tests

`test/k8s_sandbox/test_exec_none_frame.py` uses a websocket-like stub that returns `None` after a truthy peek. It validates the retained guards for that synthetic precondition. It is not a reproduction of the supported `WSClient` contract.

## Verification

`uv run --extra dev pytest test/k8s_sandbox/test_exec_none_frame.py -q` passed: 3 passed.

`uv run --extra dev ruff check test/k8s_sandbox/test_exec_none_frame.py` passed.

`uv run --extra dev ruff format --check test/k8s_sandbox/test_exec_none_frame.py` passed.