### PR TITLE
Add INSPECT_POD_RESTART_CHECK to skip the pre-op pod read in file operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- `INSPECT_POD_RESTART_CHECK=false` skips the pre-operation pod read inside
+  `read_file()` / `write_file()`, for deployments where that per-op
+  `read_namespaced_pod` call becomes a load problem on the Kubernetes API server at
+  high concurrency. Defaults to enabled, so behaviour is unchanged unless set.
+  `exec()` always performs the check regardless.
+
 - **BREAKING CHANGE**: The CoreDNS sidecar now runs as UID/GID 65532 on a read-only root
   filesystem with only `NET_BIND_SERVICE`. A custom `corednsImage` must run under that
   context; set the new `corednsSecurityContext` if it cannot. The default image moves

--- a/src/k8s_sandbox/_pod/pod.py
+++ b/src/k8s_sandbox/_pod/pod.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import os
 from pathlib import Path
 from typing import IO, Callable, Literal, TypeVar
 
@@ -17,6 +18,15 @@ from k8s_sandbox._pod.write import WriteFileOperation
 T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
+
+
+def _file_op_restart_check_enabled() -> bool:
+    # Gates the pre-op `read_namespaced_pod` call inside read_file / write_file
+    # (only — exec is unaffected and always checks). At high concurrency
+    # (200+ ops) the per-op reads can overwhelm the K8s API server; exec's
+    # check is the high-signal way we learn a sandbox pod was replaced and
+    # stays unconditional, while file-op API errors are self-revealing.
+    return os.environ.get("INSPECT_POD_RESTART_CHECK", "true").lower() != "false"
 
 
 class Pod:
@@ -179,7 +189,8 @@ class Pod:
           dst (Path): The path to write the file to on the pod. Relative paths will be
             resolved relative to the pod's default working directory.
         """
-        await self.check_for_pod_restart()
+        if _file_op_restart_check_enabled():
+            await self.check_for_pod_restart()
         writer = WriteFileOperation(self._info)
         await self._run_async(lambda: writer.write_file(data, dst))
 
@@ -195,7 +206,8 @@ class Pod:
             relative to the pod's default working directory.
           dst (IO[bytes]): A file-like object to write the file to on the client system.
         """
-        await self.check_for_pod_restart()
+        if _file_op_restart_check_enabled():
+            await self.check_for_pod_restart()
         reader = ReadFileOperation(self._info)
         await self._run_async(lambda: reader.read_file(src, dst))
 

--- a/test/k8s_sandbox/pod/test_check_for_pod_restart.py
+++ b/test/k8s_sandbox/pod/test_check_for_pod_restart.py
@@ -198,7 +198,7 @@ def test_env_var_skips_file_op_check_but_not_exec(monkeypatch):
                 assert mock_client.return_value.read_namespaced_pod.call_count == 0
 
                 # write_file: same.
-                asyncio.run(pod.write_file(io.BytesIO(b""), pathlib.Path("/x")))
+                asyncio.run(pod.write_file(b"", pathlib.Path("/x")))
                 assert mock_client.return_value.read_namespaced_pod.call_count == 0
 
                 # exec: must always check, env var notwithstanding.

--- a/test/k8s_sandbox/pod/test_check_for_pod_restart.py
+++ b/test/k8s_sandbox/pod/test_check_for_pod_restart.py
@@ -1,4 +1,7 @@
+import asyncio
+import io
 import json
+import pathlib
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -149,3 +152,81 @@ def test_pod_auto_refreshes_restart_count_after_container_restart():
             uid="uid-OLD", container_name="default", restart_count=4
         )
         pod._check_for_pod_restart_sync()
+
+
+# --- INSPECT_POD_RESTART_CHECK gating (METR-private; not upstream) -----------
+
+
+def _make_replaced_pod_response() -> MagicMock:
+    return _k8s_pod(uid="uid-NEW", container_name="default", restart_count=0)
+
+
+def test_env_var_skips_file_op_check_but_not_exec(monkeypatch):
+    # Sandbox provider: Pod.read_file / Pod.write_file must skip the pre-op
+    # restart check when INSPECT_POD_RESTART_CHECK=false, while Pod.exec must
+    # always run it. Gate the file-op API hammer; keep the high-signal exec
+    # check unconditional.
+    monkeypatch.setenv("INSPECT_POD_RESTART_CHECK", "false")
+
+    # Patch the executor to run callables inline so we don't need a real
+    # threadpool / event loop boundary here.
+    with patch(
+        "k8s_sandbox._pod.executor.PodOpExecutor.get_instance"
+    ) as mock_get_instance:
+        executor = MagicMock()
+
+        async def queue(callable):
+            return callable()
+
+        executor.queue_operation = queue
+        mock_get_instance.return_value = executor
+
+        with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
+            mock_client.return_value.read_namespaced_pod.return_value = (
+                _make_replaced_pod_response()
+            )
+            # Patch the actual file ops so they don't try to hit a real pod.
+            with (
+                patch("k8s_sandbox._pod.pod.ReadFileOperation"),
+                patch("k8s_sandbox._pod.pod.WriteFileOperation"),
+                patch("k8s_sandbox._pod.pod.ExecuteOperation"),
+            ):
+                pod = _make_pod()
+
+                # read_file: env var should suppress the check entirely.
+                asyncio.run(pod.read_file(pathlib.Path("/x"), io.BytesIO()))
+                assert mock_client.return_value.read_namespaced_pod.call_count == 0
+
+                # write_file: same.
+                asyncio.run(pod.write_file(io.BytesIO(b""), pathlib.Path("/x")))
+                assert mock_client.return_value.read_namespaced_pod.call_count == 0
+
+                # exec: must always check, env var notwithstanding.
+                with pytest.raises(PodReplacedError):
+                    asyncio.run(pod.exec(["true"], None, None, {}, None, None))
+                assert mock_client.return_value.read_namespaced_pod.call_count == 1
+
+
+def test_env_var_default_keeps_file_op_check(monkeypatch):
+    monkeypatch.delenv("INSPECT_POD_RESTART_CHECK", raising=False)
+
+    with patch(
+        "k8s_sandbox._pod.executor.PodOpExecutor.get_instance"
+    ) as mock_get_instance:
+        executor = MagicMock()
+
+        async def queue(callable):
+            return callable()
+
+        executor.queue_operation = queue
+        mock_get_instance.return_value = executor
+
+        with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
+            mock_client.return_value.read_namespaced_pod.return_value = (
+                _make_replaced_pod_response()
+            )
+            with patch("k8s_sandbox._pod.pod.ReadFileOperation"):
+                pod = _make_pod()
+                with pytest.raises(PodReplacedError):
+                    asyncio.run(pod.read_file(pathlib.Path("/x"), io.BytesIO()))
+                assert mock_client.return_value.read_namespaced_pod.call_count == 1


### PR DESCRIPTION
## What

Adds an opt-out for the `read_namespaced_pod` call that runs before every `read_file()` / `write_file()`:

```
INSPECT_POD_RESTART_CHECK=false
```

Defaults to enabled, so nothing changes unless a deployment sets it.

## Why

At high concurrency (200+ concurrent pod operations) that per-operation read becomes a meaningful load source on the Kubernetes API server — one extra API call for every file read and write, across every sandbox in an eval set.

## Why `exec()` is deliberately not gated

`exec()` keeps its check unconditionally, and that asymmetry is the point rather than an oversight.

The pre-op read is how we learn a sandbox pod was replaced underneath us. An agent `exec`s constantly, so detection-on-exec is both cheap in relative terms and the high-signal path — it is where a replaced pod is noticed first. File operations are different: an API error against a replaced pod is self-revealing without the pre-check, so the check earns less there while costing the same.

So the knob trades away the redundant half of the detection and keeps the half that does the work.

## Testing

`test/k8s_sandbox/pod/test_check_for_pod_restart.py` gains coverage for both settings across `read_file`, `write_file` and `exec`, asserting `exec` still checks when the variable is `false`.

```
9 passed
```

## Provenance

Originally written by @rasmusfaber for METR's fork, where it has been running in production since May. Commit authorship is preserved. We are upstreaming it rather than carrying a private divergence — it is currently the only commit in our fork that is not upstream, and a configurable knob defaulting to today's behaviour seemed more useful shared than held.