### PR TITLE
fix(helm): make network isolation subtractive so layered policies are not shadowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- `network_mode: none` isolation is now enforced by omitting any ingress allow for the
+  service rather than an unconditional ingress deny. Observable behaviour is unchanged
+  for a chart used on its own, but a network policy layered on top of this chart (e.g.
+  to allow a specific port) now takes effect instead of being silently shadowed.
 - **BREAKING CHANGE**: The CoreDNS sidecar now runs as UID/GID 65532 on a read-only root
   filesystem with only `NET_BIND_SERVICE`. A custom `corednsImage` must run under that
   context; set the new `corednsSecurityContext` if it cannot. The default image moves

--- a/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
@@ -138,7 +138,7 @@ spec:
     - {}
 {{- if .Values.networks }}
   {{- range $svcName, $svc := .Values.services }}
-    {{- if $svc.networks }}
+    {{- if and $svc.networks (not $svc.networkIsolated) }}
       {{- range $net := $svc.networks }}
 ---
 apiVersion: cilium.io/v2

--- a/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
@@ -190,6 +190,7 @@ spec:
 {{- else }}
   {{- /* No global networks: allow same-sandbox ingress per service (no network scoping) */}}
   {{- range $svcName, $svc := .Values.services }}
+  {{- if not $svc.networkIsolated }}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -230,6 +231,7 @@ spec:
           - type: 128
             family: IPv6
   {{- end }}
+  {{- end }}
 {{- end }}
 {{- range $svcName, $svc := .Values.services }}
 {{- if $svc.networkIsolated }}
@@ -244,15 +246,18 @@ metadata:
     {{- toYaml $.Values.labels | nindent 4 }}
 spec:
   description: |
-    Deny all ingress and egress for isolated service "{{ $svcName }}" (network_mode: none).
+    Isolate service "{{ $svcName }}" (network_mode: none): no ingress allow is emitted
+    for this service, so sandbox-default-deny-ingress denies all ingress to it. Egress
+    is explicitly denied below. This is deliberately subtractive rather than an
+    unconditional ingressDeny, so that a policy layered on top of this chart (e.g. an
+    allow for a specific port) is not shadowed -- Cilium resolves deny before allow,
+    with no exception mechanism, so an ingressDeny here would silently defeat any such
+    allow.
   endpointSelector:
     matchLabels:
       io.kubernetes.pod.namespace: {{ $.Release.Namespace }}
       {{- include "agentEnv.selectorLabels" $ | nindent 6 }}
       inspect/service: {{ $svcName }}
-  ingressDeny:
-    - fromEntities:
-        - all
   egressDeny:
     - toEntities:
         - all

--- a/test/k8s_sandbox/helm_chart/resources/network-isolated-with-global-network-values.yaml
+++ b/test/k8s_sandbox/helm_chart/resources/network-isolated-with-global-network-values.yaml
@@ -1,0 +1,12 @@
+networks:
+  tasknet: {}
+services:
+  isolated-service:
+    image: my-isolated-image:1.0.0
+    networkIsolated: true
+    networks:
+      - tasknet
+  normal-service:
+    image: my-normal-image:1.0.0
+    networks:
+      - tasknet

--- a/test/k8s_sandbox/helm_chart/test_helm_chart.py
+++ b/test/k8s_sandbox/helm_chart/test_helm_chart.py
@@ -567,16 +567,30 @@ def test_network_isolated_service(chart_dir: Path, test_resources_dir: Path) -> 
         isolate_policy["metadata"]["name"]
         == "agent-env-my-release-svc-isolated-service-isolate"
     )
-    # ingressDeny and egressDeny deny all traffic from/to all entities
-    assert isolate_policy["spec"]["ingressDeny"] == [{"fromEntities": ["all"]}]
+    # Ingress is denied subtractively: no allow selects the isolated service, so
+    # sandbox-default-deny-ingress denies it. No ingressDeny is emitted -- an
+    # unconditional ingressDeny would shadow any allow layered on top of this chart.
+    assert "ingressDeny" not in isolate_policy["spec"]
     assert isolate_policy["spec"]["egressDeny"] == [{"toEntities": ["all"]}]
 
-    # Verify normal-service doesn't have isolate policy
+    # No per-service ingress allow is rendered at all for the isolated service.
+    isolated_ingress_policies = [
+        cnp
+        for cnp in cnps
+        if cnp["metadata"]["name"].endswith("-svc-isolated-service-ingress")
+    ]
+    assert isolated_ingress_policies == []
+
+    # Verify normal-service doesn't have isolate policy, and still gets its ingress
+    # allow.
     normal_service_policies = [
         cnp for cnp in cnps if "normal-service" in cnp["metadata"]["name"]
     ]
     assert len(normal_service_policies) == 1
     assert "isolate" not in normal_service_policies[0]["metadata"]["name"]
+    assert normal_service_policies[0]["metadata"]["name"].endswith(
+        "-svc-normal-service-ingress"
+    )
 
     normal_spec = normal_service_policies[0]["spec"]
     assert normal_spec.get("ingress") != []

--- a/test/k8s_sandbox/helm_chart/test_helm_chart.py
+++ b/test/k8s_sandbox/helm_chart/test_helm_chart.py
@@ -597,6 +597,36 @@ def test_network_isolated_service(chart_dir: Path, test_resources_dir: Path) -> 
     assert normal_spec.get("egress") != []
 
 
+def test_network_isolated_service_joining_a_global_network(
+    chart_dir: Path, test_resources_dir: Path
+) -> None:
+    # A service can be networkIsolated and still list `networks` (nothing in the chart
+    # rejects the combination), which renders through the .Values.networks branch
+    # rather than the no-networks branch covered by test_network_isolated_service. That
+    # branch's per-network ingress allow must also be skipped for an isolated service.
+    documents = _run_helm_template(
+        chart_dir,
+        test_resources_dir / "network-isolated-with-global-network-values.yaml",
+    )
+
+    cnps = _get_documents(documents, "CiliumNetworkPolicy")
+
+    isolated_ingress_policies = [
+        cnp
+        for cnp in cnps
+        if cnp["metadata"]["name"].endswith("-svc-isolated-service-tasknet-ingress")
+    ]
+    assert isolated_ingress_policies == []
+
+    normal_ingress_policies = [
+        cnp
+        for cnp in cnps
+        if cnp["metadata"]["name"].endswith("-svc-normal-service-tasknet-ingress")
+    ]
+    assert len(normal_ingress_policies) == 1
+    assert normal_ingress_policies[0]["spec"]["ingress"] != []
+
+
 def test_allow_domains_egress_enforces_identity_on_pinned_ips(
     chart_dir: Path, test_resources_dir: Path
 ) -> None:

--- a/test/k8s_sandbox/helm_chart/test_helm_chart.py
+++ b/test/k8s_sandbox/helm_chart/test_helm_chart.py
@@ -551,6 +551,26 @@ def test_rejects_names_that_can_inject_rendered_configuration(
     assert "values don't meet the specifications of the schema" in excinfo.value.stderr
 
 
+def test_default_deny_ingress_selects_every_pod(chart_dir: Path) -> None:
+    documents = _run_helm_template(chart_dir)
+
+    cnps = _get_documents(documents, "CiliumNetworkPolicy")
+    default_deny = next(
+        cnp
+        for cnp in cnps
+        if cnp["metadata"]["name"].endswith("-sandbox-default-deny-ingress")
+    )
+
+    # Release-wide selector, not per-service: no inspect/service label, so this
+    # selects every sandbox pod (isolated or not).
+    match_labels = default_deny["spec"]["endpointSelector"]["matchLabels"]
+    assert "inspect/service" not in match_labels
+
+    # An empty ingress rule enables default-deny while allowing nothing -- this is
+    # the shape the whole subtractive-isolation model rests on.
+    assert default_deny["spec"]["ingress"] == [{}]
+
+
 def test_network_isolated_service(chart_dir: Path, test_resources_dir: Path) -> None:
     documents = _run_helm_template(
         chart_dir, test_resources_dir / "network-isolated-values.yaml"
@@ -558,28 +578,7 @@ def test_network_isolated_service(chart_dir: Path, test_resources_dir: Path) -> 
 
     cnps = _get_documents(documents, "CiliumNetworkPolicy")
 
-    # Verify isolate-service has isolate policy
-    isolate_policy = next(
-        (cnp for cnp in cnps if cnp["metadata"]["name"].endswith("-isolate")), None
-    )
-    assert isolate_policy is not None
-    assert (
-        isolate_policy["metadata"]["name"]
-        == "agent-env-my-release-svc-isolated-service-isolate"
-    )
-    # Ingress is denied subtractively: no allow selects the isolated service, so
-    # sandbox-default-deny-ingress denies it. No ingressDeny is emitted -- an
-    # unconditional ingressDeny would shadow any allow layered on top of this chart.
-    assert "ingressDeny" not in isolate_policy["spec"]
-    assert isolate_policy["spec"]["egressDeny"] == [{"toEntities": ["all"]}]
-
-    # No per-service ingress allow is rendered at all for the isolated service.
-    isolated_ingress_policies = [
-        cnp
-        for cnp in cnps
-        if cnp["metadata"]["name"].endswith("-svc-isolated-service-ingress")
-    ]
-    assert isolated_ingress_policies == []
+    _assert_isolated(cnps, "isolated-service")
 
     # Verify normal-service doesn't have isolate policy, and still gets its ingress
     # allow.
@@ -592,9 +591,7 @@ def test_network_isolated_service(chart_dir: Path, test_resources_dir: Path) -> 
         "-svc-normal-service-ingress"
     )
 
-    normal_spec = normal_service_policies[0]["spec"]
-    assert normal_spec.get("ingress") != []
-    assert normal_spec.get("egress") != []
+    assert normal_service_policies[0]["spec"]["ingress"]
 
 
 def test_network_isolated_service_joining_a_global_network(
@@ -611,12 +608,7 @@ def test_network_isolated_service_joining_a_global_network(
 
     cnps = _get_documents(documents, "CiliumNetworkPolicy")
 
-    isolated_ingress_policies = [
-        cnp
-        for cnp in cnps
-        if cnp["metadata"]["name"].endswith("-svc-isolated-service-tasknet-ingress")
-    ]
-    assert isolated_ingress_policies == []
+    _assert_isolated(cnps, "isolated-service")
 
     normal_ingress_policies = [
         cnp
@@ -795,6 +787,49 @@ def _run_helm_template(
 
 def _get_documents(documents: list[Any], doc_type_filter: str) -> list[dict[str, Any]]:
     return [doc for doc in documents if doc["kind"] == doc_type_filter]
+
+
+def _selector_matches_service(match_labels: dict[str, Any], service_name: str) -> bool:
+    """Whether an endpointSelector's matchLabels selects `service_name`'s pod.
+
+    It selects the pod if it carries no inspect/service label (release-wide, e.g.
+    sandbox-default-deny-ingress) or if that label names this service.
+    """
+    service_label = match_labels.get("inspect/service")
+    return service_label is None or service_label == service_name
+
+
+def _assert_isolated(cnps: list[dict[str, Any]], service_name: str) -> None:
+    """Assert `service_name` is fully network-isolated.
+
+    Its isolate policy denies egress (without an ingressDeny, which would shadow a
+    layered-on allow), and -- walking every rendered policy by selector rather than
+    by name, so a stray allow under an unexpected name can't hide -- the only
+    ingress-bearing policy that selects it is the release-wide
+    sandbox-default-deny-ingress.
+    """
+    isolate_policy = next(
+        (
+            cnp
+            for cnp in cnps
+            if cnp["metadata"]["name"].endswith(f"-svc-{service_name}-isolate")
+        ),
+        None,
+    )
+    assert isolate_policy is not None
+    assert "ingressDeny" not in isolate_policy["spec"]
+    assert isolate_policy["spec"]["egressDeny"] == [{"toEntities": ["all"]}]
+
+    selecting_policies = [
+        cnp["metadata"]["name"]
+        for cnp in cnps
+        if "ingress" in cnp["spec"]
+        and _selector_matches_service(
+            cnp["spec"]["endpointSelector"]["matchLabels"], service_name
+        )
+    ]
+    assert len(selecting_policies) == 1
+    assert selecting_policies[0].endswith("-sandbox-default-deny-ingress")
 
 
 def _chart_version(chart_dir: Path) -> str:


### PR DESCRIPTION
## Problem

A service with `network_mode: none` gets `networkIsolated: true`, which renders `svc-<n>-isolate` with a
blanket `ingressDeny: [{fromEntities: [all]}]`. Cilium resolves deny before allow with no exception
mechanism, so **any** ingress policy layered on top of this chart by a deployment is silently shadowed.

METR hit this attaching a policy that allows TCP 2222 to the `default` service so a human evaluator can SSH
into a sandbox and perform the task by hand. On a task that isolates `default`, the sandbox listens on 2222
and drops every packet, while the tooling still prints a connect command. Advertised, and silently
impossible.

## Why not just carve a port out of the deny

That was tried first and cannot work. Two reasons:

1. This chart's per-service ingress allow emits `toPorts` only under `{{- if $svc.ports }}`, so for a
   service with no declared ports — the normal case for `network_mode: none` — it is an **L3 allow covering
   every IP protocol**. A port-scoped deny cannot cancel it.
2. Cilium's `toPorts` cannot express a deny for protocols like GRE, ESP or AH, so a port-scoped deny can
   never reach parity with the blanket one.

## Change

Make isolation subtractive: stop granting the isolated service anything and let the chart's existing
default-deny do the work.

- Skip the per-service `svc-<n>-ingress` allow entirely when `$svc.networkIsolated` is set. Previously it
  was rendered and then cancelled by the blanket deny. (The `.Values.networks` branch already behaves this
  way, since a service cannot set both `network_mode: none` and `networks`.)
- Drop `ingressDeny` from `svc-<n>-isolate`, keeping `egressDeny` unchanged.

`sandbox-default-deny-ingress` already selects every pod in the release with `ingress: [- {}]`, so with no
allow selecting it, an isolated service is denied everything — including the protocols a `toPorts` deny
cannot express.

## Behaviour change

For a chart used on its own, observable behaviour is unchanged: the service was fully denied before and is
fully denied now. What changes is robustness. Isolation now rests on "no allow selects this service" rather
than on an unconditional deny, so a policy layered on top **will** take effect rather than being shadowed.
That is the point of the change, but it is a real semantic difference and is called out in the CHANGELOG.

## Verification

Beyond the chart tests, the resulting policy shape was verified on a live cluster running Cilium v1.18.4,
with two pods from a real image and the sandbox running a real SSH daemon on 2222 and 8000:

| | result |
|---|---|
| external → 2222 | open, full SSH key exchange completes |
| external → 8000 | blocked |
| sibling pod → 2222 | open (only because a deployment-supplied allow permits it) |
| sibling pod → 8000 | blocked |
| sibling pod → ICMP echo | blocked, with no ICMP rule present at all |
| egress from the isolated pod | dead (DNS and HTTPS both fail) |

Reply traffic on an allowed inbound connection flows despite the retained blanket `egressDeny`, because
Cilium is conntrack-based.

`test_network_isolated_service` is updated to assert the new shape, and additionally that no ingress allow
is rendered for the isolated service while a normal service still gets one.

`uv run pytest test/k8s_sandbox/helm_chart test/k8s_sandbox/compose -q` → 167 passed.