### PR TITLE
Harden the CoreDNS sandbox sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## Unreleased
 
 - Fix `write_file()` silently writing a truncated or empty file while reporting success
+- **BREAKING CHANGE**: The CoreDNS sidecar now runs as UID/GID 65532 on a read-only root
+  filesystem with only `NET_BIND_SERVICE`. A custom `corednsImage` must run under that
+  context; set the new `corednsSecurityContext` if it cannot. The default image moves
+  from CoreDNS 1.8.3 to a digest-pinned CoreDNS 1.14.6.
+- **BREAKING CHANGE**: Service names, network names and `additionalDnsRecords` are now
+  validated at install time and rejected with a schema error, rather than producing a
+  release that fails later or resolves unexpectedly.
+- The CoreDNS sidecar no longer serves its `ready` endpoint on port 8181, and refuses
+  queries beyond 1000 concurrent.
 - `inspect sandbox cleanup k8s` (with no release name) now **exits non-zero** if any release fails to uninstall, rather than reporting `Complete.` and exiting 0. Releases which fail to uninstall are named, at end-of-task cleanup too, along with their namespace and the `inspect sandbox cleanup k8s <release>` command to retry them.
 - **BREAKING CHANGE**: Sandbox pods created by the built-in Helm chart no longer mount
   Kubernetes service-account API tokens by default. Set
@@ -17,7 +26,7 @@
 - On Helm install failure, the raised error now includes pod diagnostics.
 - Compose to HELM: Support the `security_opt` seccomp option (mapped to a pod `seccompProfile`) and ignore the unsupported `memswap_limit`. See [Compose to Helm](https://k8s-sandbox.aisi.org.uk/helm/compose-to-helm/) for details.
 - The package and bundled `agent-env` chart versions are now unified, both jumping to
-  `0.13.0` (intervening numbers are unused).
+  `0.14.0` (intervening numbers are unused).
 
 ## 2026-06-25 0.6.1
 

--- a/docs/docs/design/limitations.md
+++ b/docs/docs/design/limitations.md
@@ -192,8 +192,14 @@ The `timeout` binary on busybox images behaves differently, causing a 128 + 15 (
 = 143 exit code rather than a 124 exit code. This will result in a suitable `ExecResult`
 being returned rather than raising a `TimeoutError`.
 
-## Service names must be lower case alphanumeric
+## Service and network names must be lower case alphanumeric
 
 In the built-in Helm chart, service names (i.e. the keys in the `services` dict) must
 match the case-sensitive regex `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` e.g. `my-name` or
-`123-abc`. The Helm chart will fail to install if this is not the case.
+`123-abc`. Network names may additionally contain `.`. The Helm chart will fail to
+install if this is not the case.
+
+Both are also length-limited: 63 characters for a service name and 55 for a network
+name. These are outer guards rather than usable budgets — each is combined with the
+release name to form Kubernetes object names and label keys which are themselves capped
+at 63 characters, so the practical limit is considerably shorter.

--- a/docs/docs/helm/built-in-chart.md
+++ b/docs/docs/helm/built-in-chart.md
@@ -232,6 +232,10 @@ services:
       - example.com
 ```
 
+Records are interpolated into the CoreDNS configuration, so they are restricted to
+letters, digits and `_ - .` (e.g. `_dmarc.example.com` is fine). Anything containing
+whitespace or other characters is rejected when the chart is installed.
+
 To achieve this, whilst maintaining support for deploying multiple instances of the same
 chart in a given namespace, a CoreDNS "sidecar" container is deployed in each service
 Pod.
@@ -257,10 +261,15 @@ the nameserver.
 Note that the CoreDNS sidecar only binds to `127.0.0.1` so won't be accessible from
 outside the Pod.
 
-The bundled sidecar image is pinned by digest. The chart also fixes its runtime
-security context independently of the image: UID/GID 65532, a read-only root
-filesystem, RuntimeDefault seccomp, no privilege escalation, and no Linux capability
-other than `NET_BIND_SERVICE`. A custom `corednsImage` must support that contract.
+The bundled sidecar image is pinned by digest and runs under a hardened security
+context: UID/GID 65532, a read-only root filesystem, RuntimeDefault seccomp, no
+privilege escalation, and no Linux capability other than `NET_BIND_SERVICE`. A custom
+`corednsImage` must be able to run under that contract, or must override
+`corednsSecurityContext` as well.
+
+`NET_BIND_SERVICE` is required rather than merely defensive: the CoreDNS binary carries
+a `cap_net_bind_service` file capability, so dropping it from the capability set stops
+the container from starting at all.
 
 CoreDNS is used over Dnsmasq for 2 reasons:
 

--- a/docs/docs/helm/built-in-chart.md
+++ b/docs/docs/helm/built-in-chart.md
@@ -257,6 +257,11 @@ the nameserver.
 Note that the CoreDNS sidecar only binds to `127.0.0.1` so won't be accessible from
 outside the Pod.
 
+The bundled sidecar image is pinned by digest. The chart also fixes its runtime
+security context independently of the image: UID/GID 65532, a read-only root
+filesystem, RuntimeDefault seccomp, no privilege escalation, and no Linux capability
+other than `NET_BIND_SERVICE`. A custom `corednsImage` must support that contract.
+
 CoreDNS is used over Dnsmasq for 2 reasons:
 
 * CoreDNS is the default DNS server in Kubernetes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inspect-k8s-sandbox"
-version = "0.13.0"
+version = "0.14.0"
 description = "A Kubernetes Sandbox Environment for Inspect"
 authors = [{name = "UK AI Security Institute"}]
 readme = "README.md"

--- a/src/k8s_sandbox/resources/helm/agent-env/Chart.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: agent-env
-version: 0.13.0
+version: 0.14.0

--- a/src/k8s_sandbox/resources/helm/agent-env/README.md
+++ b/src/k8s_sandbox/resources/helm/agent-env/README.md
@@ -1,6 +1,6 @@
 # agent-env
 
-![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square)
+![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square)
 
 ## Values
 
@@ -14,7 +14,7 @@
 | annotations | object | `{}` | A dict of annotations to apply to resources within the agent environment. |
 | automountServiceAccountToken | bool | `false` | Whether to mount the selected ServiceAccount's Kubernetes API token in sandbox pods. Keep disabled for cloud workload identity such as IRSA, which injects a provider-specific token separately. |
 | corednsCommand | list | `["/coredns","-conf","/etc/coredns/Corefile"]` | The command to use for the coredns container. |
-| corednsImage | string | `"coredns/coredns:1.8.3"` | The image to use for the coredns container. |
+| corednsImage | string | `"coredns/coredns:1.14.6@sha256:900f9c109f7a33545d3c811516e8376df9019147b750f5ce3e254468769176ea"` | The image to use for the coredns container. Images must be executable as UID/GID 65532 with a read-only root filesystem. |
 | global | object | set by inspect | The name of the agent environment, only overwrite in cases where e.g. name lengths are causing failures. |
 | imagePullSecrets | list | `[]` | References to pre-existing secrets that contain registry credentials. |
 | labels | object | `{}` | A dict of labels to apply to resources within the agent environment. |
@@ -43,4 +43,3 @@
 | services.default.volumes | list | `[]` | Volumes accessible to the container. Supports arbitrary yaml or colon-separated strings of the form `volume-name:/mount-path`. |
 | services.default.workingDir | string | `nil` | The container's working directory. |
 | volumes | object | `{}` | A dict of volumes to deploy within the agent environment as NFS-CSI PersistentVolumeClaims. These volumes can be mounted in services using the `volumes:` field. The actual volume name will include the release name. |
-

--- a/src/k8s_sandbox/resources/helm/agent-env/README.md
+++ b/src/k8s_sandbox/resources/helm/agent-env/README.md
@@ -14,16 +14,17 @@
 | annotations | object | `{}` | A dict of annotations to apply to resources within the agent environment. |
 | automountServiceAccountToken | bool | `false` | Whether to mount the selected ServiceAccount's Kubernetes API token in sandbox pods. Keep disabled for cloud workload identity such as IRSA, which injects a provider-specific token separately. |
 | corednsCommand | list | `["/coredns","-conf","/etc/coredns/Corefile"]` | The command to use for the coredns container. |
-| corednsImage | string | `"coredns/coredns:1.14.6@sha256:900f9c109f7a33545d3c811516e8376df9019147b750f5ce3e254468769176ea"` | The image to use for the coredns container. Images must be executable as UID/GID 65532 with a read-only root filesystem. |
+| corednsImage | string | `"coredns/coredns:1.14.6@sha256:900f9c109f7a33545d3c811516e8376df9019147b750f5ce3e254468769176ea"` | The image to use for the coredns container. Pinned by digest; the tag is recorded alongside it for readability and the two must be updated together. An override must run under `corednsSecurityContext` below, or that must be overridden too. |
+| corednsSecurityContext | object | Non-root 65532, read-only root filesystem, RuntimeDefault seccomp, no privilege escalation, and no capability other than `NET_BIND_SERVICE` | Security context for the coredns container. Override only if a custom `corednsImage` cannot run under the hardened default. |
 | global | object | set by inspect | The name of the agent environment, only overwrite in cases where e.g. name lengths are causing failures. |
 | imagePullSecrets | list | `[]` | References to pre-existing secrets that contain registry credentials. |
 | labels | object | `{}` | A dict of labels to apply to resources within the agent environment. |
-| networks | object | `{}` | Defines network names that can be attached to services in order to specify subsets of services that can communicate with one another. |
+| networks | object | `{}` | Defines network names that can be attached to services in order to specify subsets of services that can communicate with one another. Names must be lower case alphanumeric with `-` or `.`, and at most 55 characters. |
 | serviceAccountCreate | bool | `false` | Whether to create the selected ServiceAccount. Keep disabled to use an externally managed ServiceAccount across concurrent sandbox releases. |
 | serviceAccountName | string | `nil` | Service account name for sandbox pods. The account must already exist unless `serviceAccountCreate` is enabled. |
 | services | object | see [values.yaml](./values.yaml) | A collection of services to deploy within the agent environment. A service can connect to another service using DNS, e.g. `http://nginx:80`. |
 | services.default | object | see [values.yaml](./values.yaml) | The default service, this is required for the agent environment to function. |
-| services.default.additionalDnsRecords | list | `[]` | A list of additional domains which will resolve to this service from within the agent environment (e.g. example.com). If one or more records are provided, `dnsRecord` is automatically set to true. |
+| services.default.additionalDnsRecords | list | `[]` | A list of additional domains which will resolve to this service from within the agent environment (e.g. example.com). If one or more records are provided, `dnsRecord` is automatically set to true. Records may contain letters, digits and `_ - .`; whitespace and other characters are rejected at install time because these are interpolated into the CoreDNS Corefile. |
 | services.default.args | list | `[]` | The container's entrypoint arguments. |
 | services.default.command | list | `["tail","-f","/dev/null"]` | The container's entrypoint command. |
 | services.default.dnsRecord | bool | false | Whether to create a DNS record which will resolve to this service from within the agent environment, using the service name as the domain (e.g. default). |
@@ -43,3 +44,4 @@
 | services.default.volumes | list | `[]` | Volumes accessible to the container. Supports arbitrary yaml or colon-separated strings of the form `volume-name:/mount-path`. |
 | services.default.workingDir | string | `nil` | The container's working directory. |
 | volumes | object | `{}` | A dict of volumes to deploy within the agent environment as NFS-CSI PersistentVolumeClaims. These volumes can be mounted in services using the `volumes:` field. The actual volume name will include the release name. |
+

--- a/src/k8s_sandbox/resources/helm/agent-env/templates/coredns.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/coredns.yaml
@@ -8,7 +8,6 @@ data:
     .:53 {
         log
         errors
-        ready
 
         # Add rewrite rules for each service which exposes ports.
 
@@ -26,7 +25,10 @@ data:
         {{- end }}
 
         # Forward all queries to the Kubernetes cluster DNS server.
-        forward . /etc/resolv.conf
+        forward . /etc/resolv.conf {
+            # Bound memory use when an untrusted workload floods the local resolver.
+            max_concurrent 1000
+        }
 
         # Only process DNS requests from localhost as we're deployed as a sidecar.
         # This prevents our port 53 from appearing open to other Pods.

--- a/src/k8s_sandbox/resources/helm/agent-env/templates/services.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/services.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ template "agentEnv.fullname" $ -}}-{{ $name }}
   labels:
     {{- include "agentEnv.labels" $ | nindent 4 }}
+    inspect.aisi.org/k8s-sandbox-version: {{ $.Chart.Version | quote }}
     inspect/service: {{ $name }}
   annotations:
     {{- toYaml $.Values.annotations | nindent 4 }}
@@ -20,6 +21,7 @@ spec:
       labels:
         {{- include "agentEnv.labelsFromValues" $ | nindent 8 }}
         {{- include "agentEnv.selectorLabels" $ | nindent 8 }}
+        inspect.aisi.org/k8s-sandbox-version: {{ $.Chart.Version | quote }}
         {{- if $service.networks }}
         {{- range $service.networks }}
         aisi.gov.uk/network-{{ . }}: "true"
@@ -148,6 +150,19 @@ spec:
         image: {{ quote $.Values.corednsImage }}
         command:
           {{- toYaml $.Values.corednsCommand | nindent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+            add:
+              - NET_BIND_SERVICE
+          readOnlyRootFilesystem: true
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
         resources:
           requests:
             memory: "128Mi"
@@ -166,6 +181,7 @@ spec:
           - name: coredns-config
             mountPath: /etc/coredns/Corefile
             subPath: Corefile
+            readOnly: true
       {{- with $service.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/src/k8s_sandbox/resources/helm/agent-env/templates/services.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/services.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ template "agentEnv.fullname" $ -}}-{{ $name }}
   labels:
     {{- include "agentEnv.labels" $ | nindent 4 }}
-    inspect.aisi.org/k8s-sandbox-version: {{ $.Chart.Version | quote }}
     inspect/service: {{ $name }}
   annotations:
     {{- toYaml $.Values.annotations | nindent 4 }}
@@ -21,7 +20,9 @@ spec:
       labels:
         {{- include "agentEnv.labelsFromValues" $ | nindent 8 }}
         {{- include "agentEnv.selectorLabels" $ | nindent 8 }}
-        inspect.aisi.org/k8s-sandbox-version: {{ $.Chart.Version | quote }}
+        {{- /* The StatefulSet gets this via helm.sh/chart; Pods don't, and knowing
+               which chart version created a leaked Pod is useful when triaging. */}}
+        aisi.gov.uk/k8s-sandbox-version: {{ $.Chart.Version | quote }}
         {{- if $service.networks }}
         {{- range $service.networks }}
         aisi.gov.uk/network-{{ . }}: "true"
@@ -151,18 +152,7 @@ spec:
         command:
           {{- toYaml $.Values.corednsCommand | nindent 10 }}
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
-            add:
-              - NET_BIND_SERVICE
-          readOnlyRootFilesystem: true
-          runAsGroup: 65532
-          runAsNonRoot: true
-          runAsUser: 65532
-          seccompProfile:
-            type: RuntimeDefault
+          {{- toYaml $.Values.corednsSecurityContext | nindent 10 }}
         resources:
           requests:
             memory: "128Mi"

--- a/src/k8s_sandbox/resources/helm/agent-env/values.schema.json
+++ b/src/k8s_sandbox/resources/helm/agent-env/values.schema.json
@@ -71,6 +71,10 @@
     },
     "services": {
       "type": "object",
+      "propertyNames": {
+        "maxLength": 63,
+        "pattern": "^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$"
+      },
       "patternProperties": {
         ".*": {
           "type": "object",
@@ -96,7 +100,9 @@
             "additionalDnsRecords": {
               "type": "array",
               "items": {
-                "type": "string"
+                "type": "string",
+                "maxLength": 253,
+                "pattern": "^(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\\.)*[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\\.?$"
               }
             },
             "ports": {

--- a/src/k8s_sandbox/resources/helm/agent-env/values.schema.json
+++ b/src/k8s_sandbox/resources/helm/agent-env/values.schema.json
@@ -3,7 +3,19 @@
   "type": "object",
   "properties": {
     "global": {
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "nameOverride": {
+          "type": ["string", "null"],
+          "description": "Interpolated unquoted into the CoreDNS Corefile via agentEnv.fullname. The pattern is a security control: it must keep excluding whitespace and '#'. The empty string is the default and means 'unset'.",
+          "pattern": "^$|^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$"
+        },
+        "fullnameOverride": {
+          "type": ["string", "null"],
+          "description": "See nameOverride.",
+          "pattern": "^$|^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$"
+        }
+      }
     },
     "allowDomains": {
       "type": "array",
@@ -44,7 +56,12 @@
       }
     },
     "networks": {
-      "type": "object"
+      "type": "object",
+      "propertyNames": {
+        "maxLength": 55,
+        "description": "Interpolated into pod label keys and a CiliumNetworkPolicy name. 55 rather than 63 because the label key is prefixed with 'network-'.",
+        "pattern": "^[a-z0-9](?:[-a-z0-9.]{0,53}[a-z0-9])?$"
+      }
     },
     "corednsImage": {
       "type": "string"
@@ -54,6 +71,9 @@
       "items": {
         "type": "string"
       }
+    },
+    "corednsSecurityContext": {
+      "type": "object"
     },
     "imagePullSecrets": {
       "type": "array",
@@ -73,6 +93,7 @@
       "type": "object",
       "propertyNames": {
         "maxLength": 63,
+        "description": "Interpolated into Kubernetes object names, pod label values and the CoreDNS Corefile. 63 is an outer guard only: names are prefixed with the release fullname, so the usable budget is considerably shorter.",
         "pattern": "^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$"
       },
       "patternProperties": {
@@ -82,7 +103,10 @@
             "networks": {
               "type": "array",
               "items": {
-                "type": "string"
+                "type": "string",
+                "maxLength": 55,
+                "description": "Interpolated into pod label keys and a CiliumNetworkPolicy name. 55 rather than 63 because the label key is prefixed with 'network-'.",
+                "pattern": "^[a-z0-9](?:[-a-z0-9.]{0,53}[a-z0-9])?$"
               }
             },
             "runtimeClassName": {
@@ -102,7 +126,8 @@
               "items": {
                 "type": "string",
                 "maxLength": 253,
-                "pattern": "^(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\\.)*[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\\.?$"
+                "description": "Interpolated into the CoreDNS Corefile as 'rewrite name exact <record>'. The pattern is a security control: it must keep excluding whitespace, newlines and '#'. Validating hostname shape beyond that is CoreDNS's job, not the chart's.",
+                "pattern": "^[A-Za-z0-9_*][A-Za-z0-9_.*-]*$"
               }
             },
             "ports": {

--- a/src/k8s_sandbox/resources/helm/agent-env/values.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/values.yaml
@@ -37,7 +37,7 @@ imagePullSecrets: []
 # of services that can communicate with one another.
 networks: {}
 # -- The image to use for the coredns container.
-corednsImage: "coredns/coredns:1.8.3"
+corednsImage: "coredns/coredns:1.14.6@sha256:900f9c109f7a33545d3c811516e8376df9019147b750f5ce3e254468769176ea"
 # -- The command to use for the coredns container.
 corednsCommand:
   - /coredns

--- a/src/k8s_sandbox/resources/helm/agent-env/values.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/values.yaml
@@ -34,15 +34,37 @@ allowEntities: []
 imagePullSecrets: []
 # - name: "gcr-json-key"
 # -- Defines network names that can be attached to services in order to specify subsets
-# of services that can communicate with one another.
+# of services that can communicate with one another. Names must be lower case
+# alphanumeric with `-` or `.`, and at most 55 characters.
 networks: {}
-# -- The image to use for the coredns container.
+# -- The image to use for the coredns container. Pinned by digest; the tag is recorded
+# alongside it for readability and the two must be updated together. An override must
+# run under `corednsSecurityContext` below, or that must be overridden too.
 corednsImage: "coredns/coredns:1.14.6@sha256:900f9c109f7a33545d3c811516e8376df9019147b750f5ce3e254468769176ea"
 # -- The command to use for the coredns container.
 corednsCommand:
   - /coredns
   - -conf
   - /etc/coredns/Corefile
+# -- Security context for the coredns container. Override only if a custom
+# `corednsImage` cannot run under the hardened default.
+# @default -- Non-root 65532, read-only root filesystem, RuntimeDefault seccomp, no privilege escalation, and no capability other than `NET_BIND_SERVICE`
+corednsSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+    # Load-bearing, not belt-and-braces: the coredns binary carries a
+    # cap_net_bind_service file capability, so with an empty bounding set execve
+    # itself fails with "operation not permitted" — the container never starts.
+    add:
+      - NET_BIND_SERVICE
+  readOnlyRootFilesystem: true
+  runAsGroup: 65532
+  runAsNonRoot: true
+  runAsUser: 65532
+  seccompProfile:
+    type: RuntimeDefault
 # -- A collection of services to deploy within the agent environment. A service can
 # connect to another service using DNS, e.g. `http://nginx:80`.
 # @default -- see [values.yaml](./values.yaml)
@@ -67,7 +89,9 @@ services:
     dnsRecord: false
     # -- A list of additional domains which will resolve to this service from within the
     # agent environment (e.g. example.com). If one or more records are provided,
-    # `dnsRecord` is automatically set to true.
+    # `dnsRecord` is automatically set to true. Records may contain letters, digits and
+    # `_ - .`; whitespace and other characters are rejected at install time because
+    # these are interpolated into the CoreDNS Corefile.
     additionalDnsRecords: []
     # -- Deprecated. All ports of services with a DNS record are accessible (though not
     # necessarily open) to other services within the agent environment. If one or more

--- a/test/k8s_sandbox/helm_chart/resources/invalid-dns-record-values.yaml
+++ b/test/k8s_sandbox/helm_chart/resources/invalid-dns-record-values.yaml
@@ -1,0 +1,5 @@
+services:
+  default:
+    image: nginx
+    additionalDnsRecords:
+      - "safe.example\nforward . attacker.example"

--- a/test/k8s_sandbox/helm_chart/resources/invalid-network-name-values.yaml
+++ b/test/k8s_sandbox/helm_chart/resources/invalid-network-name-values.yaml
@@ -1,0 +1,9 @@
+services:
+  default:
+    image: nginx
+    # A newline here would inject into the Pod's label keys and into the name of the
+    # generated CiliumNetworkPolicy.
+    networks:
+      - "safe\nunsafe"
+networks:
+  safe:

--- a/test/k8s_sandbox/helm_chart/resources/invalid-service-name-values.yaml
+++ b/test/k8s_sandbox/helm_chart/resources/invalid-service-name-values.yaml
@@ -1,0 +1,3 @@
+services:
+  "unsafe\nname":
+    image: nginx

--- a/test/k8s_sandbox/helm_chart/test_helm_chart.py
+++ b/test/k8s_sandbox/helm_chart/test_helm_chart.py
@@ -28,12 +28,9 @@ def test_default_chart(chart_dir: Path) -> None:
         services[0]["spec"]["template"]["spec"]["containers"][0]["image"]
         == "python:3.12-bookworm"
     )
-    assert (
-        services[0]["spec"]["template"]["metadata"]["labels"][
-            "inspect.aisi.org/k8s-sandbox-version"
-        ]
-        == "0.14.0"
-    )
+    assert services[0]["spec"]["template"]["metadata"]["labels"][
+        "aisi.gov.uk/k8s-sandbox-version"
+    ] == _chart_version(chart_dir)
 
 
 def test_additional_resources(chart_dir: Path, test_resources_dir: Path) -> None:
@@ -507,15 +504,51 @@ def test_coredns_container(
     ]
 
 
+def test_coredns_security_context_can_be_overridden(chart_dir: Path) -> None:
+    # An image which cannot run under the hardened default needs an escape hatch other
+    # than forking the chart. Overriding one field merges rather than replaces, so the
+    # rest of the hardening survives.
+    documents = _run_helm_template(
+        chart_dir, set_str="corednsSecurityContext.runAsUser=1000"
+    )
+
+    stateful_sets = _get_documents(documents, "StatefulSet")
+    corends_container = next(
+        container
+        for container in stateful_sets[0]["spec"]["template"]["spec"]["containers"]
+        if container["name"] == "coredns"
+    )
+    assert corends_container["securityContext"] == {
+        "allowPrivilegeEscalation": False,
+        "capabilities": {"add": ["NET_BIND_SERVICE"], "drop": ["ALL"]},
+        "readOnlyRootFilesystem": True,
+        "runAsGroup": 65532,
+        "runAsNonRoot": True,
+        "runAsUser": 1000,
+        "seccompProfile": {"type": "RuntimeDefault"},
+    }
+
+
 @pytest.mark.parametrize(
     "values_file",
-    ["invalid-service-name-values.yaml", "invalid-dns-record-values.yaml"],
+    [
+        "invalid-service-name-values.yaml",
+        "invalid-dns-record-values.yaml",
+        "invalid-network-name-values.yaml",
+    ],
 )
 def test_rejects_names_that_can_inject_rendered_configuration(
     chart_dir: Path, test_resources_dir: Path, values_file: str
 ) -> None:
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
         _run_helm_template(chart_dir, test_resources_dir / values_file)
+
+    # Assert the *schema* did the rejecting. Without this, the test would also pass if
+    # helm merely hit a YAML parse error on the injected newline, i.e. it would pass
+    # with values.schema.json deleted. Don't assert on the offending field name: helm
+    # switched JSON Schema libraries mid-3.x and the newer one reports propertyNames
+    # violations against an empty path.
+    assert "values don't meet the specifications of the schema" in excinfo.value.stderr
 
 
 def test_network_isolated_service(chart_dir: Path, test_resources_dir: Path) -> None:
@@ -709,9 +742,16 @@ def _run_helm_template(
     if set_string:
         cmd += ["--set-string", set_string]
 
-    result = subprocess.run(cmd, stdout=subprocess.PIPE, check=True)
+    # stderr is captured so that tests asserting rejection can check why helm failed.
+    result = subprocess.run(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True
+    )
     return list(yaml.safe_load_all(result.stdout))
 
 
 def _get_documents(documents: list[Any], doc_type_filter: str) -> list[dict[str, Any]]:
     return [doc for doc in documents if doc["kind"] == doc_type_filter]
+
+
+def _chart_version(chart_dir: Path) -> str:
+    return str(yaml.safe_load((chart_dir / "Chart.yaml").read_text())["version"])

--- a/test/k8s_sandbox/helm_chart/test_helm_chart.py
+++ b/test/k8s_sandbox/helm_chart/test_helm_chart.py
@@ -28,6 +28,12 @@ def test_default_chart(chart_dir: Path) -> None:
         services[0]["spec"]["template"]["spec"]["containers"][0]["image"]
         == "python:3.12-bookworm"
     )
+    assert (
+        services[0]["spec"]["template"]["metadata"]["labels"][
+            "inspect.aisi.org/k8s-sandbox-version"
+        ]
+        == "0.14.0"
+    )
 
 
 def test_additional_resources(chart_dir: Path, test_resources_dir: Path) -> None:
@@ -446,7 +452,7 @@ def test_cluster_default_magic_string(
             {
                 "command": ["/special-dns-command"],
             },
-            "coredns/coredns:1.8.3",
+            "coredns/coredns:1.14.6@sha256:900f9c109f7a33545d3c811516e8376df9019147b750f5ce3e254468769176ea",
             ["/special-dns-command"],
         ),
     ],
@@ -482,6 +488,34 @@ def test_coredns_container(
     assert corends_container is not None
     assert corends_container["image"] == expected_coredns_image
     assert corends_container["command"] == expected_coredns_command
+    assert corends_container["securityContext"] == {
+        "allowPrivilegeEscalation": False,
+        "capabilities": {"add": ["NET_BIND_SERVICE"], "drop": ["ALL"]},
+        "readOnlyRootFilesystem": True,
+        "runAsGroup": 65532,
+        "runAsNonRoot": True,
+        "runAsUser": 65532,
+        "seccompProfile": {"type": "RuntimeDefault"},
+    }
+    assert corends_container["volumeMounts"] == [
+        {
+            "mountPath": "/etc/coredns/Corefile",
+            "name": "coredns-config",
+            "readOnly": True,
+            "subPath": "Corefile",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "values_file",
+    ["invalid-service-name-values.yaml", "invalid-dns-record-values.yaml"],
+)
+def test_rejects_names_that_can_inject_rendered_configuration(
+    chart_dir: Path, test_resources_dir: Path, values_file: str
+) -> None:
+    with pytest.raises(subprocess.CalledProcessError):
+        _run_helm_template(chart_dir, test_resources_dir / values_file)
 
 
 def test_network_isolated_service(chart_dir: Path, test_resources_dir: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -874,7 +874,7 @@ wheels = [
 
 [[package]]
 name = "inspect-k8s-sandbox"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "inspect-ai" },


### PR DESCRIPTION
Tighten the security of our setup by using a hardened coreDNS sidecar with more restricted permissions. Codex flagged this as a weakness when I was working on unrelated code. However, as noted, this is a breaking change and could cause some annoyance.