### PR TITLE
fix: uninstall the release when a Helm install does not complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Raise an error when a conflicting `max_pod_ops` setting would otherwise be ignored.
 - Fix a service's `args` (compose `command:`) reaching the container as a single
   space-joined string instead of a list.
+- Fix an install failing with `exists and cannot be imported into the current
+  release` after an earlier install attempt for the same sandbox failed.
 
 ## 2026-08-12 0.13.0
 

--- a/src/k8s_sandbox/_helm.py
+++ b/src/k8s_sandbox/_helm.py
@@ -226,13 +226,12 @@ class Release:
                                     raise
                                 attempt += 1
                                 await asyncio.sleep(INSTALL_RETRY_DELAY_SECONDS)
-        except asyncio.CancelledError:
-            # When an eval is cancelled (either by user or by an error), the timing of
-            # uninstall operations can be interleaved with existing `helm install`
-            # processes. Uninstall the release now that we know the install process has
-            # terminated.
+        except (asyncio.CancelledError, RuntimeError, _ResourceQuotaModifiedError):
+            # Helm may have left a release owning the resources it created. Uninstall
+            # it now that we know the install process has terminated.
             log_trace(
-                "Helm install was cancelled; uninstalling.", release=self.release_name
+                "Helm install did not complete; uninstalling.",
+                release=self.release_name,
             )
             await self.uninstall(quiet=True)
             raise

--- a/test/k8s_sandbox/test_helm.py
+++ b/test/k8s_sandbox/test_helm.py
@@ -67,7 +67,7 @@ async def test_helm_install_error(
         with pytest.raises(RuntimeError) as excinfo:
             await uninstallable_release.install()
 
-    assert spy.call_count == 1
+    assert spy.call_count == 2
     assert "not found" in str(excinfo.value)
     assert "not found" in log_err.text
 
@@ -87,6 +87,15 @@ async def test_cancelling_install_uninstalls():
     assert release.release_name not in await get_all_release_names(
         get_default_namespace(context_name=None), None
     )
+
+
+@pytest.mark.req_k8s
+async def test_failed_install_uninstalls(uninstallable_release: Release) -> None:
+    with patch("k8s_sandbox._helm.uninstall", wraps=uninstall) as spy:
+        with pytest.raises(RuntimeError):
+            await uninstallable_release.install()
+
+    assert spy.call_count == 1
 
 
 @pytest.mark.req_k8s
@@ -124,12 +133,13 @@ async def test_helm_resourcequota_retries(uninstallable_release: Release) -> Non
 
     with patch("k8s_sandbox._helm.INSTALL_RETRY_DELAY_SECONDS", 0):
         with patch(
-            "k8s_sandbox._helm._run_subprocess", return_value=fail_result
+            "k8s_sandbox._helm._run_subprocess",
+            side_effect=[fail_result] * 3 + [ExecResult(True, 0, "", "")],
         ) as mock:
             with pytest.raises(Exception) as excinfo:
                 await uninstallable_release.install()
 
-    assert mock.call_count == 3
+    assert mock.call_count == 4
     assert "resourcequotas" in str(excinfo.value)
 
 


### PR DESCRIPTION
`Release.install()` uninstalls when an install is cancelled, but not when one fails. The failed release stays in the namespace owning everything Helm created before it stopped, and nothing removes it until the whole eval shuts down — `HelmReleaseManager.uninstall_all()` runs from Inspect's `startup_sandbox_environments` shutdown hook, once per `eval()` rather than once per task run.

Those resources keep their names, and `sample_init` builds a `Release` with a fresh random release name for every attempt, so a later attempt is always a different release and can never adopt them:

```
Error: INSTALLATION FAILED: Unable to continue with install:
ConfigMap "..." in namespace "..." exists and cannot be imported into the current release
```

Any fixed-name entry in `additionalResources` is exposed, as is a pull secret injected by a caller. Since `eval_set` retries a task ten times by default, one failed install becomes ten identical failures, and the surfaced error is the collision rather than whatever went wrong first.

`uninstall()` already documents this as expected behaviour:

> When a helm release fails to install (or the user cancels the eval), this uninstall function will still be called, so these errors are common and result in error desensitisation.

It was only wired for the cancel half. This adds the two exception types that mean Helm ran and did not finish. Errors raised before Helm is invoked — an invalid `INSPECT_HELM_LABELS`, for instance — are deliberately still not caught, since there is no release to remove and `test_helm_labels_cannot_override_inspect_sandbox` would otherwise see a `helm uninstall` error in place of its `ValueError`. `--ignore-not-found` already makes the uninstall a no-op when Helm created nothing.

Two existing tests count `_run_subprocess` calls that now include the uninstall. `test_helm_resourcequota_retries` mocked every call as failing, which would have made the uninstall fail too and mask the resourcequota error it asserts on, so its mock now succeeds on the uninstall.

`ruff check`, `ruff format --check`, `mypy` and `pre-commit run --all-files` are clean; `pytest -m "not req_k8s"` passes (414).

The `req_k8s` tests were run against a local `kind` cluster with the Cilium CRDs applied (kind's default CNI is kindnet, so without them the chart's `CiliumNetworkPolicy` resources cannot be built and no install succeeds).

`test/k8s_sandbox/test_helm.py` gives **82 passed, 2 failed** on this branch. The two failures are `test_helm_labels_appear_on_release_secret[...]`, and they fail identically on an unmodified `main` — so this branch matches baseline exactly. `test_failed_install_uninstalls` (added here), `test_cancelling_install_uninstalls`, `test_helm_install_error` and `test_helm_resourcequota_retries` all pass.
