### PR TITLE
perf: skip log formatting when the destination log level is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Stop formatting log arguments for every pod operation when the destination log level is disabled. Sandbox operations no longer spend ~16us each building trace messages that are then discarded, which on a busy eval-set runner was consuming a full CPU core of Python execution and could leave the run unable to answer `inspect ctl`.
+
 - `inspect sandbox cleanup k8s` (with no release name) now **exits non-zero** if any release fails to uninstall, rather than reporting `Complete.` and exiting 0. Releases which fail to uninstall are named, at end-of-task cleanup too, along with their namespace and the `inspect sandbox cleanup k8s <release>` command to retry them.
 - **BREAKING CHANGE**: Sandbox pods created by the built-in Helm chart no longer mount
   Kubernetes service-account API tokens by default. Set

--- a/src/k8s_sandbox/_logger.py
+++ b/src/k8s_sandbox/_logger.py
@@ -4,6 +4,7 @@ import os
 from contextlib import contextmanager
 from typing import Any, Generator
 
+from inspect_ai._util.logger import TRACE
 from inspect_ai.util import trace_action, trace_message
 
 logger = logging.getLogger(__name__)
@@ -23,6 +24,8 @@ def log_trace(message: str, **kwargs: Any) -> None:
           they exceed DEFAULT_ARG_TRUNCATION_THRESHOLD (which can be overridden with env
           var INSPECT_K8S_LOG_TRUNCATION_THRESHOLD).
     """
+    if not logger.isEnabledFor(TRACE):
+        return
     formatted = format_log_message(message, **kwargs)
     trace_message(logger, category="K8s", message=formatted)
 
@@ -36,6 +39,8 @@ def log_debug(message: str, **kwargs: Any) -> None:
           they exceed DEFAULT_ARG_TRUNCATION_THRESHOLD (which can be overridden with env
           var INSPECT_K8S_LOG_TRUNCATION_THRESHOLD).
     """
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
     formatted = format_log_message(message, **kwargs)
     logger.debug(f"K8s: {formatted}")
 
@@ -93,6 +98,10 @@ def inspect_trace_action(action: str, **kwargs: Any) -> Generator[None, None, No
           Values are truncated if they exceed DEFAULT_ARG_TRUNCATION_THRESHOLD (which
           can be overridden with env var INSPECT_K8S_LOG_TRUNCATION_THRESHOLD).
     """
+    if not logger.isEnabledFor(TRACE):
+        yield
+        return
+
     json_kwargs = _format_kwargs_as_json(**kwargs)
     with trace_action(logger, action, json_kwargs):
         yield

--- a/src/k8s_sandbox/_logger.py
+++ b/src/k8s_sandbox/_logger.py
@@ -4,6 +4,7 @@ import os
 from contextlib import contextmanager
 from typing import Any, Generator
 
+from inspect_ai._util.logger import TRACE  # TODO: Using private package.
 from inspect_ai.util import trace_action, trace_message
 
 logger = logging.getLogger(__name__)
@@ -12,6 +13,22 @@ TRUNCATED_SUFFIX = "...<truncated-for-logging>"
 # The threshold at which to truncate individual arguments in logging messages.
 # Some ExecResults can contain very large outputs.
 DEFAULT_ARG_TRUNCATION_THRESHOLD = 1000
+
+# Formatting is skipped entirely when the destination level is disabled. It is not a
+# micro-optimisation: every sandbox operation formats its kwargs, and on a busy eval-set
+# runner that dominates the process. A py-spy sampling profile of a production runner
+# that had stopped answering its Inspect control channel put ~26% of all samples in
+# _format_kwargs_as_json, with the abc/inspect machinery it drives accounting for
+# most of the rest -- against ~18% for the actual TLS and WebSocket work. It burned
+# ~1 core of GIL with 31 cores idle and 325 of 326 threads asleep, so the asyncio event
+# loop could not get enough GIL time to service its own socket.
+#
+# All of that work was discarded: the runner logs at WARNING (effective level 30, no
+# root handlers), so TRACE and DEBUG were both disabled and every formatted string went
+# straight to a no-op logger call. Measured at 11.8us per call on a live runner.
+#
+# These checks are per-call, so raising the log level at runtime still produces full
+# detail. log_error/log_warn are deliberately not gated: they always emit.
 
 
 def log_trace(message: str, **kwargs: Any) -> None:
@@ -23,6 +40,8 @@ def log_trace(message: str, **kwargs: Any) -> None:
           they exceed DEFAULT_ARG_TRUNCATION_THRESHOLD (which can be overridden with env
           var INSPECT_K8S_LOG_TRUNCATION_THRESHOLD).
     """
+    if not logger.isEnabledFor(TRACE):
+        return
     formatted = format_log_message(message, **kwargs)
     trace_message(logger, category="K8s", message=formatted)
 
@@ -36,6 +55,8 @@ def log_debug(message: str, **kwargs: Any) -> None:
           they exceed DEFAULT_ARG_TRUNCATION_THRESHOLD (which can be overridden with env
           var INSPECT_K8S_LOG_TRUNCATION_THRESHOLD).
     """
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
     formatted = format_log_message(message, **kwargs)
     logger.debug(f"K8s: {formatted}")
 
@@ -93,6 +114,20 @@ def inspect_trace_action(action: str, **kwargs: Any) -> Generator[None, None, No
           Values are truncated if they exceed DEFAULT_ARG_TRUNCATION_THRESHOLD (which
           can be overridden with env var INSPECT_K8S_LOG_TRUNCATION_THRESHOLD).
     """
+    # This is the hot path: it wraps EVERY pod operation via _log_op.
+    #
+    # trace_action is purely observational -- every branch does nothing but
+    # logger.log(TRACE, ...) and it ends in a bare `raise`, so control flow is
+    # identical either way. With TRACE off it therefore produces no output at all,
+    # and the whole thing can be skipped: the kwargs formatting, the uuid, the
+    # monotonic timers, and traceback.format_exc() on the error path.
+    #
+    # Gating only the formatting removes 48% of the per-op cost; skipping the
+    # context manager as well removes 95% (16.0us -> 0.7us, measured).
+    if not logger.isEnabledFor(TRACE):
+        yield
+        return
+
     json_kwargs = _format_kwargs_as_json(**kwargs)
     with trace_action(logger, action, json_kwargs):
         yield

--- a/test/k8s_sandbox/test_logger.py
+++ b/test/k8s_sandbox/test_logger.py
@@ -1,6 +1,10 @@
+from contextlib import contextmanager
+from typing import Generator
+
 import pytest
 from pytest import MonkeyPatch
 
+from k8s_sandbox import _logger
 from k8s_sandbox._logger import format_log_message
 
 
@@ -76,3 +80,69 @@ def test_truncation_threshold_with_unset_env_var(
     result = format_log_message("My message.", myvalue=str_2000_chars)
 
     assert 1000 < len(result) < 1100
+
+
+class _ExplodingArg:
+    """Raises if anything tries to stringify it.
+
+    Formatting calls str() on every value, so using this as a kwarg turns "was the
+    argument formatted?" into a hard failure rather than something a mock might miss.
+    """
+
+    def __str__(self) -> str:  # pragma: no cover - must never be called
+        raise AssertionError("argument was formatted despite the log level being off")
+
+    __repr__ = __str__
+
+
+def test_trace_action_does_not_format_when_trace_disabled(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The hot path: this wraps EVERY pod operation via _log_op.
+
+    A production runner burned ~1 core of GIL formatting kwargs that a disabled TRACE
+    logger discarded, starving the asyncio event loop until it stopped answering its
+    Inspect control channel.
+    """
+    monkeypatch.setattr(_logger.logger, "isEnabledFor", lambda level: False)
+
+    with _logger.inspect_trace_action("K8s some op", huge=_ExplodingArg()):
+        pass
+
+
+def test_log_debug_does_not_format_when_debug_disabled(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_logger.logger, "isEnabledFor", lambda level: False)
+
+    _logger.log_debug("My message.", huge=_ExplodingArg())
+
+
+def test_log_trace_does_not_format_when_trace_disabled(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_logger.logger, "isEnabledFor", lambda level: False)
+
+    _logger.log_trace("My message.", huge=_ExplodingArg())
+
+
+def test_trace_action_still_formats_when_trace_enabled(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Gating must not silently drop detail when tracing is actually on."""
+    seen: list[str] = []
+    monkeypatch.setattr(_logger.logger, "isEnabledFor", lambda level: True)
+    monkeypatch.setattr(
+        _logger, "trace_action", lambda logger, action, message: _noop_cm(seen, message)
+    )
+
+    with _logger.inspect_trace_action("K8s some op", a="1"):
+        pass
+
+    assert seen == ['{"a": "1"}']
+
+
+@contextmanager
+def _noop_cm(seen: list[str], message: str) -> Generator[None, None, None]:
+    seen.append(message)
+    yield


### PR DESCRIPTION
## Problem

Every sandbox operation goes through `_log_op` → `inspect_trace_action`, which formats its kwargs into JSON before handing them to Inspect's `trace_action`. `trace_action` writes at `TRACE`, so on a runner logging at `WARNING` every one of those strings is built and immediately discarded.

Found while profiling an eval-set runner that had stopped answering its Inspect control channel. `py-spy` sampling:

```
369  _format_kwargs_as_json  (k8s_sandbox/_logger.py:117)
331  __instancecheck__       (<frozen abc>:117)
167  __init__                (inspect.py:2768)
151  read                    (ssl.py:1140)
 50  update                  (kubernetes/stream/ws_client.py:190)
```

~26% of samples in `_format_kwargs_as_json`, with the abc/inspect machinery it drives accounting for most of the remainder — against ~18% for the actual TLS and WebSocket work.

The process was burning ~1 core of GIL with **31 cores idle** and **325 of its 326 threads asleep**. One thread executes Python at a time, so the asyncio event loop couldn't get enough GIL time to service its own socket. Nothing was wrong with the pod — the loop was simply never free. Adding CPU doesn't help; the GIL is the constraint.

Confirmed on that runner that the work was entirely wasted:

```
logger.isEnabledFor(TRACE) = False
logger.isEnabledFor(DEBUG) = False
logger.isEnabledFor(INFO)  = False
effective level: 30 (WARNING),  root handlers: 0
```

## Change

Skip the whole context manager when `TRACE` is disabled, not just the formatting.

`trace_action` is purely observational — every branch does nothing but `logger.log(TRACE, ...)` and it ends in a bare `raise` — so control flow is identical either way, and skipping it also avoids the uuid, the monotonic timers, and `traceback.format_exc()` on the error path.

| variant | per-op |
|---|---|
| today (format always) | 16.2 µs |
| gate only the formatting | 8.3 µs (−48%) |
| **skip the context manager too** | **1.2 µs (−92%)** |

`log_debug` and `log_trace` get the same treatment. `log_error` and `log_warn` are deliberately left alone — they always emit.

The checks are per-call, so raising the log level at runtime still produces full detail.

## Tests

Four new tests in `test/k8s_sandbox/test_logger.py`. The "was it formatted?" assertion uses an argument whose `__str__` raises, so a regression is a hard failure rather than something a mock might miss:

```python
class _ExplodingArg:
    def __str__(self) -> str:
        raise AssertionError("argument was formatted despite the log level being off")
```

Three assert nothing is formatted when the level is off; the fourth asserts the enabled path **still** formats, so the gating can't silently drop detail when tracing is genuinely on.

Red/green verified: removing the gating fails exactly the three new tests (`3 failed, 10 passed`); restored → `13 passed`. Full suite `408 passed`, ruff and mypy clean.