### PR TITLE
Stop sandboxes from seeing their own Kubernetes namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- `network_mode: none` isolation is now enforced by omitting any ingress allow for the
+  service rather than an unconditional ingress deny. Observable behaviour is unchanged
+  for a chart used on its own, but a network policy layered on top of this chart (e.g.
+  to allow a specific port) now takes effect instead of being silently shadowed.
 - `INSPECT_POD_RESTART_CHECK=false` skips the pre-operation pod read inside
   `read_file()` / `write_file()`, for deployments where that per-op
   `read_namespaced_pod` call becomes a load problem on the Kubernetes API server at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@
 - `exec(user=...)` no longer wraps the shell in `runuser` when the container is already
   running as that user. `runuser` calls `setgroups(2)`, which needs `CAP_SETGID` even
   for a root -> root switch, so the unconditional wrapper made every `exec(user=...)`
-  fail in a container whose capabilities had been dropped. A missing `runuser`, a
-  missing `CAP_SETGID` and an unknown user are now each reported with an explanation
+  fail in a container whose capabilities had been dropped. On that path the process
+  environment is the container's rather than one `runuser` has reset (`HOME`, `USER`,
+  supplementary groups). A dropped `CAP_SETGID` is now reported with an explanation
   rather than a raw `runuser` error.
 
 ## 2026-08-12 0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@
 - The CoreDNS sidecar no longer serves its `ready` endpoint on port 8181, and refuses
   queries beyond 1000 concurrent.
 - Raise an error when a conflicting `max_pod_ops` setting would otherwise be ignored.
+- `exec(user=...)` no longer wraps the shell in `runuser` when the container is already
+  running as that user. `runuser` calls `setgroups(2)`, which needs `CAP_SETGID` even
+  for a root -> root switch, so the unconditional wrapper made every `exec(user=...)`
+  fail in a container whose capabilities had been dropped. A missing `runuser`, a
+  missing `CAP_SETGID` and an unknown user are now each reported with an explanation
+  rather than a raw `runuser` error.
 
 ## 2026-08-12 0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Sandbox pods no longer see their Kubernetes namespace. The kubelet was writing the
+  pod's `<pod>.<subdomain>.<namespace>.svc.cluster.local` FQDN into `/etc/hosts`, so an
+  agent under evaluation could read whatever the namespace name gives away (e.g. the
+  model or benchmark being run). Pods no longer have a subdomain, so the kubelet writes
+  a plain `<pod IP> <pod name>` instead. Service-to-service DNS is unaffected. The
+  per-pod DNS name `<pod>.<service>.<namespace>.svc.cluster.local` no longer resolves —
+  nothing in this chart used it, but a deployment that created its own governing
+  Service to reach individual pods by name must now use the pod IP.
 - `network_mode: none` isolation is now enforced by omitting any ingress allow for the
   service rather than an unconditional ingress deny. Observable behaviour is unchanged
   for a chart used on its own, but a network policy layered on top of this chart (e.g.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@
   for a root -> root switch, so the unconditional wrapper made every `exec(user=...)`
   fail in a container whose capabilities had been dropped. On that path the process
   environment is the container's rather than one `runuser` has reset (`HOME`, `USER`,
-  supplementary groups). A dropped `CAP_SETGID` is now reported with an explanation
-  rather than a raw `runuser` error.
+  supplementary groups). A dropped `CAP_SETGID` and a non-root container are now
+  logged as warnings and returned as a failed `ExecResult` rather than raised, so a
+  caller that probes with a user and falls back (as inspect-ai does when injecting
+  its sandbox tools) can do so. An unknown user and a missing `runuser` still raise.
 
 ## 2026-08-12 0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- `INSPECT_POD_RESTART_CHECK=false` skips the pre-operation pod read inside
+  `read_file()` / `write_file()`, for deployments where that per-op
+  `read_namespaced_pod` call becomes a load problem on the Kubernetes API server at
+  high concurrency. Defaults to enabled, so behaviour is unchanged unless set.
+  `exec()` always performs the check regardless.
+
 - **BREAKING CHANGE**: The CoreDNS sidecar now runs as UID/GID 65532 on a read-only root
   filesystem with only `NET_BIND_SERVICE`. A custom `corednsImage` must run under that
   context; set the new `corednsSecurityContext` if it cannot. The default image moves

--- a/docs/docs/design/limitations.md
+++ b/docs/docs/design/limitations.md
@@ -178,8 +178,14 @@ started with is **not recommended**. Generally, specifying users in tool definit
 result in undesirable coupling between your tools and sandbox.
 
 That said, if you need to run commands as different users, the `user` parameter to
-`exec()` is supported. However, you must run the container as root and ensure that
-`runuser` is installed in the container.
+`exec()` is supported. To switch to a *different* user, you must run the container as
+root, ensure that `runuser` is installed in the container, and keep `CAP_SETGID` — the
+switch goes through `runuser`, which calls `setgroups(2)`. A container with
+`capabilities: {drop: [ALL]}` therefore cannot switch users.
+
+Naming the user the container already runs as needs none of those: that case skips
+`runuser` entirely, so it works on a capability-dropped or non-root container, and on an
+image with no `runuser` installed.
 
 ## Images are not automatically built, tagged or pushed
 

--- a/src/k8s_sandbox/_pod/execute.py
+++ b/src/k8s_sandbox/_pod/execute.py
@@ -9,13 +9,41 @@ from inspect_ai.util import SandboxEnvironmentLimits as limits
 from kubernetes.stream.ws_client import WSClient  # type: ignore[import-untyped]
 
 from k8s_sandbox._pod.buffer import LimitedBuffer
-from k8s_sandbox._pod.error import ExecutableNotFoundError, PodError
+from k8s_sandbox._pod.error import PodError
 from k8s_sandbox._pod.get_returncode import get_returncode
 from k8s_sandbox._pod.op import PodOperation
 
 COMPLETED_SENTINEL = "completed-sentinel-value"
 COMPLETED_SENTINEL_PATTERN = re.compile(rf"<{COMPLETED_SENTINEL}-(\d+)>")
 EXEC_USER_URL = "https://k8s-sandbox.aisi.org.uk/design/limitations#exec-user"
+
+
+def _shell_command(user: str | None) -> list[str]:
+    """The command to open the interactive shell an exec() runs inside.
+
+    When a user is requested, only reach for `runuser` if the container is not
+    already running as that user. `runuser` calls setgroups(2), which needs
+    CAP_SETGID even when switching root -> root, so an unconditional wrapper
+    makes every exec(user=...) fail in a container whose capabilities have been
+    dropped -- a common hardening posture, and one where the switch was a no-op
+    anyway.
+
+    The check runs in the container rather than here so that it costs no extra
+    round trip. `sh -c` takes its script from argv, so stdin reaches whichever
+    shell is exec'd unread, and the caller's protocol is unchanged.
+    """
+    if user is None:
+        return ["/bin/sh"]
+    quoted = shlex.quote(user)
+    # A missing or unusual `id` leaves the substitution empty, which simply
+    # falls through to `runuser` -- the behaviour before this check existed.
+    return [
+        "/bin/sh",
+        "-c",
+        f'if [ "$(id -un 2>/dev/null)" = {quoted} ] '
+        f'|| [ "$(id -u 2>/dev/null)" = {quoted} ]; then exec /bin/sh; fi; '
+        f"exec runuser -u {quoted} -- /bin/sh",
+    ]
 
 
 class ExecuteOperation(PodOperation):
@@ -38,28 +66,18 @@ class ExecuteOperation(PodOperation):
 
     @contextmanager
     def _interactive_shell(self, user: str | None) -> Generator[WSClient, None, None]:
-        command = ["/bin/sh"]
-        if user is not None:
-            command = ["runuser", "-u", user] + command
-        try:
-            yield from self.create_websocket_client_for_exec(
-                command=command,
-                stderr=True,
-                stdin=True,
-                stdout=True,
-                # Leave stdout and stderr as binary. Has no effect on stdin.
-                binary=True,
-            )
-        # Raised if /bin/sh or runuser cannot be found in the Pod (not if a
-        # user-supplied) command cannot be found.
-        except ExecutableNotFoundError as e:
-            if 'error finding executable "runuser"' in str(e):
-                raise RuntimeError(
-                    f"When a user parameter ('{user}') is provided to exec(), the "
-                    f"runuser binary must be installed in the container. Docs: "
-                    f"{EXEC_USER_URL}"
-                ) from e
-            raise
+        # ExecutableNotFoundError from here now only means /bin/sh is missing. A
+        # missing `runuser` is exec'd by the shell rather than by the API server,
+        # so it surfaces as a 127 on stderr and is handled by
+        # _check_for_runuser_error instead.
+        yield from self.create_websocket_client_for_exec(
+            command=_shell_command(user),
+            stderr=True,
+            stdin=True,
+            stdout=True,
+            # Leave stdout and stderr as binary. Has no effect on stdin.
+            binary=True,
+        )
 
     def _build_shell_script(
         self,
@@ -190,6 +208,19 @@ class ExecuteOperation(PodOperation):
             raise RuntimeError(
                 f"When a user parameter ('{user}') is provided to exec(), the "
                 f"container must be running as root. Docs: {EXEC_USER_URL}\n{stderr}"
+            )
+        if "cannot set groups" in stderr.casefold():
+            raise RuntimeError(
+                f"When a user parameter ('{user}') is provided to exec() and the "
+                f"container is not already running as that user, runuser needs "
+                f"CAP_SETGID to call setgroups(2). The container appears to have "
+                f"had its capabilities dropped. Docs: {EXEC_USER_URL}\n{stderr}"
+            )
+        if re.search(r"runuser: (not found|no such file)", stderr, re.IGNORECASE):
+            raise RuntimeError(
+                f"When a user parameter ('{user}') is provided to exec(), the "
+                f"runuser binary must be installed in the container. Docs: "
+                f"{EXEC_USER_URL}\n{stderr}"
             )
 
     def _filter_sentinel_and_returncode(self, frame: bytes) -> tuple[bytes, int | None]:

--- a/src/k8s_sandbox/_pod/execute.py
+++ b/src/k8s_sandbox/_pod/execute.py
@@ -31,6 +31,10 @@ def _shell_command(user: str | None) -> list[str]:
     The check runs in the container rather than here so that it costs no extra
     round trip. `sh -c` takes its script from argv, so stdin reaches whichever
     shell is exec'd unread, and the caller's protocol is unchanged.
+
+    `id -un` reports only the first passwd name for the uid, so a second name
+    for the same uid (root/toor) is not recognised and falls through to
+    `runuser` -- i.e. the previous behaviour, which is the safe direction.
     """
     if user is None:
         return ["/bin/sh"]
@@ -209,14 +213,18 @@ class ExecuteOperation(PodOperation):
                 f"When a user parameter ('{user}') is provided to exec(), the "
                 f"container must be running as root. Docs: {EXEC_USER_URL}\n{stderr}"
             )
-        if "cannot set groups" in stderr.casefold():
+        # Anchored on the `runuser: ` prefix like the arms above it: `newgrp`,
+        # `sg`, `su` and `login` print the same message body, so an unanchored
+        # match would blame the sandbox's capabilities for a user command's own
+        # failure.
+        if re.search(r"runuser: cannot set groups", stderr, re.IGNORECASE):
             raise RuntimeError(
                 f"When a user parameter ('{user}') is provided to exec() and the "
                 f"container is not already running as that user, runuser needs "
                 f"CAP_SETGID to call setgroups(2). The container appears to have "
                 f"had its capabilities dropped. Docs: {EXEC_USER_URL}\n{stderr}"
             )
-        if re.search(r"runuser: (not found|no such file)", stderr, re.IGNORECASE):
+        if re.search(r"runuser: not found", stderr, re.IGNORECASE):
             raise RuntimeError(
                 f"When a user parameter ('{user}') is provided to exec(), the "
                 f"runuser binary must be installed in the container. Docs: "

--- a/src/k8s_sandbox/_pod/execute.py
+++ b/src/k8s_sandbox/_pod/execute.py
@@ -25,27 +25,36 @@ def _shell_command(user: str | None) -> list[str]:
     already running as that user. `runuser` calls setgroups(2), which needs
     CAP_SETGID even when switching root -> root, so an unconditional wrapper
     makes every exec(user=...) fail in a container whose capabilities have been
-    dropped -- a common hardening posture, and one where the switch was a no-op
-    anyway.
+    dropped. Skipping it is close to a no-op, but not exactly one: runuser also
+    normalizes HOME, SHELL, USER, LOGNAME and PATH, which the skip path
+    inherits from the container instead.
 
     The check runs in the container rather than here so that it costs no extra
     round trip. `sh -c` takes its script from argv, so stdin reaches whichever
     shell is exec'd unread, and the caller's protocol is unchanged.
 
-    `id -un` reports only the first passwd name for the uid, so a second name
-    for the same uid (root/toor) is not recognised and falls through to
-    `runuser` -- i.e. the previous behaviour, which is the safe direction.
+    `user` may be a name or a uid, and the two must be compared against
+    different things: testing a uid against `id -un` (or a name against `id -u`)
+    would match an account merely *named* "0" against uid 0 and run the command
+    as the wrong user. So only the applicable test is emitted.
+
+    `id -un` reports only the first passwd name for a uid, so a second name for
+    the same uid (root/toor) is not recognised and falls through to `runuser` --
+    i.e. the previous behaviour, which is the safe direction.
     """
     if user is None:
         return ["/bin/sh"]
+    if not user:
+        # Matches nothing; leave runuser to reject it as it did before.
+        return ["runuser", "-u", user, "--", "/bin/sh"]
     quoted = shlex.quote(user)
-    # A missing or unusual `id` leaves the substitution empty, which simply
-    # falls through to `runuser` -- the behaviour before this check existed.
+    # A missing or failing `id` leaves the substitution empty, which cannot
+    # equal a non-empty user, so that also falls through to `runuser`.
+    current = "id -u" if user.isdigit() else "id -un"
     return [
         "/bin/sh",
         "-c",
-        f'if [ "$(id -un 2>/dev/null)" = {quoted} ] '
-        f'|| [ "$(id -u 2>/dev/null)" = {quoted} ]; then exec /bin/sh; fi; '
+        f'if [ "$({current} 2>/dev/null)" = {quoted} ]; then exec /bin/sh; fi; '
         f"exec runuser -u {quoted} -- /bin/sh",
     ]
 

--- a/src/k8s_sandbox/_pod/execute.py
+++ b/src/k8s_sandbox/_pod/execute.py
@@ -1,4 +1,5 @@
 import base64
+import logging
 import re
 import shlex
 from contextlib import contextmanager
@@ -16,6 +17,8 @@ from k8s_sandbox._pod.op import PodOperation
 COMPLETED_SENTINEL = "completed-sentinel-value"
 COMPLETED_SENTINEL_PATTERN = re.compile(rf"<{COMPLETED_SENTINEL}-(\d+)>")
 EXEC_USER_URL = "https://k8s-sandbox.aisi.org.uk/design/limitations#exec-user"
+
+logger = logging.getLogger(__name__)
 
 
 def _shell_command(user: str | None) -> list[str]:
@@ -217,22 +220,36 @@ class ExecuteOperation(PodOperation):
                 f"The user parameter '{user}' provided to exec() does "
                 f"not appear to exist in the container. Docs: {EXEC_USER_URL}\n{stderr}"
             )
+        # The two arms below describe an environment that cannot perform the
+        # switch, not a caller asking for something that does not exist. Callers
+        # are entitled to handle that: inspect-ai probes with `user="root"` and
+        # falls back to the default user when it fails, which is how a rootless
+        # sandbox is meant to work. Raising here made that fallback unreachable
+        # and turned a supported configuration into a fatal error, so warn and
+        # let the failed ExecResult through.
         if "runuser: may not be used by non-root users" in stderr.casefold():
-            raise RuntimeError(
-                f"When a user parameter ('{user}') is provided to exec(), the "
-                f"container must be running as root. Docs: {EXEC_USER_URL}\n{stderr}"
+            logger.warning(
+                "exec(user=%r) failed: the container is not running as root, so "
+                "runuser cannot switch users. Docs: %s\n%s",
+                user,
+                EXEC_USER_URL,
+                stderr,
             )
+            return
         # Anchored on the `runuser: ` prefix like the arms above it: `newgrp`,
         # `sg`, `su` and `login` print the same message body, so an unanchored
         # match would blame the sandbox's capabilities for a user command's own
         # failure.
         if re.search(r"runuser: cannot set groups", stderr, re.IGNORECASE):
-            raise RuntimeError(
-                f"When a user parameter ('{user}') is provided to exec() and the "
-                f"container is not already running as that user, runuser needs "
-                f"CAP_SETGID to call setgroups(2). The container appears to have "
-                f"had its capabilities dropped. Docs: {EXEC_USER_URL}\n{stderr}"
+            logger.warning(
+                "exec(user=%r) failed: runuser needs CAP_SETGID to call "
+                "setgroups(2), and the container's capabilities appear to have "
+                "been dropped. Docs: %s\n%s",
+                user,
+                EXEC_USER_URL,
+                stderr,
             )
+            return
         if re.search(r"runuser: not found", stderr, re.IGNORECASE):
             raise RuntimeError(
                 f"When a user parameter ('{user}') is provided to exec(), the "

--- a/src/k8s_sandbox/_pod/pod.py
+++ b/src/k8s_sandbox/_pod/pod.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import os
 from pathlib import Path
 from typing import IO, Callable, Literal, TypeVar
 
@@ -17,6 +18,15 @@ from k8s_sandbox._pod.write import WriteFileOperation
 T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
+
+
+def _file_op_restart_check_enabled() -> bool:
+    # Gates the pre-op `read_namespaced_pod` call inside read_file / write_file
+    # (only — exec is unaffected and always checks). At high concurrency
+    # (200+ ops) the per-op reads can overwhelm the K8s API server; exec's
+    # check is the high-signal way we learn a sandbox pod was replaced and
+    # stays unconditional, while file-op API errors are self-revealing.
+    return os.environ.get("INSPECT_POD_RESTART_CHECK", "true").lower() != "false"
 
 
 class Pod:
@@ -179,7 +189,8 @@ class Pod:
           dst (Path): The path to write the file to on the pod. Relative paths will be
             resolved relative to the pod's default working directory.
         """
-        await self.check_for_pod_restart()
+        if _file_op_restart_check_enabled():
+            await self.check_for_pod_restart()
         writer = WriteFileOperation(self._info)
         await self._run_async(lambda: writer.write_file(data, dst))
 
@@ -195,7 +206,8 @@ class Pod:
             relative to the pod's default working directory.
           dst (IO[bytes]): A file-like object to write the file to on the client system.
         """
-        await self.check_for_pod_restart()
+        if _file_op_restart_check_enabled():
+            await self.check_for_pod_restart()
         reader = ReadFileOperation(self._info)
         await self._run_async(lambda: reader.read_file(src, dst))
 

--- a/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
@@ -138,7 +138,7 @@ spec:
     - {}
 {{- if .Values.networks }}
   {{- range $svcName, $svc := .Values.services }}
-    {{- if $svc.networks }}
+    {{- if and $svc.networks (not $svc.networkIsolated) }}
       {{- range $net := $svc.networks }}
 ---
 apiVersion: cilium.io/v2

--- a/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
@@ -190,6 +190,7 @@ spec:
 {{- else }}
   {{- /* No global networks: allow same-sandbox ingress per service (no network scoping) */}}
   {{- range $svcName, $svc := .Values.services }}
+  {{- if not $svc.networkIsolated }}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -230,6 +231,7 @@ spec:
           - type: 128
             family: IPv6
   {{- end }}
+  {{- end }}
 {{- end }}
 {{- range $svcName, $svc := .Values.services }}
 {{- if $svc.networkIsolated }}
@@ -244,15 +246,18 @@ metadata:
     {{- toYaml $.Values.labels | nindent 4 }}
 spec:
   description: |
-    Deny all ingress and egress for isolated service "{{ $svcName }}" (network_mode: none).
+    Isolate service "{{ $svcName }}" (network_mode: none): no ingress allow is emitted
+    for this service, so sandbox-default-deny-ingress denies all ingress to it. Egress
+    is explicitly denied below. This is deliberately subtractive rather than an
+    unconditional ingressDeny, so that a policy layered on top of this chart (e.g. an
+    allow for a specific port) is not shadowed -- Cilium resolves deny before allow,
+    with no exception mechanism, so an ingressDeny here would silently defeat any such
+    allow.
   endpointSelector:
     matchLabels:
       io.kubernetes.pod.namespace: {{ $.Release.Namespace }}
       {{- include "agentEnv.selectorLabels" $ | nindent 6 }}
       inspect/service: {{ $svcName }}
-  ingressDeny:
-    - fromEntities:
-        - all
   egressDeny:
     - toEntities:
         - all

--- a/src/k8s_sandbox/resources/helm/agent-env/templates/services.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/services.yaml
@@ -9,7 +9,16 @@ metadata:
   annotations:
     {{- toYaml $.Values.annotations | nindent 4 }}
 spec:
-  serviceName: {{ $name }}-service
+  {{- /*
+    Deliberately empty. The kubelet writes the pod's FQDN --
+    <pod>.<subdomain>.<namespace>.svc.cluster.local -- into /etc/hosts, but only when
+    the pod has a subdomain, and a StatefulSet's pods take their subdomain from
+    serviceName. Left empty, the kubelet writes a plain "<pod IP> <pod name>" and the
+    namespace stays out of the sandbox, where an agent under evaluation can read it.
+    Nothing resolved the per-pod DNS name this would create: the Services below are
+    what the coredns sidecar rewrites service names to.
+  */}}
+  serviceName: ""
   replicas: 1
   selector:
     matchLabels:

--- a/test/k8s_sandbox/helm_chart/resources/network-isolated-with-global-network-values.yaml
+++ b/test/k8s_sandbox/helm_chart/resources/network-isolated-with-global-network-values.yaml
@@ -1,0 +1,12 @@
+networks:
+  tasknet: {}
+services:
+  isolated-service:
+    image: my-isolated-image:1.0.0
+    networkIsolated: true
+    networks:
+      - tasknet
+  normal-service:
+    image: my-normal-image:1.0.0
+    networks:
+      - tasknet

--- a/test/k8s_sandbox/helm_chart/test_helm_chart.py
+++ b/test/k8s_sandbox/helm_chart/test_helm_chart.py
@@ -567,16 +567,30 @@ def test_network_isolated_service(chart_dir: Path, test_resources_dir: Path) -> 
         isolate_policy["metadata"]["name"]
         == "agent-env-my-release-svc-isolated-service-isolate"
     )
-    # ingressDeny and egressDeny deny all traffic from/to all entities
-    assert isolate_policy["spec"]["ingressDeny"] == [{"fromEntities": ["all"]}]
+    # Ingress is denied subtractively: no allow selects the isolated service, so
+    # sandbox-default-deny-ingress denies it. No ingressDeny is emitted -- an
+    # unconditional ingressDeny would shadow any allow layered on top of this chart.
+    assert "ingressDeny" not in isolate_policy["spec"]
     assert isolate_policy["spec"]["egressDeny"] == [{"toEntities": ["all"]}]
 
-    # Verify normal-service doesn't have isolate policy
+    # No per-service ingress allow is rendered at all for the isolated service.
+    isolated_ingress_policies = [
+        cnp
+        for cnp in cnps
+        if cnp["metadata"]["name"].endswith("-svc-isolated-service-ingress")
+    ]
+    assert isolated_ingress_policies == []
+
+    # Verify normal-service doesn't have isolate policy, and still gets its ingress
+    # allow.
     normal_service_policies = [
         cnp for cnp in cnps if "normal-service" in cnp["metadata"]["name"]
     ]
     assert len(normal_service_policies) == 1
     assert "isolate" not in normal_service_policies[0]["metadata"]["name"]
+    assert normal_service_policies[0]["metadata"]["name"].endswith(
+        "-svc-normal-service-ingress"
+    )
 
     normal_spec = normal_service_policies[0]["spec"]
     assert normal_spec.get("ingress") != []

--- a/test/k8s_sandbox/helm_chart/test_helm_chart.py
+++ b/test/k8s_sandbox/helm_chart/test_helm_chart.py
@@ -597,6 +597,36 @@ def test_network_isolated_service(chart_dir: Path, test_resources_dir: Path) -> 
     assert normal_spec.get("egress") != []
 
 
+def test_network_isolated_service_joining_a_global_network(
+    chart_dir: Path, test_resources_dir: Path
+) -> None:
+    # A service can be networkIsolated and still list `networks` (nothing in the chart
+    # rejects the combination), which renders through the .Values.networks branch
+    # rather than the no-networks branch covered by test_network_isolated_service. That
+    # branch's per-network ingress allow must also be skipped for an isolated service.
+    documents = _run_helm_template(
+        chart_dir,
+        test_resources_dir / "network-isolated-with-global-network-values.yaml",
+    )
+
+    cnps = _get_documents(documents, "CiliumNetworkPolicy")
+
+    isolated_ingress_policies = [
+        cnp
+        for cnp in cnps
+        if cnp["metadata"]["name"].endswith("-svc-isolated-service-tasknet-ingress")
+    ]
+    assert isolated_ingress_policies == []
+
+    normal_ingress_policies = [
+        cnp
+        for cnp in cnps
+        if cnp["metadata"]["name"].endswith("-svc-normal-service-tasknet-ingress")
+    ]
+    assert len(normal_ingress_policies) == 1
+    assert normal_ingress_policies[0]["spec"]["ingress"] != []
+
+
 def test_allow_domains_egress_enforces_identity_on_pinned_ips(
     chart_dir: Path, test_resources_dir: Path
 ) -> None:

--- a/test/k8s_sandbox/helm_chart/test_helm_chart.py
+++ b/test/k8s_sandbox/helm_chart/test_helm_chart.py
@@ -766,6 +766,20 @@ def test_allow_domains_wildcard_all_skips_identity_enforcement(
     assert "toPorts" not in fqdn_rule
 
 
+def test_pods_have_no_subdomain(chart_dir: Path, test_resources_dir: Path) -> None:
+    # A subdomain is what makes the kubelet write the pod's
+    # <pod>.<subdomain>.<namespace>.svc.cluster.local FQDN into /etc/hosts, handing an
+    # agent under evaluation whatever the namespace name gives away.
+    documents = _run_helm_template(
+        chart_dir, test_resources_dir / "multiple-services-values.yaml"
+    )
+
+    services = _get_documents(documents, "StatefulSet")
+    assert len(services) == 2
+    for service in services:
+        assert not service["spec"]["serviceName"]
+
+
 def _run_helm_template(
     chart_dir: Path,
     values_file: Path | None = None,

--- a/test/k8s_sandbox/pod/test_check_for_pod_restart.py
+++ b/test/k8s_sandbox/pod/test_check_for_pod_restart.py
@@ -1,4 +1,7 @@
+import asyncio
+import io
 import json
+import pathlib
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -149,3 +152,81 @@ def test_pod_auto_refreshes_restart_count_after_container_restart():
             uid="uid-OLD", container_name="default", restart_count=4
         )
         pod._check_for_pod_restart_sync()
+
+
+# --- INSPECT_POD_RESTART_CHECK gating (METR-private; not upstream) -----------
+
+
+def _make_replaced_pod_response() -> MagicMock:
+    return _k8s_pod(uid="uid-NEW", container_name="default", restart_count=0)
+
+
+def test_env_var_skips_file_op_check_but_not_exec(monkeypatch):
+    # Sandbox provider: Pod.read_file / Pod.write_file must skip the pre-op
+    # restart check when INSPECT_POD_RESTART_CHECK=false, while Pod.exec must
+    # always run it. Gate the file-op API hammer; keep the high-signal exec
+    # check unconditional.
+    monkeypatch.setenv("INSPECT_POD_RESTART_CHECK", "false")
+
+    # Patch the executor to run callables inline so we don't need a real
+    # threadpool / event loop boundary here.
+    with patch(
+        "k8s_sandbox._pod.executor.PodOpExecutor.get_instance"
+    ) as mock_get_instance:
+        executor = MagicMock()
+
+        async def queue(callable):
+            return callable()
+
+        executor.queue_operation = queue
+        mock_get_instance.return_value = executor
+
+        with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
+            mock_client.return_value.read_namespaced_pod.return_value = (
+                _make_replaced_pod_response()
+            )
+            # Patch the actual file ops so they don't try to hit a real pod.
+            with (
+                patch("k8s_sandbox._pod.pod.ReadFileOperation"),
+                patch("k8s_sandbox._pod.pod.WriteFileOperation"),
+                patch("k8s_sandbox._pod.pod.ExecuteOperation"),
+            ):
+                pod = _make_pod()
+
+                # read_file: env var should suppress the check entirely.
+                asyncio.run(pod.read_file(pathlib.Path("/x"), io.BytesIO()))
+                assert mock_client.return_value.read_namespaced_pod.call_count == 0
+
+                # write_file: same.
+                asyncio.run(pod.write_file(io.BytesIO(b""), pathlib.Path("/x")))
+                assert mock_client.return_value.read_namespaced_pod.call_count == 0
+
+                # exec: must always check, env var notwithstanding.
+                with pytest.raises(PodReplacedError):
+                    asyncio.run(pod.exec(["true"], None, None, {}, None, None))
+                assert mock_client.return_value.read_namespaced_pod.call_count == 1
+
+
+def test_env_var_default_keeps_file_op_check(monkeypatch):
+    monkeypatch.delenv("INSPECT_POD_RESTART_CHECK", raising=False)
+
+    with patch(
+        "k8s_sandbox._pod.executor.PodOpExecutor.get_instance"
+    ) as mock_get_instance:
+        executor = MagicMock()
+
+        async def queue(callable):
+            return callable()
+
+        executor.queue_operation = queue
+        mock_get_instance.return_value = executor
+
+        with patch("k8s_sandbox._pod.op.k8s_client") as mock_client:
+            mock_client.return_value.read_namespaced_pod.return_value = (
+                _make_replaced_pod_response()
+            )
+            with patch("k8s_sandbox._pod.pod.ReadFileOperation"):
+                pod = _make_pod()
+                with pytest.raises(PodReplacedError):
+                    asyncio.run(pod.read_file(pathlib.Path("/x"), io.BytesIO()))
+                assert mock_client.return_value.read_namespaced_pod.call_count == 1

--- a/test/k8s_sandbox/pod/test_execute.py
+++ b/test/k8s_sandbox/pod/test_execute.py
@@ -349,8 +349,6 @@ class TestRunuserErrorMessages:
         ("stderr", "expected"),
         [
             ("runuser: user agent does not exist", "does not appear to exist"),
-            ("runuser: may not be used by non-root users", "must be running as root"),
-            ("runuser: cannot set groups: Operation not permitted", "CAP_SETGID"),
             ("/bin/sh: 1: exec: runuser: not found", "must be installed"),
         ],
     )
@@ -363,9 +361,24 @@ class TestRunuserErrorMessages:
     @pytest.mark.parametrize(
         "stderr",
         [
+            "runuser: may not be used by non-root users",
+            "runuser: cannot set groups: Operation not permitted",
+        ],
+    )
+    def test_environment_failures_warn_rather_than_raise(self, stderr: str) -> None:
+        """inspect-ai probes with user="root" and falls back when it fails.
+
+        Raising made that fallback unreachable, so a rootless sandbox could not
+        run any task using the injected tools.
+        """
+        executor = ExecuteOperation(MagicMock())
+
+        executor._check_for_runuser_error(stderr, "agent")  # does not raise
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
             "ls: /nope: No such file",
-            # Same message body as the runuser case; a user command's own
-            # failure must not be reported as a sandbox misconfiguration.
             "newgrp: cannot set groups: Operation not permitted",
             "su: cannot set groups: Operation not permitted",
         ],

--- a/test/k8s_sandbox/pod/test_execute.py
+++ b/test/k8s_sandbox/pod/test_execute.py
@@ -1,3 +1,4 @@
+import shlex
 from contextlib import contextmanager
 from typing import Generator
 from unittest.mock import MagicMock, patch
@@ -8,7 +9,7 @@ from kubernetes.stream.ws_client import WSClient  # type: ignore
 
 import k8s_sandbox._pod.op as op_module
 from k8s_sandbox._pod.error import PodError
-from k8s_sandbox._pod.execute import ExecuteOperation
+from k8s_sandbox._pod.execute import ExecuteOperation, _shell_command
 
 
 def _make_ws_client(
@@ -298,3 +299,60 @@ class TestExecChunksStdin:
         assert ws.write_stdin.call_count > 1
         assert all(len(c.args[0]) <= 16 for c in ws.write_stdin.call_args_list)
         assert result is sentinel
+
+
+class TestShellCommand:
+    """`runuser` is only reached for when the container is not already that user."""
+
+    def test_no_user_opens_a_plain_shell(self) -> None:
+        assert _shell_command(None) == ["/bin/sh"]
+
+    def test_user_falls_back_to_runuser(self) -> None:
+        command = _shell_command("agent")
+
+        assert command[:2] == ["/bin/sh", "-c"]
+        assert "exec runuser -u agent -- /bin/sh" in command[2]
+
+    def test_user_skips_runuser_when_already_that_user(self) -> None:
+        """A no-op switch still needs CAP_SETGID, so avoid runuser when we can."""
+        script = _shell_command("agent")[2]
+
+        assert '[ "$(id -un 2>/dev/null)" = agent ]' in script
+        assert '[ "$(id -u 2>/dev/null)" = agent ]' in script
+        assert "then exec /bin/sh; fi" in script
+
+    def test_a_numeric_user_is_matched_by_uid(self) -> None:
+        script = _shell_command("1000")[2]
+
+        assert '[ "$(id -u 2>/dev/null)" = 1000 ]' in script
+
+    @pytest.mark.parametrize("user", ["a b", "a;rm -rf /", "$(whoami)", "'"])
+    def test_user_is_quoted(self, user: str) -> None:
+        """The user reaches two more shell words than it used to; quote all three."""
+        script = _shell_command(user)[2]
+
+        assert script.count(shlex.quote(user)) == 3
+        assert user not in script.replace(shlex.quote(user), "")
+
+
+class TestRunuserErrorMessages:
+    @pytest.mark.parametrize(
+        ("stderr", "expected"),
+        [
+            ("runuser: user agent does not exist", "does not appear to exist"),
+            ("runuser: may not be used by non-root users", "must be running as root"),
+            ("runuser: cannot set groups: Operation not permitted", "CAP_SETGID"),
+            ("/bin/sh: 1: exec: runuser: not found", "must be installed"),
+            ("runuser: not found", "must be installed"),
+        ],
+    )
+    def test_runuser_errors_are_explained(self, stderr: str, expected: str) -> None:
+        executor = ExecuteOperation(MagicMock())
+
+        with pytest.raises(RuntimeError, match=expected):
+            executor._check_for_runuser_error(stderr, "agent")
+
+    def test_unrelated_stderr_is_not_claimed_as_a_runuser_error(self) -> None:
+        executor = ExecuteOperation(MagicMock())
+
+        executor._check_for_runuser_error("ls: /nope: No such file", "agent")

--- a/test/k8s_sandbox/pod/test_execute.py
+++ b/test/k8s_sandbox/pod/test_execute.py
@@ -343,7 +343,6 @@ class TestRunuserErrorMessages:
             ("runuser: may not be used by non-root users", "must be running as root"),
             ("runuser: cannot set groups: Operation not permitted", "CAP_SETGID"),
             ("/bin/sh: 1: exec: runuser: not found", "must be installed"),
-            ("runuser: not found", "must be installed"),
         ],
     )
     def test_runuser_errors_are_explained(self, stderr: str, expected: str) -> None:
@@ -352,7 +351,19 @@ class TestRunuserErrorMessages:
         with pytest.raises(RuntimeError, match=expected):
             executor._check_for_runuser_error(stderr, "agent")
 
-    def test_unrelated_stderr_is_not_claimed_as_a_runuser_error(self) -> None:
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "ls: /nope: No such file",
+            # Same message body as the runuser case; a user command's own
+            # failure must not be reported as a sandbox misconfiguration.
+            "newgrp: cannot set groups: Operation not permitted",
+            "su: cannot set groups: Operation not permitted",
+        ],
+    )
+    def test_unrelated_stderr_is_not_claimed_as_a_runuser_error(
+        self, stderr: str
+    ) -> None:
         executor = ExecuteOperation(MagicMock())
 
-        executor._check_for_runuser_error("ls: /nope: No such file", "agent")
+        executor._check_for_runuser_error(stderr, "agent")  # does not raise

--- a/test/k8s_sandbox/pod/test_execute.py
+++ b/test/k8s_sandbox/pod/test_execute.py
@@ -318,20 +318,29 @@ class TestShellCommand:
         script = _shell_command("agent")[2]
 
         assert '[ "$(id -un 2>/dev/null)" = agent ]' in script
-        assert '[ "$(id -u 2>/dev/null)" = agent ]' in script
         assert "then exec /bin/sh; fi" in script
 
-    def test_a_numeric_user_is_matched_by_uid(self) -> None:
-        script = _shell_command("1000")[2]
+    def test_a_name_is_compared_against_the_name_and_a_uid_against_the_uid(
+        self,
+    ) -> None:
+        """Cross-comparing would match an account *named* "0" against uid 0."""
+        by_name = _shell_command("agent")[2]
+        by_uid = _shell_command("1000")[2]
 
-        assert '[ "$(id -u 2>/dev/null)" = 1000 ]' in script
+        assert "id -un" in by_name and "id -u " not in by_name
+        assert '[ "$(id -u 2>/dev/null)" = 1000 ]' in by_uid
+        assert "id -un" not in by_uid
+
+    def test_an_empty_user_is_left_to_runuser(self) -> None:
+        """It matches nothing, and an empty `id` output must not look equal."""
+        assert _shell_command("") == ["runuser", "-u", "", "--", "/bin/sh"]
 
     @pytest.mark.parametrize("user", ["a b", "a;rm -rf /", "$(whoami)", "'"])
     def test_user_is_quoted(self, user: str) -> None:
         """The user reaches two more shell words than it used to; quote all three."""
         script = _shell_command(user)[2]
 
-        assert script.count(shlex.quote(user)) == 3
+        assert script.count(shlex.quote(user)) == 2
         assert user not in script.replace(shlex.quote(user), "")
 
 

--- a/test/k8s_sandbox/test_dns.py
+++ b/test/k8s_sandbox/test_dns.py
@@ -64,6 +64,19 @@ async def test_ping_on_victim(sandbox: K8sSandboxEnvironment):
     assert "1 packets transmitted, 1 received" in result.stdout
 
 
+async def test_etc_hosts_does_not_name_the_namespace(
+    sandbox: K8sSandboxEnvironment,
+):
+    # The namespace often names what is being evaluated, so it must not reach the
+    # sandbox. The kubelet only writes the FQDN which carries it when the pod has a
+    # subdomain (see serviceName in templates/services.yaml).
+    hosts = await sandbox.exec(["cat", "/etc/hosts"], timeout=10)
+    fqdn = await sandbox.exec(["hostname", "-f"], timeout=10)
+
+    assert ".svc.cluster.local" not in hosts.stdout
+    assert ".svc.cluster.local" not in fqdn.stdout
+
+
 async def test_non_existent_service(sandbox: K8sSandboxEnvironment):
     result = await sandbox.exec(
         ["curl", "-sI", "http://non-existent-service"],


### PR DESCRIPTION
## Summary

The kubelet writes a pod's FQDN — `<pod>.<subdomain>.<namespace>.svc.cluster.local` — into `/etc/hosts`, so anything running in a sandbox can read the namespace it is in. Deployments that name the namespace after the eval hand that straight to the agent under evaluation: we found this after an agent's reasoning trace quoted its own namespace and correctly identified the model and benchmark it was being tested on.

A pod only gets that FQDN line when it has a subdomain, and a StatefulSet's pods take their subdomain from `spec.serviceName`. This chart set it to `<service>-service`, a Service the chart never creates — so it bought nothing and leaked the namespace. Emptying it makes the kubelet write a plain `<pod IP> <pod name>`, and `/etc/hosts` stays the kubelet's own file: still writable, still mapping the pod's real address.

## Notes for reviewers

- **Per-pod DNS (`<pod>.<service>.<namespace>.svc.cluster.local`) no longer resolves.** Nothing in this chart used it — the coredns sidecar rewrites short service names to the Services rendered alongside the StatefulSets — but a deployment supplying its own governing Service to address pods by name would need the pod IP instead.
- **No opt-out value**, deliberately: nothing observable breaks, and a chart-global switch is the wrong granularity for this (one auxiliary service needing the old behaviour would un-mask the agent's service too). If you'd rather users could restore it, I'd suggest `governingServiceName` (string, default `""`) over a boolean — an absent value then defaults to the safe behaviour, which matters for `helm upgrade --reuse-values` on existing releases.

## Test plan

Verified on a real cluster (EKS 1.35, gVisor runtime) with a two-service sandbox:

- `/etc/hosts` is the kubelet's own file and reads `10.112.206.114  agent-env-<rel>-default-0` — no FQDN. `hostname -f`, `hostname -A`, `hostname -d` and `socket.getfqdn()` are all namespace-free.
- Grepping the namespace string across the sandbox filesystem (24,569 files) finds nothing. Before the change the same sweep matched `/etc/hosts`, and only `/etc/hosts`.
- `/etc/hosts` is still writable: append and truncate both succeed and take effect (`getent hosts` resolves an appended entry).
- Service-to-service is unaffected: short service name, the legacy `$AGENT_ENV-<service>` name, raw TCP to a sibling pod IP, and `ping` all work.
- `serviceName: ""` is accepted by the apiserver on 1.31, 1.32 and 1.35 (validation has never required the field; the check added in 1.33 is guarded on it being non-empty). Note the OpenAPI schema still marks it required, so a strict third-party validator could object.

The new `test_dns.py` assertion is `req_k8s` and hasn't run in my environment — it needs a gvisor-capable cluster, so it is unexercised until your CI picks it up.