### PR TITLE
Compose: support service volume extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add per-service `x-inspect_k8s_sandbox.volumes` and `volumeMounts` compose
+  extensions for Kubernetes volume types, including OCI image volumes, that Compose
+  shorthand cannot express.
 - **BREAKING CHANGE**: The CoreDNS sidecar now runs as UID/GID 65532 on a read-only root
   filesystem with only `NET_BIND_SERVICE`. A custom `corednsImage` must run under that
   context; set the new `corednsSecurityContext` if it cannot. The default image moves

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -52,6 +52,32 @@ services:
     command: ["tail", "-f", "/dev/null"]
 ```
 
+## OCI image volume
+
+Use the per-service Compose extension when an agent needs a Kubernetes volume type that
+Compose shorthand cannot express:
+
+```yaml
+services:
+  default:
+    image: python:3.12
+    x-inspect_k8s_sandbox:
+      volumes:
+        - name: agent-cli-claude
+          image:
+            reference: example.com/agent-clis:claude-2.1.205
+            pullPolicy: IfNotPresent
+      volumeMounts:
+        - name: agent-cli-claude
+          mountPath: /opt/agent-cli/claude
+          subPath: payload
+          readOnly: true
+```
+
+The extension entries are appended after ordinary Compose `volumes` entries. See
+[Compose to Helm](helm/compose-to-helm.md#kubernetes-volume-types) for the Kubernetes
+API requirements.
+
 ## Additional infrastructure
 
 Again, assuming you're using the built-in Helm chart. The Nginx server will be

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -70,7 +70,6 @@ services:
       volumeMounts:
         - name: agent-cli-claude
           mountPath: /opt/agent-cli/claude
-          subPath: payload
           readOnly: true
 ```
 

--- a/docs/docs/helm/built-in-chart.md
+++ b/docs/docs/helm/built-in-chart.md
@@ -433,6 +433,15 @@ volumes:
           storage: 1Gi
 ```
 
+### Kubernetes Volume Types
+
+Compose shorthand covers named volumes. For Kubernetes volume types it cannot express,
+such as OCI image volumes, use the per-service `x-inspect_k8s_sandbox.volumes` and
+`volumeMounts` extensions. Their list entries are passed to the chart verbatim and are
+appended after volumes derived from ordinary Compose shorthand. See [Compose to
+Helm](compose-to-helm.md#kubernetes-volume-types) for the full example and Kubernetes
+API requirements.
+
 ## Networks
 
 By default, all Pods in a Kubernetes cluster can communicate with each other. Network

--- a/docs/docs/helm/compose-to-helm.md
+++ b/docs/docs/helm/compose-to-helm.md
@@ -168,6 +168,35 @@ resources. It covers CPU and memory requests/limits (via `cpus`/`mem_limit` and
 `deploy.resources`), but has no concept of a disk (`ephemeral-storage`) request or
 limit, nor of resources such as `hugepages-*`.
 
+## Kubernetes Volume Types
+
+Use per-service `x-inspect_k8s_sandbox.volumes` and `volumeMounts` for Kubernetes
+volume types that Compose shorthand cannot express. Both values are lists passed to
+the Helm chart verbatim. They are appended after any volumes converted from the
+service's ordinary Compose `volumes` entries.
+
+For example, an OCI image volume can provide a packaged agent CLI:
+
+```yaml
+services:
+  default:
+    image: python:3.12
+    x-inspect_k8s_sandbox:
+      volumes:
+        - name: agent-cli-claude
+          image:
+            reference: example.com/agent-clis:claude-2.1.205
+            pullPolicy: IfNotPresent
+      volumeMounts:
+        - name: agent-cli-claude
+          mountPath: /opt/agent-cli/claude
+          subPath: payload
+          readOnly: true
+```
+
+The volume and mount objects must follow the Kubernetes API. Use this extension
+alongside ordinary Compose volume shorthand when both are needed.
+
 ### Swap (`memswap_limit`)
 
 `memswap_limit` is ignored (with an info-level log) because Kubernetes has no

--- a/docs/docs/helm/compose-to-helm.md
+++ b/docs/docs/helm/compose-to-helm.md
@@ -190,7 +190,6 @@ services:
       volumeMounts:
         - name: agent-cli-claude
           mountPath: /opt/agent-cli/claude
-          subPath: payload
           readOnly: true
 ```
 

--- a/src/k8s_sandbox/compose/_converter.py
+++ b/src/k8s_sandbox/compose/_converter.py
@@ -561,8 +561,8 @@ class _ServiceConverter:
 
         This is an escape hatch for expressing Kubernetes resources that the Docker
         Compose shortcuts (mem_limit/cpus/deploy.resources) cannot, most notably
-        request-only resources such as 'ephemeral-storage'. Currently only a
-        'resources' block is supported.
+        request-only resources such as 'ephemeral-storage', plus volume shapes that
+        the Compose string shorthand cannot express.
         """
         if not isinstance(extensions, dict):
             raise ComposeConverterError(
@@ -571,10 +571,22 @@ class _ServiceConverter:
             )
         if (resources := extensions.pop("resources", None)) is not None:
             self._merge_extension_resources(resources, result)
+        # Passed through verbatim: Kubernetes volume shapes that the Compose string
+        # shorthand cannot express (e.g. OCI image volumes, KEP-4639). Appended so
+        # compose-shorthand volumes are preserved.
+        for key in ("volumes", "volumeMounts"):
+            if (entries := extensions.pop(key, None)) is not None:
+                if not isinstance(entries, list):
+                    raise ComposeConverterError(
+                        f"Invalid 'x-inspect_k8s_sandbox.{key}' type: {type(entries)}. "
+                        f"Expected list. {self.context}"
+                    )
+                result[key] = [*result.get(key, []), *entries]
         if extensions:
             raise ComposeConverterError(
                 f"Unsupported key(s) in service 'x-inspect_k8s_sandbox': "
-                f"{set(extensions)}. Only 'resources' is supported. {self.context}"
+                f"{set(extensions)}. Only 'resources', 'volumes', and 'volumeMounts' "
+                f"are supported. {self.context}"
             )
 
     def _merge_extension_resources(self, src: Any, result: dict[str, Any]) -> None:

--- a/src/k8s_sandbox/compose/_converter.py
+++ b/src/k8s_sandbox/compose/_converter.py
@@ -19,6 +19,9 @@ COMPOSE_SCHEMA_PATH = (
 # per-service). Listed canonical-first only for stable error messages.
 _EXTENSION_KEYS = ("x-inspect_k8s_sandbox", "x-k8s")
 
+# These volumes are added to every service Pod by the built-in Helm chart.
+_RESERVED_EXTENSION_VOLUME_NAMES = frozenset(("coredns-config", "resolv-conf"))
+
 
 class ComposeConverterError(Exception):
     """Raised when an error occurs converting a Docker Compose file to Helm values."""
@@ -581,6 +584,17 @@ class _ServiceConverter:
                         f"Invalid 'x-inspect_k8s_sandbox.{key}' type: {type(entries)}. "
                         f"Expected list. {self.context}"
                     )
+                if key == "volumes":
+                    for entry in entries:
+                        if (
+                            isinstance(entry, dict)
+                            and entry.get("name") in _RESERVED_EXTENSION_VOLUME_NAMES
+                        ):
+                            raise ComposeConverterError(
+                                f"Volume name '{entry['name']}' in "
+                                "'x-inspect_k8s_sandbox.volumes' is reserved by the "
+                                f"Helm chart. {self.context}"
+                            )
                 result[key] = [*result.get(key, []), *entries]
         if extensions:
             raise ComposeConverterError(

--- a/test/k8s_sandbox/compose/test_converter.py
+++ b/test/k8s_sandbox/compose/test_converter.py
@@ -590,6 +590,105 @@ services:
 ### Service-level x-inspect_k8s_sandbox extension
 
 
+def test_service_extension_passes_through_volumes_and_volume_mounts(
+    tmp_path: Path,
+) -> None:
+    compose = tmp_path / "test-compose.yaml"
+    compose.write_text(
+        """
+services:
+  default:
+    image: python:3.12
+    x-inspect_k8s_sandbox:
+      volumes:
+        - name: agent-cli-claude
+          image:
+            reference: example.com/agent-clis:claude-2.1.205
+            pullPolicy: IfNotPresent
+      volumeMounts:
+        - name: agent-cli-claude
+          mountPath: /opt/agent-cli/claude
+          subPath: payload
+          readOnly: true
+""",
+        encoding="utf-8",
+    )
+    values = convert_compose_to_helm_values(compose)
+    service = values["services"]["default"]
+    assert service["volumes"] == [
+        {
+            "name": "agent-cli-claude",
+            "image": {
+                "reference": "example.com/agent-clis:claude-2.1.205",
+                "pullPolicy": "IfNotPresent",
+            },
+        }
+    ]
+    assert service["volumeMounts"] == [
+        {
+            "name": "agent-cli-claude",
+            "mountPath": "/opt/agent-cli/claude",
+            "subPath": "payload",
+            "readOnly": True,
+        }
+    ]
+
+
+def test_service_extension_appends_volumes_after_compose_shorthand(
+    tmp_compose: TmpComposeFixture,
+) -> None:
+    compose_path = tmp_compose("""
+services:
+  default:
+    image: python:3.12
+    volumes:
+      - data:/data
+    x-inspect_k8s_sandbox:
+      volumes:
+        - name: agent-cli-claude
+          image:
+            reference: example.com/agent-clis:claude-2.1.205
+            pullPolicy: IfNotPresent
+volumes:
+  data:
+""")
+
+    values = convert_compose_to_helm_values(compose_path)
+
+    assert values["services"]["default"]["volumes"] == [
+        "data:/data",
+        {
+            "name": "agent-cli-claude",
+            "image": {
+                "reference": "example.com/agent-clis:claude-2.1.205",
+                "pullPolicy": "IfNotPresent",
+            },
+        },
+    ]
+
+
+@pytest.mark.parametrize("key", ["volumes", "volumeMounts"])
+@pytest.mark.parametrize("entries", ["{name: agent-cli-claude}", "not-a-list"])
+def test_rejects_non_list_service_extension_volume_entries(
+    tmp_compose: TmpComposeFixture,
+    key: str,
+    entries: str,
+) -> None:
+    compose_path = tmp_compose(f"""
+services:
+  default:
+    image: python:3.12
+    x-inspect_k8s_sandbox:
+      {key}: {entries}
+""")
+
+    with pytest.raises(ComposeConverterError) as exc_info:
+        convert_compose_to_helm_values(compose_path)
+
+    assert f"Invalid 'x-inspect_k8s_sandbox.{key}' type" in str(exc_info.value)
+    assert "Expected list." in str(exc_info.value)
+
+
 def test_service_extension_request_only_ephemeral_storage(
     tmp_compose: TmpComposeFixture,
 ) -> None:

--- a/test/k8s_sandbox/compose/test_converter.py
+++ b/test/k8s_sandbox/compose/test_converter.py
@@ -591,11 +591,9 @@ services:
 
 
 def test_service_extension_passes_through_volumes_and_volume_mounts(
-    tmp_path: Path,
+    tmp_compose: TmpComposeFixture,
 ) -> None:
-    compose = tmp_path / "test-compose.yaml"
-    compose.write_text(
-        """
+    compose_path = tmp_compose("""
 services:
   default:
     image: python:3.12
@@ -610,10 +608,8 @@ services:
           mountPath: /opt/agent-cli/claude
           subPath: payload
           readOnly: true
-""",
-        encoding="utf-8",
-    )
-    values = convert_compose_to_helm_values(compose)
+""")
+    values = convert_compose_to_helm_values(compose_path)
     service = values["services"]["default"]
     assert service["volumes"] == [
         {

--- a/test/k8s_sandbox/compose/test_converter.py
+++ b/test/k8s_sandbox/compose/test_converter.py
@@ -667,6 +667,31 @@ volumes:
     ]
 
 
+@pytest.mark.parametrize("name", ["coredns-config", "resolv-conf"])
+def test_rejects_service_extension_chart_reserved_volume_names(
+    tmp_compose: TmpComposeFixture,
+    name: str,
+) -> None:
+    compose_path = tmp_compose(f"""
+services:
+  default:
+    image: python:3.12
+    x-inspect_k8s_sandbox:
+      volumes:
+        - name: {name}
+          emptyDir: {{}}
+""")
+
+    with pytest.raises(ComposeConverterError) as exc_info:
+        convert_compose_to_helm_values(compose_path)
+
+    message = (
+        f"Volume name '{name}' in "
+        "'x-inspect_k8s_sandbox.volumes' is reserved by the Helm chart."
+    )
+    assert message in str(exc_info.value)
+
+
 @pytest.mark.parametrize("key", ["volumes", "volumeMounts"])
 @pytest.mark.parametrize("entries", ["{name: agent-cli-claude}", "not-a-list"])
 def test_rejects_non_list_service_extension_volume_entries(

--- a/test/k8s_sandbox/resources/image-volume-compose.yaml
+++ b/test/k8s_sandbox/resources/image-volume-compose.yaml
@@ -1,0 +1,19 @@
+services:
+  default:
+    image: ubuntu:24.04
+    command: ["tail", "-f", "/dev/null"]
+    deploy:
+      resources:
+        limits:
+          memory: 128mb
+          cpus: 0.1
+    x-inspect_k8s_sandbox:
+      volumes:
+        - name: alpine-release
+          image:
+            reference: docker.io/library/alpine:3.19
+            pullPolicy: IfNotPresent
+      volumeMounts:
+        - name: alpine-release
+          mountPath: /mnt/alpine
+          readOnly: true

--- a/test/k8s_sandbox/test_volume.py
+++ b/test/k8s_sandbox/test_volume.py
@@ -20,3 +20,22 @@ async def test_volumes(sandbox: K8sSandboxEnvironment):
     result = await sandbox.read_file("/mount/test.txt")
 
     assert result == "test\n"
+
+
+@pytest_asyncio.fixture(scope="module")
+async def image_volume_sandbox() -> AsyncGenerator[K8sSandboxEnvironment, None]:
+    async with install_sandbox_environments(
+        __file__, "image-volume-compose.yaml"
+    ) as envs:
+        yield envs["default"]
+
+
+async def test_service_extension_image_volume(
+    image_volume_sandbox: K8sSandboxEnvironment,
+):
+    # Exercises the x-inspect_k8s_sandbox 'volumes'/'volumeMounts' extension end to
+    # end: Compose extension -> converter -> Helm chart -> a real Kubernetes OCI
+    # image volume (KEP-4639) mounted into the pod.
+    result = await image_volume_sandbox.read_file("/mnt/alpine/etc/alpine-release")
+
+    assert result.startswith("3.19.")


### PR DESCRIPTION
## Summary
- pass per-service `x-inspect_k8s_sandbox.volumes` and `volumeMounts` into Helm values
- preserve Compose shorthand volume entries before extension entries
- reject extension volumes named `coredns-config` or `resolv-conf`, which the built-in Helm chart owns
- document OCI image volumes without their Kubernetes 1.33-only `subPath` option, and validate non-list extension values

## Verification
- Exercised the converter with a mixed shorthand and OCI image-volume Compose file; the extension entries were appended and preserved verbatim.
- Exercised rejection of extension volumes using the Helm chart's reserved names.
- Exercised the extension end to end against a real Kubernetes cluster (server v1.35, containerd 2.1): a Compose file's `x-inspect_k8s_sandbox` volumes/volumeMounts extension converted to Helm values, installed via the chart, and the resulting pod mounted a real OCI image volume (KEP-4639) whose content was read back successfully (`test/k8s_sandbox/test_volume.py::test_service_extension_image_volume`).
  - The existing `test_volumes` test (shared-PVC Compose-shorthand path, untouched by this PR) was also attempted against the same cluster and failed on an unrelated, pre-existing gap: the chart's shared-volume PVC requests `StorageClass "nfs-csi"`, which that cluster does not provision (only `gp2`). That is a limitation of the verification cluster, not a regression introduced by this PR.
- `uv run --extra dev pytest test/k8s_sandbox/compose/test_converter.py -q`
- `uv run --extra dev pytest test/k8s_sandbox/test_volume.py::test_service_extension_image_volume -m req_k8s -v`
- `uv run --extra dev ruff check src/k8s_sandbox/compose/_converter.py test/k8s_sandbox/compose/test_converter.py && uv run --extra dev ruff format --check src/k8s_sandbox/compose/_converter.py test/k8s_sandbox/compose/test_converter.py`
- `uv --directory docs run mkdocs build --strict`
