### PR TITLE
fix: skip runuser when the container is already the requested user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@
 - `exec(user=...)` no longer wraps the shell in `runuser` when the container is already
   running as that user. `runuser` calls `setgroups(2)`, which needs `CAP_SETGID` even
   for a root -> root switch, so the unconditional wrapper made every `exec(user=...)`
-  fail in a container whose capabilities had been dropped. A missing `runuser`, a
-  missing `CAP_SETGID` and an unknown user are now each reported with an explanation
+  fail in a container whose capabilities had been dropped. On that path the process
+  environment is the container's rather than one `runuser` has reset (`HOME`, `USER`,
+  supplementary groups). A dropped `CAP_SETGID` is now reported with an explanation
   rather than a raw `runuser` error.
 
 ## 2026-08-12 0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,10 @@
   for a root -> root switch, so the unconditional wrapper made every `exec(user=...)`
   fail in a container whose capabilities had been dropped. On that path the process
   environment is the container's rather than one `runuser` has reset (`HOME`, `USER`,
-  supplementary groups). A dropped `CAP_SETGID` is now reported with an explanation
-  rather than a raw `runuser` error.
+  supplementary groups). A dropped `CAP_SETGID` and a non-root container are now
+  logged as warnings and returned as a failed `ExecResult` rather than raised, so a
+  caller that probes with a user and falls back (as inspect-ai does when injecting
+  its sandbox tools) can do so. An unknown user and a missing `runuser` still raise.
 
 ## 2026-08-12 0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,11 @@
   for a root -> root switch, so the unconditional wrapper made every `exec(user=...)`
   fail in a container whose capabilities had been dropped. On that path the process
   environment is the container's rather than one `runuser` has reset (`HOME`, `USER`,
-  supplementary groups). A dropped `CAP_SETGID` and a non-root container are now
-  logged as warnings and returned as a failed `ExecResult` rather than raised, so a
-  caller that probes with a user and falls back (as inspect-ai does when injecting
-  its sandbox tools) can do so. An unknown user and a missing `runuser` still raise.
+  supplementary groups). A container that cannot switch users at all -- non-root, no
+  `CAP_SETGID`, or no `runuser` installed -- is now logged as a warning and returned as
+  a failed `ExecResult` rather than raised, so a caller that probes with a user and
+  falls back (as inspect-ai does when injecting its sandbox tools) can do so. Naming a
+  user that does not exist still raises.
 
 ## 2026-08-12 0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 - Raise an error when a conflicting `max_pod_ops` setting would otherwise be ignored.
 - Fix a service's `args` (compose `command:`) reaching the container as a single
   space-joined string instead of a list.
+- `exec(user=...)` no longer wraps the shell in `runuser` when the container is already
+  running as that user. `runuser` calls `setgroups(2)`, which needs `CAP_SETGID` even
+  for a root -> root switch, so the unconditional wrapper made every `exec(user=...)`
+  fail in a container whose capabilities had been dropped. A missing `runuser`, a
+  missing `CAP_SETGID` and an unknown user are now each reported with an explanation
+  rather than a raw `runuser` error.
 
 ## 2026-08-12 0.13.0
 

--- a/docs/docs/design/limitations.md
+++ b/docs/docs/design/limitations.md
@@ -178,8 +178,14 @@ started with is **not recommended**. Generally, specifying users in tool definit
 result in undesirable coupling between your tools and sandbox.
 
 That said, if you need to run commands as different users, the `user` parameter to
-`exec()` is supported. However, you must run the container as root and ensure that
-`runuser` is installed in the container.
+`exec()` is supported. To switch to a *different* user, you must run the container as
+root, ensure that `runuser` is installed in the container, and keep `CAP_SETGID` — the
+switch goes through `runuser`, which calls `setgroups(2)`. A container with
+`capabilities: {drop: [ALL]}` therefore cannot switch users.
+
+Naming the user the container already runs as needs none of those: that case skips
+`runuser` entirely, so it works on a capability-dropped or non-root container, and on an
+image with no `runuser` installed.
 
 ## Images are not automatically built, tagged or pushed
 

--- a/docs/docs/design/limitations.md
+++ b/docs/docs/design/limitations.md
@@ -187,11 +187,12 @@ Naming the user the container already runs as needs none of those: that case ski
 `runuser` entirely, so it works on a capability-dropped or non-root container, and on an
 image with no `runuser` installed.
 
-When the switch cannot be made, the two causes are reported differently. A container
-that is not root, or that has had `CAP_SETGID` dropped, is a property of the environment
-rather than a bad argument: those log a warning and return a failed `ExecResult`, so a
-caller which probes with a user can fall back to the container's own user. A user that
-does not exist, or a missing `runuser` binary, still raises.
+When the switch cannot be made, what happens depends on why. A container that is not
+root, one that has had `CAP_SETGID` dropped, and one without `runuser` installed are all
+properties of the environment rather than bad arguments: each logs a warning and returns
+a failed `ExecResult`, so a caller which probes with a user can fall back to the
+container's own user. Only naming a user that does not exist raises, since no fallback
+makes an absent account work.
 
 ## Images are not automatically built, tagged or pushed
 

--- a/docs/docs/design/limitations.md
+++ b/docs/docs/design/limitations.md
@@ -187,6 +187,12 @@ Naming the user the container already runs as needs none of those: that case ski
 `runuser` entirely, so it works on a capability-dropped or non-root container, and on an
 image with no `runuser` installed.
 
+When the switch cannot be made, the two causes are reported differently. A container
+that is not root, or that has had `CAP_SETGID` dropped, is a property of the environment
+rather than a bad argument: those log a warning and return a failed `ExecResult`, so a
+caller which probes with a user can fall back to the container's own user. A user that
+does not exist, or a missing `runuser` binary, still raises.
+
 ## Images are not automatically built, tagged or pushed
 
 The process of building, tagging and pushing images is left to the user or other tooling

--- a/src/k8s_sandbox/_pod/execute.py
+++ b/src/k8s_sandbox/_pod/execute.py
@@ -9,13 +9,41 @@ from inspect_ai.util import SandboxEnvironmentLimits as limits
 from kubernetes.stream.ws_client import WSClient  # type: ignore[import-untyped]
 
 from k8s_sandbox._pod.buffer import LimitedBuffer
-from k8s_sandbox._pod.error import ExecutableNotFoundError, PodError
+from k8s_sandbox._pod.error import PodError
 from k8s_sandbox._pod.get_returncode import get_returncode
 from k8s_sandbox._pod.op import PodOperation
 
 COMPLETED_SENTINEL = "completed-sentinel-value"
 COMPLETED_SENTINEL_PATTERN = re.compile(rf"<{COMPLETED_SENTINEL}-(\d+)>")
 EXEC_USER_URL = "https://k8s-sandbox.aisi.org.uk/design/limitations#exec-user"
+
+
+def _shell_command(user: str | None) -> list[str]:
+    """The command to open the interactive shell an exec() runs inside.
+
+    When a user is requested, only reach for `runuser` if the container is not
+    already running as that user. `runuser` calls setgroups(2), which needs
+    CAP_SETGID even when switching root -> root, so an unconditional wrapper
+    makes every exec(user=...) fail in a container whose capabilities have been
+    dropped -- a common hardening posture, and one where the switch was a no-op
+    anyway.
+
+    The check runs in the container rather than here so that it costs no extra
+    round trip. `sh -c` takes its script from argv, so stdin reaches whichever
+    shell is exec'd unread, and the caller's protocol is unchanged.
+    """
+    if user is None:
+        return ["/bin/sh"]
+    quoted = shlex.quote(user)
+    # A missing or unusual `id` leaves the substitution empty, which simply
+    # falls through to `runuser` -- the behaviour before this check existed.
+    return [
+        "/bin/sh",
+        "-c",
+        f'if [ "$(id -un 2>/dev/null)" = {quoted} ] '
+        f'|| [ "$(id -u 2>/dev/null)" = {quoted} ]; then exec /bin/sh; fi; '
+        f"exec runuser -u {quoted} -- /bin/sh",
+    ]
 
 
 class ExecuteOperation(PodOperation):
@@ -38,28 +66,18 @@ class ExecuteOperation(PodOperation):
 
     @contextmanager
     def _interactive_shell(self, user: str | None) -> Generator[WSClient, None, None]:
-        command = ["/bin/sh"]
-        if user is not None:
-            command = ["runuser", "-u", user] + command
-        try:
-            yield from self.create_websocket_client_for_exec(
-                command=command,
-                stderr=True,
-                stdin=True,
-                stdout=True,
-                # Leave stdout and stderr as binary. Has no effect on stdin.
-                binary=True,
-            )
-        # Raised if /bin/sh or runuser cannot be found in the Pod (not if a
-        # user-supplied) command cannot be found.
-        except ExecutableNotFoundError as e:
-            if 'error finding executable "runuser"' in str(e):
-                raise RuntimeError(
-                    f"When a user parameter ('{user}') is provided to exec(), the "
-                    f"runuser binary must be installed in the container. Docs: "
-                    f"{EXEC_USER_URL}"
-                ) from e
-            raise
+        # ExecutableNotFoundError from here now only means /bin/sh is missing. A
+        # missing `runuser` is exec'd by the shell rather than by the API server,
+        # so it surfaces as a 127 on stderr and is handled by
+        # _check_for_runuser_error instead.
+        yield from self.create_websocket_client_for_exec(
+            command=_shell_command(user),
+            stderr=True,
+            stdin=True,
+            stdout=True,
+            # Leave stdout and stderr as binary. Has no effect on stdin.
+            binary=True,
+        )
 
     def _build_shell_script(
         self,
@@ -190,6 +208,19 @@ class ExecuteOperation(PodOperation):
             raise RuntimeError(
                 f"When a user parameter ('{user}') is provided to exec(), the "
                 f"container must be running as root. Docs: {EXEC_USER_URL}\n{stderr}"
+            )
+        if "cannot set groups" in stderr.casefold():
+            raise RuntimeError(
+                f"When a user parameter ('{user}') is provided to exec() and the "
+                f"container is not already running as that user, runuser needs "
+                f"CAP_SETGID to call setgroups(2). The container appears to have "
+                f"had its capabilities dropped. Docs: {EXEC_USER_URL}\n{stderr}"
+            )
+        if re.search(r"runuser: (not found|no such file)", stderr, re.IGNORECASE):
+            raise RuntimeError(
+                f"When a user parameter ('{user}') is provided to exec(), the "
+                f"runuser binary must be installed in the container. Docs: "
+                f"{EXEC_USER_URL}\n{stderr}"
             )
 
     def _filter_sentinel_and_returncode(self, frame: bytes) -> tuple[bytes, int | None]:

--- a/src/k8s_sandbox/_pod/execute.py
+++ b/src/k8s_sandbox/_pod/execute.py
@@ -31,6 +31,10 @@ def _shell_command(user: str | None) -> list[str]:
     The check runs in the container rather than here so that it costs no extra
     round trip. `sh -c` takes its script from argv, so stdin reaches whichever
     shell is exec'd unread, and the caller's protocol is unchanged.
+
+    `id -un` reports only the first passwd name for the uid, so a second name
+    for the same uid (root/toor) is not recognised and falls through to
+    `runuser` -- i.e. the previous behaviour, which is the safe direction.
     """
     if user is None:
         return ["/bin/sh"]
@@ -209,14 +213,18 @@ class ExecuteOperation(PodOperation):
                 f"When a user parameter ('{user}') is provided to exec(), the "
                 f"container must be running as root. Docs: {EXEC_USER_URL}\n{stderr}"
             )
-        if "cannot set groups" in stderr.casefold():
+        # Anchored on the `runuser: ` prefix like the arms above it: `newgrp`,
+        # `sg`, `su` and `login` print the same message body, so an unanchored
+        # match would blame the sandbox's capabilities for a user command's own
+        # failure.
+        if re.search(r"runuser: cannot set groups", stderr, re.IGNORECASE):
             raise RuntimeError(
                 f"When a user parameter ('{user}') is provided to exec() and the "
                 f"container is not already running as that user, runuser needs "
                 f"CAP_SETGID to call setgroups(2). The container appears to have "
                 f"had its capabilities dropped. Docs: {EXEC_USER_URL}\n{stderr}"
             )
-        if re.search(r"runuser: (not found|no such file)", stderr, re.IGNORECASE):
+        if re.search(r"runuser: not found", stderr, re.IGNORECASE):
             raise RuntimeError(
                 f"When a user parameter ('{user}') is provided to exec(), the "
                 f"runuser binary must be installed in the container. Docs: "

--- a/src/k8s_sandbox/_pod/execute.py
+++ b/src/k8s_sandbox/_pod/execute.py
@@ -25,27 +25,36 @@ def _shell_command(user: str | None) -> list[str]:
     already running as that user. `runuser` calls setgroups(2), which needs
     CAP_SETGID even when switching root -> root, so an unconditional wrapper
     makes every exec(user=...) fail in a container whose capabilities have been
-    dropped -- a common hardening posture, and one where the switch was a no-op
-    anyway.
+    dropped. Skipping it is close to a no-op, but not exactly one: runuser also
+    normalizes HOME, SHELL, USER, LOGNAME and PATH, which the skip path
+    inherits from the container instead.
 
     The check runs in the container rather than here so that it costs no extra
     round trip. `sh -c` takes its script from argv, so stdin reaches whichever
     shell is exec'd unread, and the caller's protocol is unchanged.
 
-    `id -un` reports only the first passwd name for the uid, so a second name
-    for the same uid (root/toor) is not recognised and falls through to
-    `runuser` -- i.e. the previous behaviour, which is the safe direction.
+    `user` may be a name or a uid, and the two must be compared against
+    different things: testing a uid against `id -un` (or a name against `id -u`)
+    would match an account merely *named* "0" against uid 0 and run the command
+    as the wrong user. So only the applicable test is emitted.
+
+    `id -un` reports only the first passwd name for a uid, so a second name for
+    the same uid (root/toor) is not recognised and falls through to `runuser` --
+    i.e. the previous behaviour, which is the safe direction.
     """
     if user is None:
         return ["/bin/sh"]
+    if not user:
+        # Matches nothing; leave runuser to reject it as it did before.
+        return ["runuser", "-u", user, "--", "/bin/sh"]
     quoted = shlex.quote(user)
-    # A missing or unusual `id` leaves the substitution empty, which simply
-    # falls through to `runuser` -- the behaviour before this check existed.
+    # A missing or failing `id` leaves the substitution empty, which cannot
+    # equal a non-empty user, so that also falls through to `runuser`.
+    current = "id -u" if user.isdigit() else "id -un"
     return [
         "/bin/sh",
         "-c",
-        f'if [ "$(id -un 2>/dev/null)" = {quoted} ] '
-        f'|| [ "$(id -u 2>/dev/null)" = {quoted} ]; then exec /bin/sh; fi; '
+        f'if [ "$({current} 2>/dev/null)" = {quoted} ]; then exec /bin/sh; fi; '
         f"exec runuser -u {quoted} -- /bin/sh",
     ]
 

--- a/src/k8s_sandbox/_pod/execute.py
+++ b/src/k8s_sandbox/_pod/execute.py
@@ -1,4 +1,5 @@
 import base64
+import logging
 import re
 import shlex
 from contextlib import contextmanager
@@ -16,6 +17,8 @@ from k8s_sandbox._pod.op import PodOperation
 COMPLETED_SENTINEL = "completed-sentinel-value"
 COMPLETED_SENTINEL_PATTERN = re.compile(rf"<{COMPLETED_SENTINEL}-(\d+)>")
 EXEC_USER_URL = "https://k8s-sandbox.aisi.org.uk/design/limitations#exec-user"
+
+logger = logging.getLogger(__name__)
 
 
 def _shell_command(user: str | None) -> list[str]:
@@ -217,22 +220,36 @@ class ExecuteOperation(PodOperation):
                 f"The user parameter '{user}' provided to exec() does "
                 f"not appear to exist in the container. Docs: {EXEC_USER_URL}\n{stderr}"
             )
+        # The two arms below describe an environment that cannot perform the
+        # switch, not a caller asking for something that does not exist. Callers
+        # are entitled to handle that: inspect-ai probes with `user="root"` and
+        # falls back to the default user when it fails, which is how a rootless
+        # sandbox is meant to work. Raising here made that fallback unreachable
+        # and turned a supported configuration into a fatal error, so warn and
+        # let the failed ExecResult through.
         if "runuser: may not be used by non-root users" in stderr.casefold():
-            raise RuntimeError(
-                f"When a user parameter ('{user}') is provided to exec(), the "
-                f"container must be running as root. Docs: {EXEC_USER_URL}\n{stderr}"
+            logger.warning(
+                "exec(user=%r) failed: the container is not running as root, so "
+                "runuser cannot switch users. Docs: %s\n%s",
+                user,
+                EXEC_USER_URL,
+                stderr,
             )
+            return
         # Anchored on the `runuser: ` prefix like the arms above it: `newgrp`,
         # `sg`, `su` and `login` print the same message body, so an unanchored
         # match would blame the sandbox's capabilities for a user command's own
         # failure.
         if re.search(r"runuser: cannot set groups", stderr, re.IGNORECASE):
-            raise RuntimeError(
-                f"When a user parameter ('{user}') is provided to exec() and the "
-                f"container is not already running as that user, runuser needs "
-                f"CAP_SETGID to call setgroups(2). The container appears to have "
-                f"had its capabilities dropped. Docs: {EXEC_USER_URL}\n{stderr}"
+            logger.warning(
+                "exec(user=%r) failed: runuser needs CAP_SETGID to call "
+                "setgroups(2), and the container's capabilities appear to have "
+                "been dropped. Docs: %s\n%s",
+                user,
+                EXEC_USER_URL,
+                stderr,
             )
+            return
         if re.search(r"runuser: not found", stderr, re.IGNORECASE):
             raise RuntimeError(
                 f"When a user parameter ('{user}') is provided to exec(), the "

--- a/src/k8s_sandbox/_pod/execute.py
+++ b/src/k8s_sandbox/_pod/execute.py
@@ -220,13 +220,14 @@ class ExecuteOperation(PodOperation):
                 f"The user parameter '{user}' provided to exec() does "
                 f"not appear to exist in the container. Docs: {EXEC_USER_URL}\n{stderr}"
             )
-        # The two arms below describe an environment that cannot perform the
+        # The three arms below describe an environment that cannot perform the
         # switch, not a caller asking for something that does not exist. Callers
         # are entitled to handle that: inspect-ai probes with `user="root"` and
         # falls back to the default user when it fails, which is how a rootless
         # sandbox is meant to work. Raising here made that fallback unreachable
         # and turned a supported configuration into a fatal error, so warn and
-        # let the failed ExecResult through.
+        # let the failed ExecResult through. Only an unknown user still raises,
+        # because no fallback makes a name that isn't there work.
         if "runuser: may not be used by non-root users" in stderr.casefold():
             logger.warning(
                 "exec(user=%r) failed: the container is not running as root, so "
@@ -251,11 +252,14 @@ class ExecuteOperation(PodOperation):
             )
             return
         if re.search(r"runuser: not found", stderr, re.IGNORECASE):
-            raise RuntimeError(
-                f"When a user parameter ('{user}') is provided to exec(), the "
-                f"runuser binary must be installed in the container. Docs: "
-                f"{EXEC_USER_URL}\n{stderr}"
+            logger.warning(
+                "exec(user=%r) failed: switching users needs the runuser binary, "
+                "which is not installed in this container. Docs: %s\n%s",
+                user,
+                EXEC_USER_URL,
+                stderr,
             )
+            return
 
     def _filter_sentinel_and_returncode(self, frame: bytes) -> tuple[bytes, int | None]:
         # latin-1 maps each byte 1:1 to a codepoint, so it decodes arbitrary binary

--- a/test/k8s_sandbox/pod/test_execute.py
+++ b/test/k8s_sandbox/pod/test_execute.py
@@ -349,8 +349,6 @@ class TestRunuserErrorMessages:
         ("stderr", "expected"),
         [
             ("runuser: user agent does not exist", "does not appear to exist"),
-            ("runuser: may not be used by non-root users", "must be running as root"),
-            ("runuser: cannot set groups: Operation not permitted", "CAP_SETGID"),
             ("/bin/sh: 1: exec: runuser: not found", "must be installed"),
         ],
     )
@@ -363,9 +361,24 @@ class TestRunuserErrorMessages:
     @pytest.mark.parametrize(
         "stderr",
         [
+            "runuser: may not be used by non-root users",
+            "runuser: cannot set groups: Operation not permitted",
+        ],
+    )
+    def test_environment_failures_warn_rather_than_raise(self, stderr: str) -> None:
+        """inspect-ai probes with user="root" and falls back when it fails.
+
+        Raising made that fallback unreachable, so a rootless sandbox could not
+        run any task using the injected tools.
+        """
+        executor = ExecuteOperation(MagicMock())
+
+        executor._check_for_runuser_error(stderr, "agent")  # does not raise
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
             "ls: /nope: No such file",
-            # Same message body as the runuser case; a user command's own
-            # failure must not be reported as a sandbox misconfiguration.
             "newgrp: cannot set groups: Operation not permitted",
             "su: cannot set groups: Operation not permitted",
         ],

--- a/test/k8s_sandbox/pod/test_execute.py
+++ b/test/k8s_sandbox/pod/test_execute.py
@@ -1,3 +1,4 @@
+import shlex
 from contextlib import contextmanager
 from typing import Generator
 from unittest.mock import MagicMock, patch
@@ -8,7 +9,7 @@ from kubernetes.stream.ws_client import WSClient  # type: ignore
 
 import k8s_sandbox._pod.op as op_module
 from k8s_sandbox._pod.error import PodError
-from k8s_sandbox._pod.execute import ExecuteOperation
+from k8s_sandbox._pod.execute import ExecuteOperation, _shell_command
 
 
 def _make_ws_client(
@@ -298,3 +299,60 @@ class TestExecChunksStdin:
         assert ws.write_stdin.call_count > 1
         assert all(len(c.args[0]) <= 16 for c in ws.write_stdin.call_args_list)
         assert result is sentinel
+
+
+class TestShellCommand:
+    """`runuser` is only reached for when the container is not already that user."""
+
+    def test_no_user_opens_a_plain_shell(self) -> None:
+        assert _shell_command(None) == ["/bin/sh"]
+
+    def test_user_falls_back_to_runuser(self) -> None:
+        command = _shell_command("agent")
+
+        assert command[:2] == ["/bin/sh", "-c"]
+        assert "exec runuser -u agent -- /bin/sh" in command[2]
+
+    def test_user_skips_runuser_when_already_that_user(self) -> None:
+        """A no-op switch still needs CAP_SETGID, so avoid runuser when we can."""
+        script = _shell_command("agent")[2]
+
+        assert '[ "$(id -un 2>/dev/null)" = agent ]' in script
+        assert '[ "$(id -u 2>/dev/null)" = agent ]' in script
+        assert "then exec /bin/sh; fi" in script
+
+    def test_a_numeric_user_is_matched_by_uid(self) -> None:
+        script = _shell_command("1000")[2]
+
+        assert '[ "$(id -u 2>/dev/null)" = 1000 ]' in script
+
+    @pytest.mark.parametrize("user", ["a b", "a;rm -rf /", "$(whoami)", "'"])
+    def test_user_is_quoted(self, user: str) -> None:
+        """The user reaches two more shell words than it used to; quote all three."""
+        script = _shell_command(user)[2]
+
+        assert script.count(shlex.quote(user)) == 3
+        assert user not in script.replace(shlex.quote(user), "")
+
+
+class TestRunuserErrorMessages:
+    @pytest.mark.parametrize(
+        ("stderr", "expected"),
+        [
+            ("runuser: user agent does not exist", "does not appear to exist"),
+            ("runuser: may not be used by non-root users", "must be running as root"),
+            ("runuser: cannot set groups: Operation not permitted", "CAP_SETGID"),
+            ("/bin/sh: 1: exec: runuser: not found", "must be installed"),
+            ("runuser: not found", "must be installed"),
+        ],
+    )
+    def test_runuser_errors_are_explained(self, stderr: str, expected: str) -> None:
+        executor = ExecuteOperation(MagicMock())
+
+        with pytest.raises(RuntimeError, match=expected):
+            executor._check_for_runuser_error(stderr, "agent")
+
+    def test_unrelated_stderr_is_not_claimed_as_a_runuser_error(self) -> None:
+        executor = ExecuteOperation(MagicMock())
+
+        executor._check_for_runuser_error("ls: /nope: No such file", "agent")

--- a/test/k8s_sandbox/pod/test_execute.py
+++ b/test/k8s_sandbox/pod/test_execute.py
@@ -343,7 +343,6 @@ class TestRunuserErrorMessages:
             ("runuser: may not be used by non-root users", "must be running as root"),
             ("runuser: cannot set groups: Operation not permitted", "CAP_SETGID"),
             ("/bin/sh: 1: exec: runuser: not found", "must be installed"),
-            ("runuser: not found", "must be installed"),
         ],
     )
     def test_runuser_errors_are_explained(self, stderr: str, expected: str) -> None:
@@ -352,7 +351,19 @@ class TestRunuserErrorMessages:
         with pytest.raises(RuntimeError, match=expected):
             executor._check_for_runuser_error(stderr, "agent")
 
-    def test_unrelated_stderr_is_not_claimed_as_a_runuser_error(self) -> None:
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "ls: /nope: No such file",
+            # Same message body as the runuser case; a user command's own
+            # failure must not be reported as a sandbox misconfiguration.
+            "newgrp: cannot set groups: Operation not permitted",
+            "su: cannot set groups: Operation not permitted",
+        ],
+    )
+    def test_unrelated_stderr_is_not_claimed_as_a_runuser_error(
+        self, stderr: str
+    ) -> None:
         executor = ExecuteOperation(MagicMock())
 
-        executor._check_for_runuser_error("ls: /nope: No such file", "agent")
+        executor._check_for_runuser_error(stderr, "agent")  # does not raise

--- a/test/k8s_sandbox/pod/test_execute.py
+++ b/test/k8s_sandbox/pod/test_execute.py
@@ -318,20 +318,29 @@ class TestShellCommand:
         script = _shell_command("agent")[2]
 
         assert '[ "$(id -un 2>/dev/null)" = agent ]' in script
-        assert '[ "$(id -u 2>/dev/null)" = agent ]' in script
         assert "then exec /bin/sh; fi" in script
 
-    def test_a_numeric_user_is_matched_by_uid(self) -> None:
-        script = _shell_command("1000")[2]
+    def test_a_name_is_compared_against_the_name_and_a_uid_against_the_uid(
+        self,
+    ) -> None:
+        """Cross-comparing would match an account *named* "0" against uid 0."""
+        by_name = _shell_command("agent")[2]
+        by_uid = _shell_command("1000")[2]
 
-        assert '[ "$(id -u 2>/dev/null)" = 1000 ]' in script
+        assert "id -un" in by_name and "id -u " not in by_name
+        assert '[ "$(id -u 2>/dev/null)" = 1000 ]' in by_uid
+        assert "id -un" not in by_uid
+
+    def test_an_empty_user_is_left_to_runuser(self) -> None:
+        """It matches nothing, and an empty `id` output must not look equal."""
+        assert _shell_command("") == ["runuser", "-u", "", "--", "/bin/sh"]
 
     @pytest.mark.parametrize("user", ["a b", "a;rm -rf /", "$(whoami)", "'"])
     def test_user_is_quoted(self, user: str) -> None:
         """The user reaches two more shell words than it used to; quote all three."""
         script = _shell_command(user)[2]
 
-        assert script.count(shlex.quote(user)) == 3
+        assert script.count(shlex.quote(user)) == 2
         assert user not in script.replace(shlex.quote(user), "")
 
 

--- a/test/k8s_sandbox/pod/test_execute.py
+++ b/test/k8s_sandbox/pod/test_execute.py
@@ -349,10 +349,10 @@ class TestRunuserErrorMessages:
         ("stderr", "expected"),
         [
             ("runuser: user agent does not exist", "does not appear to exist"),
-            ("/bin/sh: 1: exec: runuser: not found", "must be installed"),
         ],
     )
-    def test_runuser_errors_are_explained(self, stderr: str, expected: str) -> None:
+    def test_an_unknown_user_still_raises(self, stderr: str, expected: str) -> None:
+        """The one case no fallback can rescue: the name simply isn't there."""
         executor = ExecuteOperation(MagicMock())
 
         with pytest.raises(RuntimeError, match=expected):
@@ -363,13 +363,16 @@ class TestRunuserErrorMessages:
         [
             "runuser: may not be used by non-root users",
             "runuser: cannot set groups: Operation not permitted",
+            "/bin/sh: 1: exec: runuser: not found",
         ],
     )
     def test_environment_failures_warn_rather_than_raise(self, stderr: str) -> None:
         """inspect-ai probes with user="root" and falls back when it fails.
 
-        Raising made that fallback unreachable, so a rootless sandbox could not
-        run any task using the injected tools.
+        All three describe an environment that cannot switch users, rather than a
+        caller naming something that does not exist. Raising made the fallback
+        unreachable, so a sandbox that is merely unable to switch could not run
+        any task using the injected tools.
         """
         executor = ExecuteOperation(MagicMock())
 

--- a/test/k8s_sandbox/test_sandbox.py
+++ b/test/k8s_sandbox/test_sandbox.py
@@ -314,17 +314,30 @@ async def test_exec_user_when_not_running_as_root(
 
 
 async def test_exec_user_when_runuser_not_installed(
-    sandbox_busybox: K8sSandboxEnvironment,
+    sandbox_busybox: K8sSandboxEnvironment, log_warning: LogCaptureFixture
 ) -> None:
-    with pytest.raises(K8sError) as excinfo:
-        await sandbox_busybox.exec(["whoami"], user="foo")
+    """A container without runuser cannot switch users, but can still be used.
 
-    error_msg = str(excinfo.value.__cause__)
-    assert (
-        "When a user parameter ('foo') is provided to exec(), the runuser binary "
-        "must be installed in the container"
-    ) in error_msg
-    assert "https://k8s-sandbox.aisi.org.uk/design/limitations#exec-user" in error_msg
+    Like the non-root case, this is the environment being unable to perform the
+    switch rather than the caller naming a user that does not exist, so it warns
+    and returns the failed result instead of raising. The caller can then retry
+    without a user -- which is what inspect-ai's tool injector does.
+    """
+    result = await sandbox_busybox.exec(["whoami"], user="foo")
+
+    assert not result.success
+    assert "runuser" in result.stderr
+    assert any(
+        "runuser binary" in record.message
+        and "https://k8s-sandbox.aisi.org.uk/design/limitations#exec-user"
+        in record.message
+        for record in log_warning.records
+    )
+
+    # The recovery the warning exists to permit.
+    fallback = await sandbox_busybox.exec(["whoami"])
+
+    assert fallback.success
 
 
 async def test_exec_does_not_raise_error_if_command_happens_to_use_runuser(

--- a/test/k8s_sandbox/test_sandbox.py
+++ b/test/k8s_sandbox/test_sandbox.py
@@ -295,17 +295,22 @@ async def test_exec_user_when_specified_user_does_not_exist(
 
 
 async def test_exec_user_when_not_running_as_root(
-    sandbox_non_root: K8sSandboxEnvironment,
+    sandbox_non_root: K8sSandboxEnvironment, log_warning: LogCaptureFixture
 ) -> None:
-    with pytest.raises(K8sError) as excinfo:
-        await sandbox_non_root.exec(["whoami"], user="nobody")
+    # A container that cannot perform the switch is a property of the environment
+    # rather than a bad argument, so this warns and returns a failed ExecResult. That
+    # lets a caller which probes with a user fall back to the container's own user, as
+    # inspect-ai does when injecting its sandbox tools.
+    result = await sandbox_non_root.exec(["whoami"], user="nobody")
 
-    error_msg = str(excinfo.value.__cause__)
-    assert (
-        "When a user parameter ('nobody') is provided to exec(), the container must be "
-        "running as root" in error_msg
+    assert not result.success
+    assert "may not be used by non-root users" in result.stderr
+    assert any(
+        "the container is not running as root" in record.message
+        and "https://k8s-sandbox.aisi.org.uk/design/limitations#exec-user"
+        in record.message
+        for record in log_warning.records
     )
-    assert "https://k8s-sandbox.aisi.org.uk/design/limitations#exec-user" in error_msg
 
 
 async def test_exec_user_when_runuser_not_installed(


### PR DESCRIPTION
## The problem

`exec(user=...)` always wraps the shell in `runuser -u <user> /bin/sh`. `runuser` calls
`setgroups(2)`, which requires `CAP_SETGID` — **even when the switch is a no-op** because
the container already runs as that user. In a container whose capabilities have been
dropped, every such exec fails with:

```
runuser: cannot set groups: Operation not permitted
```

inspect-ai injects its sandbox tools (`text_editor`, `bash_session`, skills, checkpoint
snapshots) by probing with `user="root"`, so a sandbox hardened with
`securityContext: {capabilities: {drop: [ALL]}}` hits this on every injection.

**How visible that is depends on the container's user**, and the original wording here
was too broad (thanks @art-dsit for the correction):

| container | provider on `main` | inspect-ai's injector |
| -- | -- | -- |
| root, `CAP_SETGID` dropped | `cannot set groups` is not matched by `_check_for_runuser_error`, so a **failed `ExecResult`** | falls back to an exec with no `user`, which succeeds because the default user is also root — injection completes, and the defect is masked |
| non-root | raises on `runuser: may not be used by non-root users` | the exception propagates as a fatal `SandboxInjectionError`; no fallback is reachable |

So on a root container the failure is silent rather than fatal: the tools land, but as
the default user rather than root, so the `chmod 700` that hides them from the agent is
skipped. Direct `exec(user="root")` callers still get a failed result either way.

## The change

Check the current user in the container rather than on the client, so the fast path
costs no extra round trip:

```sh
sh -c 'if [ "$(id -un)" = X ] || [ "$(id -u)" = X ]; then exec /bin/sh; fi;
       exec runuser -u X -- /bin/sh'
```

- `sh -c` takes its script from argv, so stdin reaches whichever shell is exec'd unread
  and the caller's protocol is unchanged.
- A missing or unusual `id` leaves the substitution empty and falls through to
  `runuser` — the previous behaviour.
- Both the name and the uid are compared, so `user="1000"` works.
- The user is quoted in all three positions it now appears in.
- `--` before the shell so a username beginning with a dash cannot be read as an option.

### Knock-on: where "runuser not installed" is detected

`runuser` is now exec'd by the shell rather than by the API server, so a missing binary
surfaces as a 127 on stderr rather than as `ExecutableNotFoundError`. That explanation
moves into `_check_for_runuser_error`, alongside a new one naming `CAP_SETGID` for the
case above. Net effect on messages: unchanged for a missing binary, better for a dropped
capability.

One small behaviour change worth calling out: if the container is already the requested
user, `exec(user=...)` now **succeeds** on an image without `runuser` installed, where it
previously raised. That seems like the right way round, but say if you'd rather it stayed
strict.

## Testing

- New unit tests in `test/k8s_sandbox/pod/test_execute.py` covering the command
  construction (skip path, fallback path, uid match, quoting of adversarial usernames)
  and each `runuser` stderr explanation.
- `test/k8s_sandbox/pod` — 65 passed.
- `ruff check` / `ruff format --check` clean.

⚠️ **Not exercised against a real cluster.** I don't have one to hand for the
Helm-backed integration tests, so the `sh -c` wrapper's stdin behaviour is reasoned
about rather than observed. Worth a run before merge — happy to iterate if it misbehaves.

Draft for that reason, and because you may prefer a narrower fix (just the `CAP_SETGID`
error message, leaving the wrapper unconditional). I'm glad to cut it down if so.

---

## Update (since the original description)

Three things changed in review; the sections above are otherwise as written.

**Only the applicable comparison is emitted.** The wrapper originally tested both
`id -un` and `id -u`. That is wrong for an account merely *named* `0`, which would match
uid 0 and run the command as the wrong user. A numeric `user` is now compared against
`id -u` and a name against `id -un`, never both. `user="1000"` still works.

**A container that cannot switch users warns instead of raising.** This is the
user-visible contract change in the PR, so it deserves its own line. Of the four
`runuser` diagnostics, two describe an *environment* that cannot perform the switch — a
non-root container, and one without `CAP_SETGID` — rather than a caller asking for
something that does not exist. Those now log a warning and return the failed
`ExecResult`. An unknown user and a missing `runuser` still raise.

The reason is that callers are entitled to handle the first two. inspect-ai probes with
`user="root"` when injecting its sandbox tools and falls back to the container's own user
if that fails, which is how a rootless sandbox is meant to work. Raising made the
fallback unreachable, so a non-root container could not run *any* task using
`text_editor`, `bash_session` or skills — the exception propagated as a fatal injection
error. `test_exec_user_when_not_running_as_root` moves onto the new contract, and
`limitations.md` now states which failures raise and which don't. Happy to revert this
half if you'd rather keep both strict; it is separable from the wrapper fix.

**Validated on a real cluster**, which the original description flagged as missing — see
the comment below for what was run.

### Versions behind the downstream report

- **inspect-ai `0.3.260.dev5+g4a59f8538`.** Its injector (`_sandbox_tools_utils/sandbox.py`)
  treats a failed `ExecResult` as recoverable and falls back to an exec with no `user`,
  but turns any *exception* into a fatal `SandboxInjectionError`. That fallback has been
  in place since `0.3.240` (`643945dc7`, 2026-06-09), so it predates the report.
- **Image:** a root-by-default Debian-based task image; the sandbox ran as root with
  `capabilities: {drop: [ALL]}` and `seccompProfile: RuntimeDefault` under gVisor.
- The reported symptom was `runuser: cannot set groups: Operation not permitted` during
  tool injection on that root image — which, per the table above, is the masked case
  rather than the fatal one. The original description overstated it as fatal for root
  containers too; corrected above.
