### PR TITLE
Ask contributors to verify runtime-behaviour claims against a real cluster

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,23 @@
 # Repo guidance for coding agents
 
+Read [CONTRIBUTING.md](CONTRIBUTING.md) too — dev setup, test invocation and the
+reasoning behind the rules below are there.
+
+## Before you open a PR
+
+1. Does your change assert something about runtime behaviour — what Kubernetes, Helm or
+   Cilium actually does? Run it against a real cluster (minikube is fine) and paste the
+   output. Reading upstream source is not evidence, and neither is a Helm render test,
+   however green.
+2. Show it failing without your change and passing with it. If you can't, say so
+   explicitly in the PR description.
+3. If you can't run against a cluster, don't open the PR. Open an issue with your
+   reasoning and stop.
+4. Report what you actually ran, verbatim, including which tests were skipped. Never
+   describe a run you didn't perform.
+5. Note the tooling you used. If you ran review passes over your own change, say which
+   model and what they found.
+
 ## Changelog (`CHANGELOG.md`)
 
 New work goes under the `## Unreleased` heading. Each entry is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,35 @@ in our [Inspect
 Community](https://join.slack.com/t/inspectcommunity/shared_invite/zt-2w9eaeusj-4Hu~IBHx2aORsKz~njuz4g)
 Slack workspace.
 
-## Development
+## Before you open a PR
+
+This provider is a thin layer over infrastructure we don't control — Kubernetes, Helm
+and Cilium. Most bugs in it are claims about what that infrastructure does at runtime,
+and those are cheap to get wrong from reading documentation or upstream source.
+
+If your change asserts a runtime behaviour, we need the observation, not the derivation.
+
+- **Run it against a real cluster and paste what you saw.** minikube is fine (see
+  below); the `req_k8s` marker identifies the tests that need a cluster. A test without
+  that marker is not evidence about runtime behaviour, however green it is.
+- **Show the negative control.** Give the result with your change and without it. If you
+  can't produce a run that fails on `main` and passes on your branch, say so and explain
+  why.
+- **If you can't run it, open an issue rather than a PR.** Reasoning, upstream source
+  links and a proposed patch are all welcome in an issue. A confidently argued wrong
+  premise costs more than no PR at all, because it has to be disproved before it can be
+  declined.
+
+The trap specific to this repo is the Helm render tests. They assert what YAML we emit,
+not what the cluster enforces: two manifests that render differently can enforce
+identically, and two that look equivalent can behave differently. A render test can't
+settle an enforcement question in either direction.
+
+A sufficient experiment looks like: baseline without the change, the behaviour with it,
+then baseline again to show the effect went away — several attempts per phase, plus a
+positive control proving the test could have observed a difference if there were one.
+
+## Getting started
 
 This project uses [uv](https://github.com/astral-sh/uv) for Python packaging.
 
@@ -16,13 +44,13 @@ Run this beforehand:
 uv sync --extra dev
 ```
 
-You then can either source the venv with
+The commands below are written as `uv run --extra dev ...`, which works whether or not
+the venv is activated (`--extra dev` is needed because the dev tools are an optional
+extra here). Drop the prefix if you'd rather activate the venv:
 
 ```
 source .venv/bin/activate
 ```
-
-or prefix your pytest (etc.) commands with `uv run ...`
 
 If you don't have access to a K8s cluster, you can develop using
 [minikube](https://minikube.sigs.k8s.io/). If you're using VS Code, the devcontainer
@@ -33,7 +61,7 @@ If you don't have access to a K8s cluster, you can develop using
 This project uses [pytest](https://docs.pytest.org/en/stable/). To run all tests:
 
 ```bash
-pytest
+uv run --extra dev pytest
 ```
 
 (AISI users: first `unset INSPECT_TELEMETRY INSPECT_API_KEY_OVERRIDE INSPECT_REQUIRED_HOOKS`)
@@ -42,7 +70,7 @@ These tests are automatically run as part of CI. Some tests require a K8s cluste
 available. To skip these tests:
 
 ```bash
-pytest -m "not req_k8s"
+uv run --extra dev pytest -m "not req_k8s"
 ```
 
 ### Test Timeouts
@@ -54,7 +82,7 @@ that isn't overloaded, this should be adequate.
 Override if needed:
 
 ```bash
-INSPECT_HELM_TIMEOUT=300 pytest
+INSPECT_HELM_TIMEOUT=300 uv run --extra dev pytest
 ```
 
 ## Linting & Formatting
@@ -63,8 +91,8 @@ INSPECT_HELM_TIMEOUT=300 pytest
 checks manually:
 
 ```bash
-ruff check .
-ruff format .
+uv run --extra dev ruff check .
+uv run --extra dev ruff format .
 ```
 
 These checks are automatically run as part of CI and pre-commit hooks.
@@ -75,7 +103,7 @@ These checks are automatically run as part of CI and pre-commit hooks.
 manually:
 
 ```bash
-mypy .
+uv run --extra dev mypy .
 ```
 
 ## Pre-commit Hooks and Continuous Integration
@@ -86,7 +114,7 @@ and code quality.
 Installing the pre-commit hooks locally is not mandatory, but it is recommended.
 
 ```bash
-pre-commit install
+uv run --extra dev pre-commit install
 ```
 
 So long as the checks pass, feel free to use alternative tooling locally.
@@ -94,7 +122,7 @@ So long as the checks pass, feel free to use alternative tooling locally.
 To run these checks manually:
 
 ```bash
-pre-commit run --all-files
+uv run --extra dev pre-commit run --all-files
 ```
 
 These hooks are automatically run as part of CI. When run in CI, no changes are made to


### PR DESCRIPTION
Document the evidence bar for a PR that asserts runtime behaviour: an observation against
a real cluster, not a derivation from documentation or upstream source. This provider is a
thin layer over Kubernetes, Helm and Cilium, so most bugs in it are claims about what that
infrastructure does at runtime — and the Helm render tests, which assert what YAML we emit
rather than what the cluster enforces, can look like evidence for such a claim without
being any.

The rule goes in CONTRIBUTING.md with its rationale (a human reasoning from upstream source
without testing makes the same error) and in AGENTS.md as a pre-PR checklist, because agents
reliably read that file and often don't read CONTRIBUTING.md. Companion PRs do the same for the
ec2 and proxmox providers, keyed to their own infrastructure:
UKGovernmentBEIS/inspect_ec2_sandbox#42 and UKGovernmentBEIS/inspect_proxmox_sandbox#114.

Also aligns this guide with those two while I'm here: `Getting started` / `Testing`
headings, and the commands are now `uv run --extra dev ...` so they work without activating
the venv — plain `uv run` fails here, because the dev tools are an optional extra rather
than a dependency group, and `uv run` re-syncs without them.

Docs only. Verified the commands the new text quotes: `uv run --extra dev` ruff check /
ruff format --check / pre-commit run --all-files all pass.

Unrelated, noticed while checking: `test/k8s_sandbox/test_kubernetes_api.py` imports
`Self` from `typing`, which needs Python 3.11, but the package declares
`requires-python = ">=3.10"`. On a 3.10 interpreter the whole module fails to collect. CI
only runs 3.11, so it doesn't catch it. Not fixing it here.

### Agent review
- Reviewer: none. Author is Claude Opus 5 (Claude Code) working interactively with me; no
  separate review pass over this docs change.
