### PR TITLE
compose converter: support NVIDIA GPU device reservations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,10 @@ Rules:
   types callers catch).
 - **Don't churn existing entries.** When editing, make changes that are necessary
   (accuracy, completeness) and minimal. Don't swap synonyms or reorder for taste.
+- **When the feature has a docs page, just announce it.** One sentence for what the
+  change is. Usage details (required keys, caveats, companion settings) belong on
+  the docs page — anyone adopting the feature reads the docs, not the changelog.
+  Don't signpost the docs with "see ... for details" links either.
 
 Examples (all from real entries):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - The CoreDNS sidecar no longer serves its `ready` endpoint on port 8181, and refuses
   queries beyond 1000 concurrent.
 - Raise an error when a conflicting `max_pod_ops` setting would otherwise be ignored.
+- Compose to Helm: Convert NVIDIA GPU device reservations
+  (`deploy.resources.reservations.devices`) to `nvidia.com/gpu` requests and limits.
 
 ## 2026-08-12 0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## Unreleased
 
-- Raise an error when a conflicting `max_pod_ops` setting would otherwise be ignored.
-
-## 2026-08-12 0.13.0
-
-- Fix `write_file()` silently writing a truncated or empty file while reporting success
 - **BREAKING CHANGE**: The CoreDNS sidecar now runs as UID/GID 65532 on a read-only root
   filesystem with only `NET_BIND_SERVICE`. A custom `corednsImage` must run under that
   context; set the new `corednsSecurityContext` if it cannot. The default image moves
@@ -16,6 +11,11 @@
   release that fails later or resolves unexpectedly.
 - The CoreDNS sidecar no longer serves its `ready` endpoint on port 8181, and refuses
   queries beyond 1000 concurrent.
+- Raise an error when a conflicting `max_pod_ops` setting would otherwise be ignored.
+
+## 2026-08-12 0.13.0
+
+- Fix `write_file()` silently writing a truncated or empty file while reporting success
 - `inspect sandbox cleanup k8s` (with no release name) now **exits non-zero** if any release fails to uninstall, rather than reporting `Complete.` and exiting 0. Releases which fail to uninstall are named, at end-of-task cleanup too, along with their namespace and the `inspect sandbox cleanup k8s <release>` command to retry them.
 - **BREAKING CHANGE**: Sandbox pods created by the built-in Helm chart no longer mount
   Kubernetes service-account API tokens by default. Set
@@ -30,7 +30,7 @@
 - On Helm install failure, the raised error now includes pod diagnostics.
 - Compose to HELM: Support the `security_opt` seccomp option (mapped to a pod `seccompProfile`) and ignore the unsupported `memswap_limit`. See [Compose to Helm](https://k8s-sandbox.aisi.org.uk/helm/compose-to-helm/) for details.
 - The package and bundled `agent-env` chart versions are now unified, both jumping to
-  `0.14.0` (intervening numbers are unused).
+  `0.13.0` (intervening numbers are unused).
 
 ## 2026-06-25 0.6.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,13 @@ Consider using the recommended [Rewrap](https://stkb.github.io/Rewrap/) extensio
 ## Changelog
 
 If appropriate, add an entry under the `## Unreleased` heading in `CHANGELOG.md` when
-submitting a PR.
+submitting a PR. Create that heading if the last release consumed it.
+
+Entries under a dated release heading are published history — don't add to or edit
+them. In particular, if a release is cut after you branch, a stale branch can silently
+land your entry in the just-released section (the release commit renames `##
+Unreleased` to the dated heading, so your diff still applies): after rebasing onto
+`main`, check your entry still sits under `## Unreleased`.
 
 ## Releasing
 

--- a/docs/docs/helm/compose-to-helm.md
+++ b/docs/docs/helm/compose-to-helm.md
@@ -208,6 +208,9 @@ Notes:
 - An explicit integer `count` is required; `count: all` (Docker's default when
   `count` is omitted), `device_ids`, and non-NVIDIA drivers are rejected. `driver`
   may be omitted (NVIDIA is Docker's default GPU driver).
+- `capabilities` must be exactly `[gpu]`. Other driver capabilities Docker accepts
+  (`utility`, `compute`, ...) have no Kubernetes equivalent and are rejected rather
+  than dropped.
 - Tolerations/node selectors for tainted GPU nodes are cluster convention and not
   generated: add them via a hand-written Helm values file, or rely on cluster-side
   admission defaults (e.g.

--- a/docs/docs/helm/compose-to-helm.md
+++ b/docs/docs/helm/compose-to-helm.md
@@ -168,6 +168,51 @@ resources. It covers CPU and memory requests/limits (via `cpus`/`mem_limit` and
 `deploy.resources`), but has no concept of a disk (`ephemeral-storage`) request or
 limit, nor of resources such as `hugepages-*`.
 
+### GPUs
+
+The standard Compose NVIDIA GPU reservation is converted to the `nvidia.com/gpu`
+extended resource:
+
+```yaml
+services:
+  default:
+    image: nvidia/cuda:12.6.3-base-ubuntu24.04
+    runtime: nvidia
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+```
+
+produces:
+
+```yaml
+services:
+  default:
+    runtimeClassName: nvidia
+    resources:
+      limits: {nvidia.com/gpu: 1}
+      requests: {nvidia.com/gpu: 1}
+```
+
+Notes:
+
+- You will typically also need `runtime: nvidia` (as above; also valid Docker
+  Compose): the chart's default `gvisor` runtime class does not support GPUs.
+- Kubernetes requires extended resources on `limits` (with `requests` equal), so a
+  Compose _reservation_ populates both — unlike `cpus`/`memory` reservations, which
+  map only to `requests`.
+- An explicit integer `count` is required; `count: all` (Docker's default when
+  `count` is omitted), `device_ids`, and non-NVIDIA drivers are rejected. `driver`
+  may be omitted (NVIDIA is Docker's default GPU driver).
+- Tolerations/node selectors for tainted GPU nodes are cluster convention and not
+  generated: add them via a hand-written Helm values file, or rely on cluster-side
+  admission defaults (e.g.
+  [ExtendedResourceToleration](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#extendedresourcetoleration)).
+
 ### Swap (`memswap_limit`)
 
 `memswap_limit` is ignored (with an info-level log) because Kubernetes has no

--- a/src/k8s_sandbox/compose/_converter.py
+++ b/src/k8s_sandbox/compose/_converter.py
@@ -504,7 +504,10 @@ class _ServiceConverter:
                 # if set, must equal limits), so populate both from the reservation.
                 requests["nvidia.com/gpu"] = gpu_count
                 result.setdefault("limits", {})["nvidia.com/gpu"] = gpu_count
-            result["requests"] = requests
+            if requests:
+                # Guard so that 'devices: []' doesn't emit 'requests: {}', which would
+                # also defeat _set_requests_to_limits_if_unset.
+                result["requests"] = requests
         if src:
             raise ComposeConverterError(
                 f"Unsupported key(s) in 'resources': {set(src)}. {self.context}"

--- a/src/k8s_sandbox/compose/_converter.py
+++ b/src/k8s_sandbox/compose/_converter.py
@@ -496,12 +496,49 @@ class _ServiceConverter:
         if limits := src.pop("limits", None):
             result["limits"] = self._convert_resource(limits)
         if reservations := src.pop("reservations", None):
-            result["requests"] = self._convert_resource(reservations)
+            devices = reservations.pop("devices", None)
+            requests = self._convert_resource(reservations)
+            if devices:
+                gpu_count = self._convert_device_reservations(devices)
+                # k8s requires extended resources to be set on limits (and requests,
+                # if set, must equal limits), so populate both from the reservation.
+                requests["nvidia.com/gpu"] = gpu_count
+                result.setdefault("limits", {})["nvidia.com/gpu"] = gpu_count
+            result["requests"] = requests
         if src:
             raise ComposeConverterError(
                 f"Unsupported key(s) in 'resources': {set(src)}. {self.context}"
             )
         return result
+
+    def _convert_device_reservations(self, devices: list[dict[str, Any]]) -> int:
+        """Convert compose GPU device reservations to an nvidia.com/gpu count.
+
+        Only NVIDIA GPU reservations with an explicit integer count are supported:
+        there is no k8s equivalent of 'count: all' or 'device_ids', and non-NVIDIA
+        drivers have no obvious extended resource name to map to.
+        """
+        total = 0
+        for device in devices:
+            capabilities = device.pop("capabilities", None)
+            driver = device.pop("driver", None)
+            count = device.pop("count", "all")  # Compose defaults count to 'all'.
+            if capabilities != ["gpu"] or driver not in (None, "nvidia") or device:
+                raise ComposeConverterError(
+                    f"Unsupported device reservation. Only NVIDIA GPU reservations "
+                    f"('driver: nvidia' or no driver, 'capabilities: [gpu]', and no "
+                    f"other keys) are supported. {self.context}"
+                )
+            if isinstance(count, str) and count.isdigit():
+                count = int(count)
+            if not isinstance(count, int) or isinstance(count, bool) or count < 1:
+                raise ComposeConverterError(
+                    f"Unsupported device reservation 'count: {count}'. Only a "
+                    f"positive integer is supported (an explicit count is required: "
+                    f"Kubernetes has no equivalent of 'all'). {self.context}"
+                )
+            total += count
+        return total
 
     def _convert_resource(self, src: dict[str, Any]) -> dict[str, Any]:
         result: dict[str, Any] = dict()

--- a/test/k8s_sandbox/compose/test_converter.py
+++ b/test/k8s_sandbox/compose/test_converter.py
@@ -572,6 +572,87 @@ services:
     assert "Unsupported key(s) in 'deploy'" in str(exc_info.value)
 
 
+def test_converts_gpu_device_reservation(tmp_compose: TmpComposeFixture) -> None:
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+""")
+
+    result = convert_compose_to_helm_values(compose_path)
+
+    # k8s requires extended resources on limits too (requests must equal limits).
+    assert result["services"]["my-service"]["resources"] == {
+        "limits": {"nvidia.com/gpu": 1},
+        "requests": {"nvidia.com/gpu": 1},
+    }
+
+
+def test_converts_gpu_device_reservation_alongside_cpu_and_memory(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+        reservations:
+          memory: 512M
+          cpus: 0.25
+          devices:
+            # No driver: Docker's default GPU driver is nvidia.
+            - count: "2"
+              capabilities: [gpu]
+""")
+
+    result = convert_compose_to_helm_values(compose_path)
+
+    assert result["services"]["my-service"]["resources"] == {
+        "limits": {"memory": "1Gi", "nvidia.com/gpu": 2},
+        "requests": {"memory": "512Mi", "cpu": 0.25, "nvidia.com/gpu": 2},
+    }
+
+
+@pytest.mark.parametrize(
+    "device,expected_error",
+    [
+        ("{driver: nvidia, count: all, capabilities: [gpu]}", "count: all"),
+        ("{driver: nvidia, count: 0, capabilities: [gpu]}", "count: 0"),
+        ("{driver: amd, count: 1, capabilities: [gpu]}", "Only NVIDIA"),
+        ("{driver: nvidia, count: 1, capabilities: [tpu]}", "Only NVIDIA"),
+        (
+            "{driver: nvidia, device_ids: ['0'], capabilities: [gpu]}",
+            "Only NVIDIA",
+        ),
+    ],
+)
+def test_rejects_unsupported_device_reservations(
+    device: str, expected_error: str, tmp_compose: TmpComposeFixture
+) -> None:
+    compose_path = tmp_compose(f"""
+services:
+  my-service:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - {device}
+""")
+
+    with pytest.raises(ComposeConverterError) as exc_info:
+        convert_compose_to_helm_values(compose_path)
+
+    assert expected_error in str(exc_info.value)
+
+
 def test_rejects_unsupported_resources_key(tmp_compose: TmpComposeFixture) -> None:
     compose_path = tmp_compose("""
 services:

--- a/test/k8s_sandbox/compose/test_converter.py
+++ b/test/k8s_sandbox/compose/test_converter.py
@@ -621,6 +621,29 @@ services:
     }
 
 
+def test_ignores_empty_gpu_device_reservations(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    compose_path = tmp_compose("""
+services:
+  my-service:
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+        reservations:
+          devices: []
+""")
+
+    result = convert_compose_to_helm_values(compose_path)
+
+    # No 'requests: {}'; requests still mirror limits as if reservations were absent.
+    assert result["services"]["my-service"]["resources"] == {
+        "limits": {"memory": "1Gi"},
+        "requests": {"memory": "1Gi"},
+    }
+
+
 @pytest.mark.parametrize(
     "device,expected_error",
     [


### PR DESCRIPTION
Fixes #234

**TL;DR** The compose→helm converter now translates the standard NVIDIA GPU reservation (`deploy.resources.reservations.devices` with `driver: nvidia`, `capabilities: [gpu]` and an integer `count`) into `nvidia.com/gpu` on both `requests` and `limits`, instead of raising `ComposeConverterError`. Both are populated because Kubernetes requires extended resources on `limits` (with `requests`, if set, equal). `count: all` (Docker's default when `count` is omitted), `device_ids`, non-NVIDIA drivers, and `capabilities` other than exactly `[gpu]` remain explicit errors. Tolerations/nodeSelector for tainted GPU nodes are deliberately left to cluster convention, per the issue.

<details><summary>e2e verification on EKS (rpv2-prod)</summary>

Ran an `inspect eval` whose compose file requests one GPU. The converted values triggered the platform's kyverno mutation (GPU toleration + `runtimeClassName: nvidia`), Karpenter provisioned a g4dn node, and `nvidia-smi` in the sandbox reported a Tesla T4 (returncode 0) — end to end in under 2 minutes.

One footgun found on the way, now covered in the docs: with the chart's default `runtimeClassName: gvisor`, the pod was rejected at admission (`conflict: runtimeClass.scheduling.nodeSelector[runtime] = nvidia; pod.spec.nodeSelector[runtime] = gvisor`) — the gvisor runtime class's node selector is merged into the pod spec before the cluster policy rewrites the runtime class. GPU services should set `runtime: nvidia` in compose (valid Docker Compose too); gvisor can't expose GPUs regardless.

Review fix: `devices: []` was emitting an empty `requests: {}` block, which defeated `_set_requests_to_limits_if_unset` for the service's other resources (cpu/memory). Now the `requests` key is only set when non-empty.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
