### PR TITLE
fix: reject conflicting pod operation limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Raise an error when a conflicting `max_pod_ops` setting would otherwise be ignored.
+
 ## 2026-08-12 0.13.0
 
 - Fix `write_file()` silently writing a truncated or empty file while reporting success

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Raise an error when a conflicting `max_pod_ops` setting would otherwise be ignored.
 - `inspect sandbox cleanup k8s` (with no release name) now **exits non-zero** if any release fails to uninstall, rather than reporting `Complete.` and exiting 0. Releases which fail to uninstall are named, at end-of-task cleanup too, along with their namespace and the `inspect sandbox cleanup k8s <release>` command to retry them.
 - **BREAKING CHANGE**: Sandbox pods created by the built-in Helm chart no longer mount
   Kubernetes service-account API tokens by default. Set

--- a/src/k8s_sandbox/_pod/executor.py
+++ b/src/k8s_sandbox/_pod/executor.py
@@ -56,14 +56,20 @@ class PodOpExecutor:
         Args:
             max_pod_ops: Maximum number of concurrent pod operations. If provided
                 on the first call, overrides the INSPECT_MAX_POD_OPS env var and
-                the default (cpu_count * 4). Ignored on subsequent calls since the
-                singleton is already created.
+                the default (cpu_count * 4). A later call with a different value
+                raises ValueError rather than silently ignoring the configuration.
 
         This method is async-safe (because it doesn't await anything) but not
         thread-safe.
         """
         if cls._instance is None:
             cls._instance = cls(max_pod_ops=max_pod_ops)
+        elif max_pod_ops is not None and cls._instance._max_workers != max_pod_ops:
+            raise ValueError(
+                "PodOpExecutor is already initialized with "
+                f"max_pod_ops={cls._instance._max_workers}; cannot use "
+                f"max_pod_ops={max_pod_ops}."
+            )
         return cls._instance
 
     async def queue_operation(self, callable: Callable[[], T]) -> T:

--- a/test/k8s_sandbox/pod/test_executor.py
+++ b/test/k8s_sandbox/pod/test_executor.py
@@ -58,6 +58,18 @@ def test_parameter_takes_precedence_over_env_var(monkeypatch: MonkeyPatch) -> No
     assert actual._max_workers == 64
 
 
+def test_parameter_conflicting_with_existing_executor_raises(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("INSPECT_MAX_POD_OPS", raising=False)
+
+    with patch("os.cpu_count", return_value=4):
+        PodOpExecutor.get_instance()
+
+    with pytest.raises(ValueError, match="already initialized with max_pod_ops=16"):
+        PodOpExecutor.get_instance(max_pod_ops=64)
+
+
 async def test_queue_operation(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("INSPECT_MAX_POD_OPS", "10")
     executor = PodOpExecutor.get_instance()


### PR DESCRIPTION
## Summary

`PodOpExecutor.get_instance(max_pod_ops=...)` previously ignored a supplied limit after a parameterless call had created the singleton. The executor now raises `ValueError` when a later supplied limit conflicts with the singleton capacity.

This was exposed on 2026-08-06 in a 400-sandbox Kubernetes eval set: `pod-op` was capped at 128 while 354 sandboxes contended, and 414 of 621 resolved samples errored with `MCPEndpointsUnreachableError`. Raising the live limit to 384 reduced the failure rate from 70% to 11%.

## Test

Adds a regression test for a parameterless initialization followed by a conflicting `max_pod_ops` value. It fails against the previous silent fallback.

## Agent review

- `uv run --with ruff==0.9.6 ruff check .`
- `uv run --with ruff==0.9.6 ruff format --check .`
- `uv run --extra dev mypy .`
- `uv run --extra dev pytest -m "not req_k8s" -q` (405 passed, 247 deselected)
- `uv run --extra dev pre-commit run --all-files`
- `make check` and `make test` are not available: this repository has no Makefile.

Authored with AI assistance by Claude.