### PR TITLE
fix: wait for Cilium to apply a release's network policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@
   a failed `ExecResult` rather than raised, so a caller that probes with a user and
   falls back (as inspect-ai does when injecting its sandbox tools) can do so. Naming a
   user that does not exist still raises.
+- Fix a sandbox's first commands racing its own egress rules on Cilium clusters: an
+  allow-listed domain that sometimes did not resolve, or a pod with unrestricted egress
+  that sometimes had no network. The built-in chart's network policies are now created
+  before the pods they protect, and installation waits for Cilium to build each pod's
+  endpoint before handing the sandbox back. The wait needs `get` and `list` on
+  `ciliumendpoints.cilium.io` in the sandbox namespace; without them it is skipped with
+  a warning, and it raises the new `CiliumPolicyNotRealizedError` if an endpoint has
+  not become ready after 60s.
+- The built-in chart's `CiliumNetworkPolicy` objects are Helm hooks, which `helm
+  uninstall` does not remove. Uninstalling through this package deletes them, which
+  needs `list` (new) and `delete` on `ciliumnetworkpolicies.cilium.io` in the namespace;
+  a release uninstalled by hand needs `kubectl delete cnp -l
+  app.kubernetes.io/instance=<release>`.
 
 ## 2026-08-12 0.13.0
 

--- a/docs/docs/getting-started/remote-cluster.md
+++ b/docs/docs/getting-started/remote-cluster.md
@@ -2,6 +2,17 @@
 
 ## Requirements
 
+### On a Cilium cluster, with any chart
+
+The identity running Inspect needs `get` and `list` on `ciliumendpoints.cilium.io` in
+the namespace it installs into, whichever chart it installs. Kubernetes reports a pod
+ready before Cilium has finished building its endpoint, so installation waits on those
+endpoints before handing the sandbox back. Without the permission the wait is skipped
+with a warning, and a sandbox's first commands can race their own egress rules: an
+allowed domain may fail to resolve, or a pod with unrestricted egress may briefly have
+no network. A cluster with no CiliumEndpoint CRD is not running Cilium and skips the
+wait silently.
+
 ### If using the built-in Helm Chart
 
 #### Cilium
@@ -15,6 +26,25 @@ Cilium effectively combines policies by means of a logical disjunction (OR)
 policies are too permissive, they may undermine the more restrictive policies deployed
 by the built-in Helm chart. In particular, see the [DNS exfiltration
 section](../security/network-access.md#dns-exfiltration).
+
+The chart's own policies are installed as Helm pre-install hooks, so that the policy
+objects exist before the pods they protect rather than after them (Helm creates custom
+resources last). Note what that does and does not guarantee: the objects are in the API
+server before the pod is created, but not that every node's Cilium agent has imported
+them before it builds the pod's endpoint. That import is the remaining window —
+milliseconds, against the seconds a pod takes to be scheduled and started — and is why
+the wait above exists as well.
+
+Helm does not remove hook resources with the release, so this package deletes the
+policies itself on uninstall. That needs `list` and `delete` on
+`ciliumnetworkpolicies.cilium.io` in the namespace. `delete` was already needed, since
+Helm deleted these objects itself while they were ordinary release resources; `list` is
+a new requirement — an identity without it installs the chart normally and then cannot
+clean up, failing the uninstall with `Failed to list the release's network policies`.
+The policies are deleted one at a time rather than as a collection, so
+`deletecollection` is not required. A release uninstalled by hand with `helm uninstall`
+leaves its `CiliumNetworkPolicy` objects behind, which `kubectl delete cnp -l
+app.kubernetes.io/instance=<release>` removes.
 
 #### `StorageClass`
 

--- a/src/k8s_sandbox/__init__.py
+++ b/src/k8s_sandbox/__init__.py
@@ -1,5 +1,6 @@
 """Package for a Kubernetes sandbox environment provider for Inspect AI."""
 
+from k8s_sandbox._cilium import CiliumPolicyNotRealizedError
 from k8s_sandbox._error import K8sError
 from k8s_sandbox._pod import GetReturncodeError, PodError
 from k8s_sandbox._pod.error import ContainerRestartedError, PodReplacedError
@@ -9,6 +10,7 @@ from k8s_sandbox._sandbox_environment import (
 )
 
 __all__ = [
+    "CiliumPolicyNotRealizedError",
     "ContainerRestartedError",
     "GetReturncodeError",
     "K8sError",

--- a/src/k8s_sandbox/_cilium.py
+++ b/src/k8s_sandbox/_cilium.py
@@ -1,0 +1,510 @@
+"""Wait for Cilium to program a release's pods before they are used.
+
+`helm install --wait` returns as soon as kubelet reports the release's pods
+Ready. Cilium builds each pod's endpoint and compiles its policy separately, so
+a sandbox handed back on kubelet's signal alone can run its first command
+against a half-programmed egress policy: an allow-listed domain that does not
+resolve, or a pod meant to have unrestricted egress with no network at all.
+
+Cilium publishes per-pod progress as a ``CiliumEndpoint`` (``cilium.io/v2``),
+named after the pod, owned by it, and carrying its labels. ``status.state`` is
+``ready`` only once that endpoint's datapath is built and not waiting to
+regenerate, and it is the only signal the API offers: the v2 CRD's
+``status.policy`` schema declares just ``ingress``/``egress`` (an
+apiextensions/v1 CRD prunes anything else), and ``CiliumNetworkPolicy.status``
+carries no per-node realization at all. So the wait covers the window in which
+the endpoint does not exist or is being (re)built. The chart's network policies
+are installed as pre-install hooks, which puts the policy objects in the API
+server before the pod is created; what remains unobservable is whether the
+node's agent had imported them by the time it built that endpoint.
+
+Reads use the raw API JSON rather than the kubernetes client's model
+deserialization, as ``k8s_sandbox._pod.snapshot`` does and for the same reason.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import json
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Sequence, cast
+
+import urllib3
+from kubernetes import client  # type: ignore
+from kubernetes.client.exceptions import ApiException  # type: ignore
+from urllib3 import HTTPResponse
+
+from k8s_sandbox._error import K8sError
+from k8s_sandbox._kubernetes_api import k8s_client, k8s_custom_objects_client
+from k8s_sandbox._logger import log_debug, log_warn
+from k8s_sandbox._pod.snapshot import PodSnapshot, list_pods
+
+CILIUM_GROUP = "cilium.io"
+CILIUM_VERSION = "v2"
+CILIUM_ENDPOINTS_PLURAL = "ciliumendpoints"
+CILIUM_NETWORK_POLICIES_PLURAL = "ciliumnetworkpolicies"
+CILIUM_ENDPOINTS_RESOURCE = f"{CILIUM_ENDPOINTS_PLURAL}.{CILIUM_GROUP}"
+
+READY_STATE = "ready"
+
+# Building an endpoint is a node-local control loop which completes in
+# milliseconds once the agent holds the policy, so poll fast enough that the
+# wait is invisible on the happy path.
+POLL_INTERVAL_SECONDS = 0.25
+# Past this the endpoint is not merely mid-build, so stop listing four times a
+# second per concurrent install against a cluster which is already struggling.
+SLOW_POLL_AFTER_SECONDS = 2.0
+SLOW_POLL_INTERVAL_SECONDS = 1.0
+# A minute of it means something is broken rather than busy — and failing is
+# better than handing back a sandbox whose egress rules are not in force.
+TIMEOUT_SECONDS = 60
+
+# The kubernetes client converts only SSLError into an ApiException, so a
+# connection-level failure reaches us as a urllib3 or socket error.
+_CONNECTION_ERRORS = (urllib3.exceptions.HTTPError, OSError)
+_READ_ERRORS = (ApiException, *_CONNECTION_ERRORS)
+
+
+class CiliumWaitOutcome(Enum):
+    """How a wait for Cilium to program the release's pods finished."""
+
+    REALIZED = "realized"
+    """Every endpoint the release's pods have was built and ready."""
+
+    CRD_ABSENT = "crd-absent"
+    """The cluster has no CiliumEndpoint CRD, so it does not run Cilium."""
+
+    NOT_PERMITTED = "not-permitted"
+    """The cluster runs Cilium but did not permit reading CiliumEndpoints."""
+
+    ENDPOINTS_ABSENT = "endpoints-absent"
+    """Pods which never got an endpoint: a node Cilium does not manage."""
+
+
+@dataclass(frozen=True)
+class CiliumEndpointStatus:
+    """A minimal view of one pod's CiliumEndpoint.
+
+    ``found`` is False for a pod whose endpoint Cilium has not published yet,
+    which is a state to wait through rather than a missing signal.
+    """
+
+    name: str
+    found: bool
+    state: str | None
+    pod_uid: str | None = None
+
+    @staticmethod
+    def absent(pod_name: str) -> CiliumEndpointStatus:
+        """The endpoint of a pod which Cilium has not published yet."""
+        return CiliumEndpointStatus(name=pod_name, found=False, state=None)
+
+    @property
+    def is_ready(self) -> bool:
+        return self.found and self.state == READY_STATE
+
+    def describe(self) -> str:
+        if not self.found:
+            return f"{self.name} (no CiliumEndpoint)"
+        return f"{self.name} (state {self.state or 'unknown'})"
+
+
+class CiliumPolicyNotRealizedError(K8sError):
+    """Cilium did not finish building a release's endpoints in time.
+
+    The release's pods were ready, but their Cilium endpoints never became
+    ready, so a command run in them would have raced its own egress rules: an
+    allowed domain may not resolve, or a pod meant to have unrestricted egress
+    may have no network at all.
+
+    Typically a symptom of an unhealthy or overloaded Cilium agent on the node
+    hosting the named endpoints.
+    """
+
+    def __init__(  # noqa: D107
+        self,
+        *,
+        release_name: str,
+        namespace: str,
+        pending: Sequence[CiliumEndpointStatus],
+        elapsed_seconds: float,
+        **kwargs: Any,
+    ):
+        self.release_name = release_name
+        self.namespace = namespace
+        self.pending = tuple(pending)
+        self.elapsed_seconds = elapsed_seconds
+        super().__init__(
+            f"Cilium did not make the endpoints of release '{release_name}' "
+            f"ready within {elapsed_seconds:.1f}s. Endpoints still waiting: "
+            f"{_describe(pending)}",
+            release=release_name,
+            namespace=namespace,
+            elapsed_seconds=round(elapsed_seconds, 3),
+            **kwargs,
+        )
+
+
+async def wait_for_policy_realized(
+    context_name: str | None,
+    namespace: str,
+    release_name: str,
+    *,
+    timeout_seconds: float = TIMEOUT_SECONDS,
+    poll_interval_seconds: float = POLL_INTERVAL_SECONDS,
+    slow_poll_interval_seconds: float = SLOW_POLL_INTERVAL_SECONDS,
+) -> CiliumWaitOutcome:
+    """Wait until Cilium has built an endpoint for each of the release's pods.
+
+    Args:
+        context_name: The kubeconfig context, or None for the current one.
+        namespace: The namespace the release was installed into.
+        release_name: The Helm release name.
+        timeout_seconds: How long to wait before raising.
+        poll_interval_seconds: How long to wait between reads.
+        slow_poll_interval_seconds: How long to wait between reads once the
+          wait has lasted longer than a build normally takes.
+
+    Returns:
+        What the wait observed, for the caller to act on or ignore.
+
+    Raises:
+        CiliumPolicyNotRealizedError: If an endpoint of the release exists but
+            has not become ready within `timeout_seconds`.
+        K8sError: If the release's pods could not be read.
+    """
+    loop = asyncio.get_running_loop()
+    started = time.monotonic()
+    deadline = started + timeout_seconds
+    label_selector = f"app.kubernetes.io/instance={release_name}"
+    # Create the clients here and use them from the worker threads, as
+    # Release.get_sandbox_pods does. k8s_client() is thread-local, so creating
+    # one inside each worker re-runs the kubeconfig's credential plugin
+    # (measured at ~0.9s) on the critical path of every concurrent sandbox.
+    api = k8s_client(context_name)
+    custom_objects = k8s_custom_objects_client(context_name)
+    pods: tuple[PodSnapshot, ...] | None = None
+    last_read_error: Exception | None = None
+    logged_waiting = False
+    while True:
+        try:
+            if pods is None:
+                pods = await loop.run_in_executor(
+                    None, lambda: _pods_with_endpoints(api, namespace, label_selector)
+                )
+            statuses = (
+                _join(
+                    pods,
+                    await loop.run_in_executor(
+                        None,
+                        lambda: _list_endpoints(
+                            custom_objects, namespace, label_selector
+                        ),
+                    ),
+                )
+                if pods
+                else ()
+            )
+        except ApiException as e:
+            if e.status == 404 and pods is not None:
+                # The API 404s on the collection path itself when the CRD is
+                # not registered: the cluster does not run Cilium, so there is
+                # no policy to wait for. An endpoint which merely does not
+                # exist yet is an empty list, not a 404.
+                return _finish(CiliumWaitOutcome.CRD_ABSENT, release_name, started, ())
+            if e.status in (401, 403):
+                _warn_endpoints_unreadable()
+                return _finish(
+                    CiliumWaitOutcome.NOT_PERMITTED, release_name, started, ()
+                )
+            last_read_error = e
+            statuses = ()
+        except _CONNECTION_ERRORS as e:
+            # A throttled or briefly unavailable API server may pass: keep
+            # polling within the budget and report the last failure if it does
+            # not.
+            last_read_error = e
+            statuses = ()
+        pending = tuple(status for status in statuses if not status.is_ready)
+        if pods is not None and not pending and last_read_error is None:
+            return _finish(CiliumWaitOutcome.REALIZED, release_name, started, statuses)
+        if pending and not logged_waiting:
+            logged_waiting = True
+            log_debug(
+                "Waiting for Cilium to build the release's endpoints.",
+                release=release_name,
+                pending=_describe(pending),
+            )
+        elapsed = time.monotonic() - started
+        if time.monotonic() >= deadline:
+            return _timed_out(
+                release_name, namespace, pods, pending, elapsed, last_read_error
+            )
+        last_read_error = None
+        await asyncio.sleep(
+            poll_interval_seconds
+            if elapsed < SLOW_POLL_AFTER_SECONDS
+            else slow_poll_interval_seconds
+        )
+
+
+async def delete_release_network_policies(
+    context_name: str | None, namespace: str, release_name: str
+) -> None:
+    """Delete the CiliumNetworkPolicies a release installed.
+
+    The chart installs them as pre-install hooks so that they exist before the
+    pods they protect. Helm does not track hook resources as part of a release,
+    so `helm uninstall` leaves them behind and they are deleted here instead.
+
+    Deletes them one by one, as Helm itself would: deleting a collection is the
+    distinct `deletecollection` RBAC verb, which an identity permitted to
+    create and delete the chart's own policies does not necessarily hold. Every
+    policy is attempted; a single error then names each one that failed.
+
+    Raises:
+        K8sError: If the policies could not be listed or deleted.
+    """
+    loop = asyncio.get_running_loop()
+    custom_objects = k8s_custom_objects_client(context_name)
+    label_selector = f"app.kubernetes.io/instance={release_name}"
+    try:
+        names = await loop.run_in_executor(
+            None,
+            lambda: _network_policy_names(custom_objects, namespace, label_selector),
+        )
+    except _READ_ERRORS as e:
+        if isinstance(e, ApiException) and e.status == 404:
+            # No CiliumNetworkPolicy CRD: the cluster does not run Cilium, so
+            # the chart's policies were never created.
+            return
+        raise K8sError(
+            "Failed to list the release's network policies.",
+            release=release_name,
+            namespace=namespace,
+            cause=f"{type(e).__name__}: {e}",
+        ) from e
+    failures: list[str] = []
+    first_failure: Exception | None = None
+    for name in names:
+        try:
+            await loop.run_in_executor(
+                None,
+                functools.partial(
+                    custom_objects.delete_namespaced_custom_object,
+                    group=CILIUM_GROUP,
+                    version=CILIUM_VERSION,
+                    namespace=namespace,
+                    plural=CILIUM_NETWORK_POLICIES_PLURAL,
+                    name=name,
+                ),
+            )
+        except _READ_ERRORS as e:
+            if isinstance(e, ApiException) and e.status == 404:
+                # Already gone: another uninstall, or the namespace being torn
+                # down around us.
+                continue
+            # Try the rest before reporting: leaving the others behind because
+            # one of them failed is a worse outcome than a longer error.
+            failures.append(f"{name} ({type(e).__name__}: {e})")
+            first_failure = first_failure or e
+    if failures:
+        raise K8sError(
+            "Failed to delete some of the release's network policies.",
+            release=release_name,
+            namespace=namespace,
+            policies="; ".join(failures),
+        ) from first_failure
+
+
+def _finish(
+    outcome: CiliumWaitOutcome,
+    release_name: str,
+    started: float,
+    statuses: Sequence[CiliumEndpointStatus],
+) -> CiliumWaitOutcome:
+    log_debug(
+        "Waited for Cilium to build the release's endpoints.",
+        release=release_name,
+        outcome=outcome.value,
+        elapsed_ms=round((time.monotonic() - started) * 1000),
+        endpoints=_describe(statuses),
+    )
+    return outcome
+
+
+def _timed_out(
+    release_name: str,
+    namespace: str,
+    pods: tuple[PodSnapshot, ...] | None,
+    pending: Sequence[CiliumEndpointStatus],
+    elapsed: float,
+    last_read_error: Exception | None,
+) -> CiliumWaitOutcome:
+    cause = (
+        {"cause": f"{type(last_read_error).__name__}: {last_read_error}"}
+        if last_read_error is not None
+        else {}
+    )
+    if pods is None:
+        raise K8sError(
+            "Failed to list the release's pods while waiting for Cilium.",
+            release=release_name,
+            namespace=namespace,
+            **cause,
+        )
+    if last_read_error is not None and not pending:
+        raise K8sError(
+            "Failed to read the release's CiliumEndpoints while waiting for Cilium.",
+            release=release_name,
+            namespace=namespace,
+            **cause,
+        )
+    unready = tuple(status for status in pending if status.found)
+    if unready or last_read_error is not None:
+        raise CiliumPolicyNotRealizedError(
+            release_name=release_name,
+            namespace=namespace,
+            pending=pending,
+            elapsed_seconds=elapsed,
+            **cause,
+        )
+    # Every pending pod simply has no endpoint. Cilium creates one for every
+    # pod it manages, so after this long the likelier explanation is a node it
+    # does not manage (Fargate, Windows, a cluster mid-rollout) than a stuck
+    # agent, and failing the sandbox would be a regression for those clusters.
+    log_warn(
+        "Cilium published no endpoint for some of the release's pods, so they "
+        "were not waited for. Their first commands may race their own egress "
+        "rules if Cilium does manage them.",
+        release=release_name,
+        namespace=namespace,
+        pods=_describe(pending),
+    )
+    return CiliumWaitOutcome.ENDPOINTS_ABSENT
+
+
+def _describe(statuses: Sequence[CiliumEndpointStatus]) -> str:
+    return "; ".join(status.describe() for status in statuses)
+
+
+@functools.lru_cache(maxsize=1)
+def _warn_endpoints_unreadable() -> None:
+    """Warn once per process that the wait cannot observe Cilium.
+
+    Once, because every sandbox in an eval hits the same missing permission and
+    a warning per sandbox would bury it.
+    """
+    log_warn(
+        f"Not permitted to read {CILIUM_ENDPOINTS_RESOURCE}, so sandboxes are "
+        f"handed back without waiting for Cilium to program them. Their first "
+        f"commands may race their own egress rules. Grant 'get' and 'list' on "
+        f"{CILIUM_ENDPOINTS_RESOURCE} to fix this."
+    )
+
+
+def _pods_with_endpoints(
+    api: client.CoreV1Api, namespace: str, label_selector: str
+) -> tuple[PodSnapshot, ...]:
+    # Host-networked pods share the node's network namespace and so have no
+    # CiliumEndpoint of their own; waiting for one would never finish.
+    return tuple(
+        pod
+        for pod in list_pods(api, namespace, label_selector=label_selector)
+        if not pod.host_network
+    )
+
+
+def _list_cilium_objects(
+    custom_objects: client.CustomObjectsApi,
+    namespace: str,
+    plural: str,
+    label_selector: str,
+) -> list[dict[str, Any]]:
+    """List one of Cilium's namespaced resources as raw API JSON items.
+
+    See k8s_sandbox._pod.snapshot for why the raw JSON, and why
+    _preload_content needs an ignore.
+    """
+    response = cast(
+        HTTPResponse,
+        custom_objects.list_namespaced_custom_object(  # type: ignore[call-arg]
+            group=CILIUM_GROUP,
+            version=CILIUM_VERSION,
+            namespace=namespace,
+            plural=plural,
+            label_selector=label_selector,
+            _preload_content=False,
+        ),
+    )
+    items: list[dict[str, Any]] = json.loads(response.data).get("items", [])
+    return items
+
+
+def _network_policy_names(
+    custom_objects: client.CustomObjectsApi, namespace: str, label_selector: str
+) -> tuple[str, ...]:
+    names: list[str] = []
+    for item in _list_cilium_objects(
+        custom_objects, namespace, CILIUM_NETWORK_POLICIES_PLURAL, label_selector
+    ):
+        name = (item.get("metadata") or {}).get("name")
+        if not isinstance(name, str):
+            raise K8sError(
+                "Read a CiliumNetworkPolicy with no name.",
+                namespace=namespace,
+                metadata=item.get("metadata"),
+            )
+        names.append(name)
+    return tuple(names)
+
+
+def _join(
+    pods: Sequence[PodSnapshot], endpoints: dict[str, CiliumEndpointStatus]
+) -> tuple[CiliumEndpointStatus, ...]:
+    """Pair each pod with its endpoint, by pod UID rather than by name.
+
+    Pods of the chart's StatefulSets have stable names, so an endpoint left
+    behind by a previous pod of the same name would otherwise satisfy the wait
+    immediately. Matching on the owning pod's UID means a stale endpoint can
+    only delay the wait, never end it.
+    """
+    matched: list[CiliumEndpointStatus] = []
+    for pod in pods:
+        endpoint = endpoints.get(pod.name)
+        if endpoint is None or (
+            endpoint.pod_uid is not None and endpoint.pod_uid != pod.uid
+        ):
+            matched.append(CiliumEndpointStatus.absent(pod.name))
+        else:
+            matched.append(endpoint)
+    return tuple(matched)
+
+
+def _list_endpoints(
+    custom_objects: client.CustomObjectsApi, namespace: str, label_selector: str
+) -> dict[str, CiliumEndpointStatus]:
+    endpoints = (
+        _parse_endpoint(item)
+        for item in _list_cilium_objects(
+            custom_objects, namespace, CILIUM_ENDPOINTS_PLURAL, label_selector
+        )
+    )
+    return {endpoint.name: endpoint for endpoint in endpoints}
+
+
+def _parse_endpoint(item: dict[str, Any]) -> CiliumEndpointStatus:
+    metadata = item.get("metadata") or {}
+    status = item.get("status") or {}
+    owners = metadata.get("ownerReferences") or []
+    return CiliumEndpointStatus(
+        name=metadata.get("name", "<unnamed>"),
+        found=True,
+        state=status.get("state"),
+        pod_uid=next(
+            (owner.get("uid") for owner in owners if owner.get("kind") == "Pod"), None
+        ),
+    )

--- a/src/k8s_sandbox/_helm.py
+++ b/src/k8s_sandbox/_helm.py
@@ -14,6 +14,10 @@ from inspect_ai.util import ExecResult, concurrency
 from kubernetes.client.exceptions import ApiException  # type: ignore
 from shortuuid import uuid
 
+from k8s_sandbox._cilium import (
+    delete_release_network_policies,
+    wait_for_policy_realized,
+)
 from k8s_sandbox._diagnostics import describe_release_pods
 from k8s_sandbox._kubernetes_api import get_default_namespace, k8s_client
 from k8s_sandbox._logger import (
@@ -327,6 +331,12 @@ class Release:
                 await watcher
         if not result.success:
             await self._raise_install_error(result)
+        # Kubelet reporting the pods Ready says nothing about Cilium having
+        # built their endpoints, so wait for that too before the release is
+        # usable and a sandbox's first command can race its own egress rules.
+        await wait_for_policy_realized(
+            self._context_name, self._namespace, self.release_name
+        )
 
     async def _watch_for_scheduling_events(self) -> None:
         """Poll for FailedScheduling events and log once if GPU provisioning is needed.
@@ -473,6 +483,10 @@ async def uninstall(
                     stdout=result.stdout,
                     stderr=result.stderr,
                 )
+            # The chart's network policies are Helm hooks so that they exist
+            # before the pods they protect, and Helm does not remove hook
+            # resources with the release.
+            await delete_release_network_policies(context_name, namespace, release_name)
 
 
 async def get_all_release_names(namespace: str, context_name: str | None) -> list[str]:

--- a/src/k8s_sandbox/_kubernetes_api.py
+++ b/src/k8s_sandbox/_kubernetes_api.py
@@ -58,6 +58,17 @@ def k8s_client(context_name: str | None) -> client.CoreV1Api:
     return _thread_local.client_factory.get_client(context_name)
 
 
+def k8s_custom_objects_client(context_name: str | None) -> client.CustomObjectsApi:
+    """Get a thread-local Kubernetes client for custom resources.
+
+    Shares the underlying API client (and so the connection pool and
+    credentials) with `k8s_client`, and carries the same threading contract.
+    """
+    core = k8s_client(context_name)
+    # api_client is present at runtime but absent from the typed stubs.
+    return client.CustomObjectsApi(api_client=core.api_client)  # type: ignore[attr-defined]
+
+
 def get_default_namespace(context_name: str | None) -> str:
     """
     Get the default namespace for the specified kubeconfig context name.

--- a/src/k8s_sandbox/_pod/snapshot.py
+++ b/src/k8s_sandbox/_pod/snapshot.py
@@ -53,6 +53,8 @@ class PodSnapshot:
     container_names: tuple[str, ...]
     """Container names from the pod spec, in declared order."""
     container_statuses: tuple[ContainerStatus, ...] | None
+    host_network: bool = False
+    """Whether the pod shares the node's network namespace."""
 
     def status_for(self, container_name: str) -> ContainerStatus | None:
         if self.container_statuses is None:
@@ -115,6 +117,7 @@ def _parse_pod(pod: dict[str, Any]) -> PodSnapshot:
         labels=metadata.get("labels") or {},
         container_names=tuple(c["name"] for c in spec.get("containers") or []),
         container_statuses=container_statuses,
+        host_network=bool(spec.get("hostNetwork")),
     )
 
 

--- a/src/k8s_sandbox/resources/helm/agent-env/templates/helpers/_helpers.tpl
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/helpers/_helpers.tpl
@@ -88,3 +88,19 @@ true
 {{- end }}
 {{ toYaml $out -}}
 {{- end -}}
+
+{{/*
+Annotations which install the network policies before the pods they protect.
+
+Helm orders an install by kind, and sorts kinds it does not know -- every custom
+resource, CiliumNetworkPolicy among them -- after the workloads. Without these
+the pod is created, scheduled and given a Cilium endpoint before its policy
+object exists; the agent then imports the policy and regenerates that endpoint,
+and a command running in the gap sees a partially programmed egress policy: an
+allowed domain that does not resolve, or no egress at all.
+*/}}
+{{- define "agentEnv.networkPolicyHookAnnotations" -}}
+helm.sh/hook: pre-install,pre-upgrade
+helm.sh/hook-weight: "-5"
+helm.sh/hook-delete-policy: before-hook-creation
+{{- end -}}

--- a/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
+++ b/src/k8s_sandbox/resources/helm/agent-env/templates/network-policy.yaml
@@ -3,9 +3,15 @@ kind: CiliumNetworkPolicy
 metadata:
   name: {{ template "agentEnv.fullname" $ -}}-sandbox-egress
   annotations:
-    {{- toYaml $.Values.annotations | nindent 4 }}
+    {{- include "agentEnv.networkPolicyHookAnnotations" $ | nindent 4 }}
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
-    {{- toYaml $.Values.labels | nindent 4 }}
+    {{- include "agentEnv.selectorLabels" $ | nindent 4 }}
+    {{- with $.Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   description: |
     Allow egress to:
@@ -125,9 +131,15 @@ kind: CiliumNetworkPolicy
 metadata:
   name: {{ template "agentEnv.fullname" $ -}}-sandbox-default-deny-ingress
   annotations:
-    {{- toYaml $.Values.annotations | nindent 4 }}
+    {{- include "agentEnv.networkPolicyHookAnnotations" $ | nindent 4 }}
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
-    {{- toYaml $.Values.labels | nindent 4 }}
+    {{- include "agentEnv.selectorLabels" $ | nindent 4 }}
+    {{- with $.Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   description: Default deny ingress. Allow other policies to be more specific.
   endpointSelector:
@@ -146,9 +158,15 @@ kind: CiliumNetworkPolicy
 metadata:
   name: {{ template "agentEnv.fullname" $ }}-svc-{{ $svcName }}-{{ $net }}-ingress
   annotations:
-    {{- toYaml $.Values.annotations | nindent 4 }}
+    {{- include "agentEnv.networkPolicyHookAnnotations" $ | nindent 4 }}
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
-    {{- toYaml $.Values.labels | nindent 4 }}
+    {{- include "agentEnv.selectorLabels" $ | nindent 4 }}
+    {{- with $.Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   description: |
     Allow ingress to workload "{{ $svcName }}" from same sandbox on network "{{ $net }}".
@@ -196,9 +214,15 @@ kind: CiliumNetworkPolicy
 metadata:
   name: {{ template "agentEnv.fullname" $ }}-svc-{{ $svcName }}-ingress
   annotations:
-    {{- toYaml $.Values.annotations | nindent 4 }}
+    {{- include "agentEnv.networkPolicyHookAnnotations" $ | nindent 4 }}
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
-    {{- toYaml $.Values.labels | nindent 4 }}
+    {{- include "agentEnv.selectorLabels" $ | nindent 4 }}
+    {{- with $.Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   description: |
     Allow ingress to workload "{{ $svcName }}" from same sandbox.
@@ -239,9 +263,15 @@ kind: CiliumNetworkPolicy
 metadata:
   name: {{ template "agentEnv.fullname" $ }}-svc-{{ $svcName }}-isolate
   annotations:
-    {{- toYaml $.Values.annotations | nindent 4 }}
+    {{- include "agentEnv.networkPolicyHookAnnotations" $ | nindent 4 }}
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
-    {{- toYaml $.Values.labels | nindent 4 }}
+    {{- include "agentEnv.selectorLabels" $ | nindent 4 }}
+    {{- with $.Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   description: |
     Deny all ingress and egress for isolated service "{{ $svcName }}" (network_mode: none).

--- a/test/k8s_sandbox/pod/test_snapshot.py
+++ b/test/k8s_sandbox/pod/test_snapshot.py
@@ -83,6 +83,14 @@ def test_parse_pod_defaults_missing_optional_fields():
     assert snapshot.container_names == ()
 
 
+def test_parse_pod_reads_host_network():
+    body = _pod_body()
+    body["spec"]["hostNetwork"] = True
+
+    assert _parse_pod(body).host_network is True
+    assert _parse_pod(_pod_body()).host_network is False
+
+
 def test_parse_pod_raises_when_identity_missing():
     with pytest.raises(ValueError, match="metadata.name or metadata.uid"):
         _parse_pod({"metadata": {"name": "no-uid"}})

--- a/test/k8s_sandbox/test_cilium.py
+++ b/test/k8s_sandbox/test_cilium.py
@@ -1,0 +1,400 @@
+import json
+import logging
+from contextlib import contextmanager
+from typing import Any, AsyncGenerator, Generator, Sequence
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_asyncio
+import urllib3
+from kubernetes.client.exceptions import ApiException
+from pytest import LogCaptureFixture
+
+from k8s_sandbox._cilium import (
+    CiliumPolicyNotRealizedError,
+    CiliumWaitOutcome,
+    _warn_endpoints_unreadable,
+    delete_release_network_policies,
+    wait_for_policy_realized,
+)
+from k8s_sandbox._error import K8sError
+from k8s_sandbox._sandbox_environment import K8sSandboxEnvironment
+from test.k8s_sandbox.utils import install_sandbox_environments
+
+RELEASE = "abcd1234"
+POD = f"agent-env-{RELEASE}-default-0"
+
+
+@pytest.fixture(autouse=True)
+def _reset_permission_warning() -> Generator[None, None, None]:
+    _warn_endpoints_unreadable.cache_clear()
+    yield
+    _warn_endpoints_unreadable.cache_clear()
+
+
+def _raw_response(body: dict[str, Any]) -> MagicMock:
+    response = MagicMock()
+    response.data = json.dumps(body).encode()
+    return response
+
+
+def _pods(*names: str, host_network: bool = False) -> dict[str, Any]:
+    return {
+        "items": [
+            {
+                "metadata": {"name": name, "uid": f"uid-{name}"},
+                "spec": {"hostNetwork": host_network},
+                "status": {},
+            }
+            for name in names
+        ]
+    }
+
+
+def _endpoints(*items: dict[str, Any]) -> dict[str, Any]:
+    return {"items": list(items)}
+
+
+def _endpoint(
+    name: str = POD, *, state: str = "ready", pod_uid: str | None = None
+) -> dict[str, Any]:
+    return {
+        "metadata": {
+            "name": name,
+            "ownerReferences": [{"kind": "Pod", "uid": pod_uid or f"uid-{name}"}],
+        },
+        "status": {"state": state},
+    }
+
+
+@contextmanager
+def fake_cluster(
+    pods: dict[str, Any] | Exception,
+    reads: list[dict[str, Any] | Exception],
+    policies: Sequence[str | None] | Exception = (),
+) -> Generator[MagicMock, None, None]:
+    """Fake the Kubernetes API at the same boundary the pod reads fake it.
+
+    `reads` is the sequence of CiliumEndpoint list responses (or errors) to
+    serve, one per poll; the last is repeated for any further polls.
+    `policies` are the names a CiliumNetworkPolicy list returns; None is a
+    policy the API returned without a name.
+    """
+    core = MagicMock()
+    if isinstance(pods, Exception):
+        core.list_namespaced_pod.side_effect = pods
+    else:
+        core.list_namespaced_pod.return_value = _raw_response(pods)
+    custom_objects = MagicMock()
+    served = list(reads)
+
+    def serve(*_args: Any, plural: str = "", **_kwargs: Any) -> MagicMock:
+        if plural == "ciliumnetworkpolicies":
+            if isinstance(policies, Exception):
+                raise policies
+            items = [
+                {"metadata": {} if name is None else {"name": name}}
+                for name in policies
+            ]
+            return _raw_response({"items": items})
+        read = served.pop(0) if len(served) > 1 else served[0]
+        if isinstance(read, Exception):
+            raise read
+        return _raw_response(read)
+
+    custom_objects.list_namespaced_custom_object.side_effect = serve
+    with (
+        patch("k8s_sandbox._cilium.k8s_client", return_value=core),
+        patch(
+            "k8s_sandbox._cilium.k8s_custom_objects_client",
+            return_value=custom_objects,
+        ),
+    ):
+        yield custom_objects
+
+
+async def _wait(timeout_seconds: float = 1, **kwargs: Any) -> CiliumWaitOutcome:
+    return await wait_for_policy_realized(
+        None,
+        "namespace",
+        RELEASE,
+        timeout_seconds=timeout_seconds,
+        poll_interval_seconds=0,
+        slow_poll_interval_seconds=0,
+        **kwargs,
+    )
+
+
+async def test_returns_when_every_endpoint_is_ready() -> None:
+    with fake_cluster(_pods(POD), [_endpoints(_endpoint())]) as custom_objects:
+        outcome = await _wait()
+
+    assert outcome is CiliumWaitOutcome.REALIZED
+    assert custom_objects.list_namespaced_custom_object.call_count == 1
+    _, kwargs = custom_objects.list_namespaced_custom_object.call_args
+    assert kwargs["group"] == "cilium.io"
+    assert kwargs["version"] == "v2"
+    assert kwargs["plural"] == "ciliumendpoints"
+    assert kwargs["namespace"] == "namespace"
+    assert kwargs["label_selector"] == f"app.kubernetes.io/instance={RELEASE}"
+
+
+async def test_waits_for_an_endpoint_which_does_not_exist_yet() -> None:
+    with fake_cluster(_pods(POD), [_endpoints(), _endpoints(_endpoint())]) as objects:
+        outcome = await _wait()
+
+    assert outcome is CiliumWaitOutcome.REALIZED
+    assert objects.list_namespaced_custom_object.call_count == 2
+
+
+async def test_waits_while_an_endpoint_is_regenerating() -> None:
+    regenerating = _endpoints(_endpoint(state="regenerating"))
+    with fake_cluster(_pods(POD), [regenerating, _endpoints(_endpoint())]) as objects:
+        outcome = await _wait()
+
+    assert outcome is CiliumWaitOutcome.REALIZED
+    assert objects.list_namespaced_custom_object.call_count == 2
+
+
+async def test_waits_for_every_pod_in_the_release() -> None:
+    other = f"agent-env-{RELEASE}-victim-0"
+    one_ready = _endpoints(_endpoint(), _endpoint(other, state="regenerating"))
+    both_ready = _endpoints(_endpoint(), _endpoint(other))
+    with fake_cluster(_pods(POD, other), [one_ready, both_ready]) as objects:
+        outcome = await _wait()
+
+    assert outcome is CiliumWaitOutcome.REALIZED
+    assert objects.list_namespaced_custom_object.call_count == 2
+
+
+async def test_ignores_an_endpoint_left_by_a_previous_pod_of_the_same_name() -> None:
+    stale = _endpoints(_endpoint(pod_uid="uid-of-the-previous-pod"))
+    with fake_cluster(_pods(POD), [stale, _endpoints(_endpoint())]) as objects:
+        outcome = await _wait()
+
+    assert outcome is CiliumWaitOutcome.REALIZED
+    assert objects.list_namespaced_custom_object.call_count == 2
+
+
+async def test_raises_naming_the_endpoint_and_its_state_on_timeout() -> None:
+    with fake_cluster(_pods(POD), [_endpoints(_endpoint(state="regenerating"))]):
+        with pytest.raises(CiliumPolicyNotRealizedError) as excinfo:
+            await _wait(timeout_seconds=0)
+
+    message = str(excinfo.value)
+    assert POD in message
+    assert "regenerating" in message
+    assert excinfo.value.release_name == RELEASE
+    assert [endpoint.name for endpoint in excinfo.value.pending] == [POD]
+
+
+async def test_warns_and_skips_when_a_pod_never_gets_an_endpoint(
+    caplog: LogCaptureFixture,
+) -> None:
+    # Cilium creates an endpoint for every pod it manages, so a pod which never
+    # gets one is on a node it does not manage rather than a stuck agent.
+    caplog.set_level(logging.WARNING)
+    with fake_cluster(_pods(POD), [_endpoints()]):
+        outcome = await _wait(timeout_seconds=0)
+
+    assert outcome is CiliumWaitOutcome.ENDPOINTS_ABSENT
+    assert len(caplog.records) == 1
+    assert POD in caplog.records[0].message
+
+
+async def test_recovers_from_a_transient_api_error() -> None:
+    reads: list[dict[str, Any] | Exception] = [
+        ApiException(status=429, reason="Too Many Requests"),
+        _endpoints(_endpoint()),
+    ]
+    with fake_cluster(_pods(POD), reads):
+        assert await _wait() is CiliumWaitOutcome.REALIZED
+
+
+async def test_recovers_from_a_connection_error() -> None:
+    # The kubernetes client converts only SSLError into ApiException.
+    reads: list[dict[str, Any] | Exception] = [
+        urllib3.exceptions.ProtocolError("connection reset"),
+        _endpoints(_endpoint()),
+    ]
+    with fake_cluster(_pods(POD), reads):
+        assert await _wait() is CiliumWaitOutcome.REALIZED
+
+
+async def test_reports_an_endpoint_read_which_never_succeeds() -> None:
+    with fake_cluster(_pods(POD), [ApiException(status=500, reason="Server Error")]):
+        with pytest.raises(K8sError, match="CiliumEndpoints") as excinfo:
+            await _wait(timeout_seconds=0)
+
+    assert "ApiException" in str(excinfo.value)
+
+
+async def test_reports_a_failed_pod_read_as_a_k8s_error() -> None:
+    with fake_cluster(ApiException(status=500, reason="Server Error"), [_endpoints()]):
+        with pytest.raises(K8sError, match="pods") as excinfo:
+            await _wait(timeout_seconds=0)
+
+    assert RELEASE in str(excinfo.value)
+    assert not isinstance(excinfo.value, CiliumPolicyNotRealizedError)
+
+
+async def test_skips_the_wait_when_pods_may_not_be_read() -> None:
+    with fake_cluster(ApiException(status=403, reason="Forbidden"), [_endpoints()]):
+        assert await _wait() is CiliumWaitOutcome.NOT_PERMITTED
+
+
+async def test_skips_the_wait_when_the_endpoint_crd_is_absent(
+    caplog: LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING)
+    with fake_cluster(_pods(POD), [ApiException(status=404, reason="Not Found")]):
+        outcome = await _wait()
+
+    assert outcome is CiliumWaitOutcome.CRD_ABSENT
+    assert caplog.records == []
+
+
+async def test_warns_once_when_endpoints_may_not_be_read(
+    caplog: LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING)
+    with fake_cluster(_pods(POD), [ApiException(status=403, reason="Forbidden")]):
+        first = await _wait()
+        second = await _wait()
+
+    assert first is CiliumWaitOutcome.NOT_PERMITTED
+    assert second is CiliumWaitOutcome.NOT_PERMITTED
+    assert len(caplog.records) == 1
+    assert "ciliumendpoints.cilium.io" in caplog.records[0].message
+
+
+async def test_ignores_host_networked_pods_which_have_no_endpoint() -> None:
+    with fake_cluster(_pods(POD, host_network=True), [_endpoints()]) as objects:
+        outcome = await _wait()
+
+    assert outcome is CiliumWaitOutcome.REALIZED
+    objects.list_namespaced_custom_object.assert_not_called()
+
+
+async def test_deletes_the_releases_network_policies_one_by_one() -> None:
+    # Deleting a collection is the separate `deletecollection` RBAC verb, which
+    # an identity permitted to create and delete the policies may not hold.
+    names = [f"agent-env-{RELEASE}-sandbox-egress", f"agent-env-{RELEASE}-svc-ingress"]
+    with fake_cluster(_pods(POD), [_endpoints()], policies=names) as objects:
+        await delete_release_network_policies(None, "namespace", RELEASE)
+
+    objects.delete_collection_namespaced_custom_object.assert_not_called()
+    deleted = objects.delete_namespaced_custom_object.call_args_list
+    assert [call.kwargs["name"] for call in deleted] == names
+    assert {call.kwargs["plural"] for call in deleted} == {"ciliumnetworkpolicies"}
+    assert {call.kwargs["namespace"] for call in deleted} == {"namespace"}
+    _, list_kwargs = objects.list_namespaced_custom_object.call_args
+    assert list_kwargs["label_selector"] == f"app.kubernetes.io/instance={RELEASE}"
+
+
+async def test_deleting_network_policies_is_a_no_op_without_the_crd() -> None:
+    absent = ApiException(status=404, reason="Not Found")
+    with fake_cluster(_pods(POD), [_endpoints()], policies=absent) as objects:
+        await delete_release_network_policies(None, "namespace", RELEASE)
+
+    objects.delete_namespaced_custom_object.assert_not_called()
+
+
+async def test_deleting_a_policy_which_is_already_gone_is_not_an_error() -> None:
+    names = ["one", "two"]
+    with fake_cluster(_pods(POD), [_endpoints()], policies=names) as objects:
+        objects.delete_namespaced_custom_object.side_effect = [
+            ApiException(status=404, reason="Not Found"),
+            None,
+        ]
+
+        await delete_release_network_policies(None, "namespace", RELEASE)
+
+    assert objects.delete_namespaced_custom_object.call_count == 2
+
+
+async def test_failing_to_list_network_policies_raises() -> None:
+    forbidden = ApiException(status=403, reason="Forbidden")
+    with fake_cluster(_pods(POD), [_endpoints()], policies=forbidden):
+        with pytest.raises(K8sError, match="list the release's network policies"):
+            await delete_release_network_policies(None, "namespace", RELEASE)
+
+
+async def test_tries_every_policy_and_reports_the_ones_which_failed() -> None:
+    # A policy left behind because an earlier one failed is a leak; the error
+    # is the last thing to give up.
+    with fake_cluster(
+        _pods(POD), [_endpoints()], policies=["one", "two", "three"]
+    ) as objects:
+        objects.delete_namespaced_custom_object.side_effect = [
+            ApiException(status=403, reason="Forbidden"),
+            None,
+            ApiException(status=500, reason="Server Error"),
+        ]
+
+        with pytest.raises(K8sError) as excinfo:
+            await delete_release_network_policies(None, "namespace", RELEASE)
+
+    deleted = objects.delete_namespaced_custom_object.call_args_list
+    attempted = [call.kwargs["name"] for call in deleted]
+    assert attempted == ["one", "two", "three"]
+    message = str(excinfo.value)
+    assert "Failed to delete some" in message
+    assert '"policies": "one (' in message
+    assert "; three (" in message
+
+
+async def test_a_connection_error_while_deleting_does_not_abort_the_sweep() -> None:
+    # Only SSLError reaches us as an ApiException; the rest are urllib3's.
+    with fake_cluster(_pods(POD), [_endpoints()], policies=["one", "two"]) as objects:
+        objects.delete_namespaced_custom_object.side_effect = [
+            urllib3.exceptions.ProtocolError("connection reset"),
+            None,
+        ]
+
+        with pytest.raises(K8sError, match="Failed to delete some") as excinfo:
+            await delete_release_network_policies(None, "namespace", RELEASE)
+
+    assert objects.delete_namespaced_custom_object.call_count == 2
+    assert "ProtocolError" in str(excinfo.value)
+
+
+async def test_a_connection_error_while_listing_is_a_k8s_error() -> None:
+    reset = urllib3.exceptions.ProtocolError("connection reset")
+    with fake_cluster(_pods(POD), [_endpoints()], policies=reset) as objects:
+        with pytest.raises(K8sError, match="list the release's network policies"):
+            await delete_release_network_policies(None, "namespace", RELEASE)
+
+    objects.delete_namespaced_custom_object.assert_not_called()
+
+
+async def test_reports_a_policy_the_api_returned_without_a_name() -> None:
+    with fake_cluster(_pods(POD), [_endpoints()], policies=[None]) as objects:
+        with pytest.raises(K8sError, match="no name"):
+            await delete_release_network_policies(None, "namespace", RELEASE)
+
+    objects.delete_namespaced_custom_object.assert_not_called()
+
+
+@pytest_asyncio.fixture(scope="module")
+async def sandbox() -> AsyncGenerator[K8sSandboxEnvironment, None]:
+    async with install_sandbox_environments(__file__, None) as envs:
+        yield envs["default"]
+
+
+@pytest.mark.req_k8s
+async def test_waits_against_the_real_cilium_crd(
+    sandbox: K8sSandboxEnvironment,
+) -> None:
+    """Pin the group, version, plural and status field against a real cluster.
+
+    Every other test in this file fakes the API, so a typo in any of them would
+    read as 'this cluster does not run Cilium' and silently skip the wait.
+    """
+    release = sandbox.release
+
+    outcome = await wait_for_policy_realized(
+        release.context_name, release.namespace, release.release_name
+    )
+
+    assert outcome is CiliumWaitOutcome.REALIZED

--- a/test/k8s_sandbox/test_helm.py
+++ b/test/k8s_sandbox/test_helm.py
@@ -9,6 +9,7 @@ import yaml
 from inspect_ai.util import ExecResult
 from pytest import LogCaptureFixture
 
+from k8s_sandbox._cilium import CiliumWaitOutcome
 from k8s_sandbox._helm import (
     INSPECT_HELM_LABELS,
     INSPECT_HELM_TIMEOUT,
@@ -40,6 +41,26 @@ def _mock_default_namespace(request: pytest.FixtureRequest) -> object:
         return
     with patch("k8s_sandbox._helm.get_default_namespace", return_value="default") as m:
         yield m
+
+
+@pytest.fixture(autouse=True)
+def _mock_cilium_calls(request: pytest.FixtureRequest) -> object:
+    """Stub the Cilium reads for tests that don't need a real cluster.
+
+    Tests marked req_k8s use the real cluster; everything else would otherwise
+    reach the Kubernetes API after a faked `helm install` or `helm uninstall`.
+    """
+    if "req_k8s" in {m.name for m in request.node.iter_markers()}:
+        yield
+        return
+    with (
+        patch(
+            "k8s_sandbox._helm.wait_for_policy_realized",
+            return_value=CiliumWaitOutcome.REALIZED,
+        ) as wait,
+        patch("k8s_sandbox._helm.delete_release_network_policies"),
+    ):
+        yield wait
 
 
 @pytest.fixture
@@ -778,3 +799,62 @@ async def test_install_error_omits_diagnostics_when_unavailable() -> None:
             await release._raise_install_error(result)
 
     assert "Helm install failed." in str(excinfo.value)
+
+
+async def test_install_waits_for_cilium_before_the_release_is_usable(
+    _mock_cilium_calls: MagicMock,
+) -> None:
+    release = Release(__file__, None, ValuesSource.none(), None)
+
+    with patch(
+        "k8s_sandbox._helm._run_subprocess",
+        return_value=ExecResult(True, 0, "", ""),
+    ):
+        await release.install()
+
+    _mock_cilium_calls.assert_awaited_once_with(None, "default", release.release_name)
+
+
+async def test_install_does_not_wait_for_cilium_when_helm_fails(
+    _mock_cilium_calls: MagicMock,
+) -> None:
+    release = Release(__file__, None, ValuesSource.none(), None)
+
+    with (
+        patch(
+            "k8s_sandbox._helm._run_subprocess",
+            return_value=ExecResult(False, 1, "", "Helm install failed"),
+        ),
+        patch("k8s_sandbox._helm.describe_release_pods", return_value=None),
+    ):
+        with pytest.raises(RuntimeError):
+            await release.install()
+
+    _mock_cilium_calls.assert_not_awaited()
+
+
+async def test_uninstall_deletes_the_releases_network_policies() -> None:
+    with (
+        patch(
+            "k8s_sandbox._helm._run_subprocess",
+            return_value=ExecResult(True, 0, "", ""),
+        ),
+        patch("k8s_sandbox._helm.delete_release_network_policies") as delete,
+    ):
+        await uninstall("abcd1234", "namespace", None, quiet=True)
+
+    delete.assert_awaited_once_with(None, "namespace", "abcd1234")
+
+
+async def test_uninstall_does_not_delete_network_policies_when_helm_fails() -> None:
+    with (
+        patch(
+            "k8s_sandbox._helm._run_subprocess",
+            return_value=ExecResult(False, 1, "", "Helm uninstall failed"),
+        ),
+        patch("k8s_sandbox._helm.delete_release_network_policies") as delete,
+    ):
+        with pytest.raises(RuntimeError):
+            await uninstall("abcd1234", "namespace", None, quiet=True)
+
+    delete.assert_not_awaited()


### PR DESCRIPTION
## What happens today

Two separate things have to be true before a sandbox's first command is safe, and the
provider waits for neither.

**The pod is created before its policy.** Helm orders an install by kind and sorts kinds
it does not know — every custom resource, `CiliumNetworkPolicy` among them — after the
workloads. On this chart that is verifiable in the release itself:

```
$ helm get manifest <release> | grep ^kind:      # before this change
kind: ConfigMap
kind: ConfigMap
kind: StatefulSet
kind: CiliumNetworkPolicy
kind: CiliumNetworkPolicy
kind: CiliumNetworkPolicy
```

**`helm install --wait` returns on kubelet's signal.** A pod is Ready once its containers
are, which says nothing about Cilium having built that pod's endpoint and compiled its
policy. So the sandbox can be handed back while the endpoint is still being built, or
rebuilt because the policy arrived after it.

Either way the first command runs against a half-programmed egress policy. In a CI suite
which starts a sandbox and runs a fixed command immediately, with no LLM turn in between,
that shows up as:

```
AssertionError: assert 'EXAMPLE=OK' in
  'curl: (6) Could not resolve host: example.com\n\nEXAMPLE=BLOCKED\n'
```

— an *allow-listed* domain failing to resolve. Five occurrences in fourteen days across
five unrelated commits and three days, on identical package pins (so not a regression in
any of them); four of that shape, and one where a pod configured for unrestricted egress
had no network at all.

## The change

**The chart's network policies are installed before the pods they protect.** They carry
`helm.sh/hook: pre-install,pre-upgrade`, so Helm applies them in the hook phase, which
completes before the manifest phase that creates the StatefulSets:

```
$ helm get hooks <release> | grep ^kind:         # after this change
kind: CiliumNetworkPolicy
kind: CiliumNetworkPolicy
kind: CiliumNetworkPolicy
$ helm get manifest <release> | grep ^kind:
kind: ConfigMap
kind: ConfigMap
kind: StatefulSet
```

Helm does not remove hook resources with the release, so `uninstall()` deletes the
release's `CiliumNetworkPolicy` objects itself, after a successful `helm uninstall`
(never after a failed one, which would unpolice pods that are still running). It lists
them by the `app.kubernetes.io/instance` label the policies now carry and deletes each by
name, as Helm itself would: deleting a collection is authorized as the distinct
`deletecollection` verb, which an identity holding the verbs a chart installer needs
(`create`, `delete`, `get`, `list`, `patch`, `update`, `watch`) does not necessarily
have. Every failing delete is attempted and reported together, so one refusal does not
leave the rest behind. A release uninstalled by hand with `helm uninstall` keeps its
policies; `kubectl delete cnp -l app.kubernetes.io/instance=<release>` removes them.

**Permissions.** The wait reads `get` and `list` on `ciliumendpoints.cilium.io` in the
namespace it installs into; without them it is skipped with one warning per process.
The uninstall cleanup needs `list` and `delete` on `ciliumnetworkpolicies.cilium.io`.
`delete` was already required, since Helm deleted these objects itself while they were
ordinary release resources; `list` is new — an identity without it installs the chart
normally and then fails the uninstall with `Failed to list the release's network
policies`. Both are stated in `docs/getting-started/remote-cluster.md`.

**Installation then waits for Cilium to build the endpoints.** After a successful
`helm install`, every pod of the release (`app.kubernetes.io/instance=<release>`, the
selector `get_sandbox_pods` already uses) must have a `CiliumEndpoint` reporting
`status.state: ready` before the release is usable:

- An endpoint that does not exist yet is a state to wait through, not a pass.
- Endpoints are matched to pods by the owning pod's UID, not by name. Chart pods are
  StatefulSet members with stable names, so an endpoint left behind by a previous pod of
  the same name would otherwise end the wait immediately; matching on UID means a stale
  endpoint can only delay it.
- Host-networked pods share the node's network namespace and have no endpoint of their
  own, so they are not waited for.

`status.state` is the only signal available: the `cilium.io/v2` CRD's `status.policy`
declares just `ingress`/`egress` (an apiextensions/v1 CRD prunes anything else, so no
agent flag can add policy revisions to it), and `CiliumNetworkPolicy.status` carries no
per-node realization at all. Ordering the policies ahead of the pods is what makes that
signal sufficient rather than merely necessary: the endpoint's first build already has
the policy, so "built and not regenerating" is the whole race. What the hooks guarantee
is that the policy *objects* exist before the pod is created — not that every node's
agent has imported them before it builds that pod's endpoint. That import is the
remaining window, and it is milliseconds against the seconds a pod takes to be scheduled
and started.

The wait polls every 250 ms, backing off to 1 s after two seconds so a stalled cluster is
not also being listed four times a second per concurrent install, and gives up after 60 s.
What happens then depends on what it saw, because these are different faults:

- An endpoint exists but never became ready — the real fault — raises the new
  `CiliumPolicyNotRealizedError` (a `K8sError`, exported for callers to catch), naming the
  endpoints, their observed state and the elapsed time.
- No endpoint ever appeared for a pod is far more likely a node Cilium does not manage
  (Fargate, Windows, a cluster mid-rollout) than a stuck agent, so it warns naming those
  pods and continues, rather than turning a working sandbox launch into a hard failure.

Two cases are not failures at all, and are distinguished rather than collapsed into one
swallowed 404:

- **No `CiliumEndpoint` CRD** — the API 404s on the collection path itself. The cluster
  does not run Cilium; the wait is a no-op.
- **Not permitted to read them** — 401/403. The wait is skipped with a single warning per
  process naming the permission to grant, rather than breaking every sandbox on a cluster
  whose RBAC predates this version. `docs/getting-started/remote-cluster.md` states the
  requirement (`get`, `list` on `ciliumendpoints.cilium.io`) under `## Requirements`
  rather than under the built-in chart, because the wait runs for every chart.

Both reads — the release's pods and its endpoints — go through the same handling: a
throttled or briefly unavailable API server (including connection-level `urllib3` and
socket errors, which the kubernetes client does not convert into `ApiException`) is
retried inside the budget, and a read that never succeeds surfaces as a `K8sError` naming
the release rather than a bare client exception.

`PodSnapshot` gains `host_network` and the pod UID is now used; `_kubernetes_api` gains
`k8s_custom_objects_client` so custom-resource clients are built where the other clients
are.

## Verification

Unit tests (`test/k8s_sandbox/test_cilium.py`, faking the Kubernetes API at the same
boundary `test_snapshot.py` does): a ready endpoint returns on the first read; a missing
endpoint, a regenerating endpoint, a multi-pod release and an endpoint owned by a previous
pod of the same name each keep polling; the timeout raises naming the endpoint and its
state; a pod that never gets an endpoint warns once and continues; transient API and
connection errors are retried; reads that never succeed raise `K8sError` naming the
release; a 403 on either read warns once and skips; the CRD being absent is a silent
no-op; host-networked pods are not waited for; the policies are deleted one at a time
(never as a collection), one already gone is not an error, every failing delete is
attempted and named in one error, a policy the API returns without a name raises, and a
failed list is distinguishable from a failed delete. `test_helm.py` pins the sequence:
install waits, a failed install does not, uninstall deletes the policies, a failed
uninstall does not.

One `req_k8s` test pins the group, version, plural and status field against a real
cluster, because every other test in the file fakes the CRD — a typo in any of those four
strings would read as "this cluster does not run Cilium" and silently skip the wait.

```
$ uv run pytest test -m 'not req_k8s' -q
456 passed, 335 deselected in 29.26s
$ uv run ruff check . && uv run ruff format --check . && uv run mypy .
All checks passed!
86 files already formatted
Success: no issues found in 86 source files
```

Live, against a Cilium v1.18.4 EKS cluster, in namespaces created and deleted for the
purpose:

- Cluster tests: `test_cilium.py` and `test_helm.py -m req_k8s` → `10 passed in 36.10s`
  on this head; earlier on the same branch, with `test_network_policy.py`,
  `test_dns.py`, `test_networks.py` and both `test_network_policy_ports_*.py`,
  `19 passed in 97.05s` and `26 passed in 135.29s`.
- The `deletecollection` verb, tested rather than reasoned about: a ServiceAccount holding
  exactly the verbs a chart installer needs (`create`, `delete`, `get`, `list`, `patch`,
  `update`, `watch` on `ciliumnetworkpolicies`) — no `deletecollection` — running against
  a real release's policies gives
  `delete_collection_namespaced_custom_object` → `HTTP 403 Forbidden`, and the
  implementation's list-then-delete-by-name → ok, with `0` policies left.
- The new `list` requirement, same method: a ServiceAccount without
  `list` on `ciliumnetworkpolicies` installs the chart normally (`Install complete`) and
  then fails the cleanup with `Failed to list the release's network policies … (403)`,
  leaving three policies behind.
- A sandbox with `allowDomains: [example.com]` running
  `curl -sS https://example.com -o /dev/null -w '%{http_code}'` as its first command:
  `EXAMPLE=OK http='200' PYPI=BLOCKED`, with
  `Waited for Cilium to build the release's endpoints. {"release": "ukautsqp", "outcome": "realized", "elapsed_ms": "14", "endpoints": "agent-env-ukautsqp-default-0 (state ready)"}`,
  and nothing left in the namespace after uninstall (`after uninstall: 0 objects left`).
- Eight concurrent launches of the same sandbox before the ordering change: all returned
  `200`, and the wait cost 17–108 ms per sandbox with every endpoint already ready.
- The blocking path, live: deleting a release's pod makes Cilium build a fresh endpoint
  for the replacement, and the wait blocks on it —
  `Waiting for Cilium to build the release's endpoints. {"release": "gbla28nx", "pending": "agent-env-gbla28nx-default-0 (no CiliumEndpoint)"}`,
  then `BLOCKED for 572 ms`.
- The manifest/hooks output quoted above is from installs of this chart on that cluster,
  before and after the change.

One measurement changed the implementation: creating the Kubernetes client inside the
worker thread re-ran the kubeconfig's credential plugin per thread, costing ~0.9 s on
every concurrent sandbox start (847–1030 ms measured across eight). The clients are now
created on the caller's thread and used from the workers, as `get_sandbox_pods` does.
