### PR TITLE
changelog: move post-0.13.0 entries back under Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## Unreleased
 
-- Raise an error when a conflicting `max_pod_ops` setting would otherwise be ignored.
-
-## 2026-08-12 0.13.0
-
-- Fix `write_file()` silently writing a truncated or empty file while reporting success
 - **BREAKING CHANGE**: The CoreDNS sidecar now runs as UID/GID 65532 on a read-only root
   filesystem with only `NET_BIND_SERVICE`. A custom `corednsImage` must run under that
   context; set the new `corednsSecurityContext` if it cannot. The default image moves
@@ -16,6 +11,11 @@
   release that fails later or resolves unexpectedly.
 - The CoreDNS sidecar no longer serves its `ready` endpoint on port 8181, and refuses
   queries beyond 1000 concurrent.
+- Raise an error when a conflicting `max_pod_ops` setting would otherwise be ignored.
+
+## 2026-08-12 0.13.0
+
+- Fix `write_file()` silently writing a truncated or empty file while reporting success
 - `inspect sandbox cleanup k8s` (with no release name) now **exits non-zero** if any release fails to uninstall, rather than reporting `Complete.` and exiting 0. Releases which fail to uninstall are named, at end-of-task cleanup too, along with their namespace and the `inspect sandbox cleanup k8s <release>` command to retry them.
 - **BREAKING CHANGE**: Sandbox pods created by the built-in Helm chart no longer mount
   Kubernetes service-account API tokens by default. Set
@@ -30,7 +30,7 @@
 - On Helm install failure, the raised error now includes pod diagnostics.
 - Compose to HELM: Support the `security_opt` seccomp option (mapped to a pod `seccompProfile`) and ignore the unsupported `memswap_limit`. See [Compose to Helm](https://k8s-sandbox.aisi.org.uk/helm/compose-to-helm/) for details.
 - The package and bundled `agent-env` chart versions are now unified, both jumping to
-  `0.14.0` (intervening numbers are unused).
+  `0.13.0` (intervening numbers are unused).
 
 ## 2026-06-25 0.6.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,13 @@ Consider using the recommended [Rewrap](https://stkb.github.io/Rewrap/) extensio
 ## Changelog
 
 If appropriate, add an entry under the `## Unreleased` heading in `CHANGELOG.md` when
-submitting a PR.
+submitting a PR. Create that heading if the last release consumed it.
+
+Entries under a dated release heading are published history — don't add to or edit
+them. In particular, if a release is cut after you branch, a stale branch can silently
+land your entry in the just-released section (the release commit renames `##
+Unreleased` to the dated heading, so your diff still applies): after rebasing onto
+`main`, check your entry still sits under `## Unreleased`.
 
 ## Releasing
 


### PR DESCRIPTION
PR #233 merged after the v0.13.0 tag was cut, but its changelog entries landed in the already-released `## 2026-08-12 0.13.0` section, and it rewrote that release's "versions unified, both jumping to `0.13.0`" entry to say `0.14.0`. Move the three CoreDNS entries under `## Unreleased`, restore `0.13.0` in the released section, and add a CONTRIBUTING.md note on the failure mode (a branch cut before a release still applies cleanly, landing its entry in the released section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
