### PR TITLE
Name the source of the existing limit in the max_pod_ops conflict error

### DIFF
--- a/src/k8s_sandbox/_pod/executor.py
+++ b/src/k8s_sandbox/_pod/executor.py
@@ -29,21 +29,21 @@ class PodOpExecutor:
     def __init__(self, max_pod_ops: int | None = None) -> None:
         if max_pod_ops is not None:
             self._max_workers = max_pod_ops
-            source = "max_pod_ops argument"
+            self._source = "max_pod_ops argument"
         else:
             try:
                 self._max_workers = int(os.environ["INSPECT_MAX_POD_OPS"])
-                source = "INSPECT_MAX_POD_OPS env var"
+                self._source = "INSPECT_MAX_POD_OPS env var"
             except (KeyError, ValueError):
                 cpu_count = os.cpu_count() or 1
                 # Pod operations are typically I/O-bound (from the
                 # client's perspective).
                 self._max_workers = cpu_count * 4
-                source = f"default (cpu_count={cpu_count} * 4)"
+                self._source = f"default (cpu_count={cpu_count} * 4)"
         log_debug(
             "Creating PodOpExecutor.",
             max_workers=self._max_workers,
-            source=source,
+            source=self._source,
         )
         self._executor = ThreadPoolExecutor(
             max_workers=self._max_workers, thread_name_prefix="pod-op-executor"
@@ -67,8 +67,10 @@ class PodOpExecutor:
         elif max_pod_ops is not None and cls._instance._max_workers != max_pod_ops:
             raise ValueError(
                 "PodOpExecutor is already initialized with "
-                f"max_pod_ops={cls._instance._max_workers}; cannot use "
-                f"max_pod_ops={max_pod_ops}."
+                f"max_pod_ops={cls._instance._max_workers} (from "
+                f"{cls._instance._source}); cannot use max_pod_ops={max_pod_ops}. "
+                "The limit is process-wide: set the same max_pod_ops on every "
+                "task, or use the INSPECT_MAX_POD_OPS env var."
             )
         return cls._instance
 

--- a/src/k8s_sandbox/_sandbox_environment.py
+++ b/src/k8s_sandbox/_sandbox_environment.py
@@ -429,7 +429,13 @@ class K8sSandboxEnvironmentConfig(BaseModel, frozen=True):
     """The user to run commands as in the container if user is not specified."""
     restarted_container_behavior: Literal["warn", "raise"] = "warn"
     max_pod_ops: int | None = None
-    """Maximum number of concurrent pod operations. Defaults to cpu_count * 4."""
+    """Maximum number of concurrent pod operations. Defaults to cpu_count * 4.
+
+    The limit is process-wide, not per-task: whichever task initialises the
+    executor first fixes it for the process. Set the same value on every task
+    run in the process (a task with a conflicting value fails at startup), or
+    use the INSPECT_MAX_POD_OPS env var instead.
+    """
 
 
 def _key_to_pascal(key: str) -> str:

--- a/test/k8s_sandbox/pod/test_executor.py
+++ b/test/k8s_sandbox/pod/test_executor.py
@@ -66,8 +66,15 @@ def test_parameter_conflicting_with_existing_executor_raises(
     with patch("os.cpu_count", return_value=4):
         PodOpExecutor.get_instance()
 
-    with pytest.raises(ValueError, match="already initialized with max_pod_ops=16"):
+    with pytest.raises(ValueError) as exc_info:
         PodOpExecutor.get_instance(max_pod_ops=64)
+
+    # The message names the source of the existing limit so that users can tell
+    # a default from an explicitly-configured value.
+    assert (
+        "already initialized with max_pod_ops=16 (from default (cpu_count=4 * 4))"
+        in str(exc_info.value)
+    )
 
 
 async def test_queue_operation(monkeypatch: MonkeyPatch) -> None:


### PR DESCRIPTION

The new `ValueError` reported `already initialized with max_pod_ops=32` even when nobody set 32 — it was the `cpu_count * 4` default, which is baffling to a user who never configured the value. The message now names where the existing limit came from.
