### PR TITLE
chore: prepare for release (v0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2026-08-12 0.13.0
 
 - Fix `write_file()` silently writing a truncated or empty file while reporting success
 - `inspect sandbox cleanup k8s` (with no release name) now **exits non-zero** if any release fails to uninstall, rather than reporting `Complete.` and exiting 0. Releases which fail to uninstall are named, at end-of-task cleanup too, along with their namespace and the `inspect sandbox cleanup k8s <release>` command to retry them.


### PR DESCRIPTION
## Description

Prepares for a new release, which jumps to 0.13.0 in order to align the `agent-env` chart version and the package version. The actual version bumps were already made in #215 so this is just a changelog edit.